### PR TITLE
Fix broken link detection, case-insensitive resolution, and hub notes limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -4573,7 +4573,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-batch"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "chrono",
  "serde",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-core"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "chrono",
  "log",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-export"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "chrono",
  "serde",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-graph"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-parser"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "insta",
  "log",
@@ -4646,7 +4646,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-tools"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4672,7 +4672,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-vault"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",

--- a/crates/turbovault-graph/src/graph.rs
+++ b/crates/turbovault-graph/src/graph.rs
@@ -14,14 +14,18 @@ pub struct LinkGraph {
     /// Directed graph: nodes are file paths, edges are links
     graph: DiGraph<PathBuf, Link>,
 
-    /// Map from file name (stem) to node index
+    /// Map from file name (stem, lowercased) to node index
     file_index: HashMap<String, NodeIndex>,
 
-    /// Map from aliases to node index
+    /// Map from aliases (lowercased) to node index
     alias_index: HashMap<String, NodeIndex>,
 
     /// Map from full path to node index (for quick lookups)
     path_index: HashMap<PathBuf, NodeIndex>,
+
+    /// Links that could not be resolved to a target file, grouped by source path.
+    /// Used by HealthAnalyzer for broken link detection.
+    unresolved_links: HashMap<PathBuf, Vec<Link>>,
 }
 
 impl LinkGraph {
@@ -32,6 +36,7 @@ impl LinkGraph {
             file_index: HashMap::new(),
             alias_index: HashMap::new(),
             path_index: HashMap::new(),
+            unresolved_links: HashMap::new(),
         }
     }
 
@@ -46,18 +51,18 @@ impl LinkGraph {
             let idx = self.graph.add_node(path.clone());
             self.path_index.insert(path.clone(), idx);
 
-            // Add to file_index by stem
+            // Add to file_index by stem (lowercased for case-insensitive resolution)
             if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                self.file_index.insert(stem.to_string(), idx);
+                self.file_index.insert(stem.to_lowercase(), idx);
             }
 
             idx
         };
 
-        // Register aliases from frontmatter
+        // Register aliases from frontmatter (lowercased for case-insensitive resolution)
         if let Some(fm) = &file.frontmatter {
             for alias in fm.aliases() {
-                self.alias_index.insert(alias, node_idx);
+                self.alias_index.insert(alias.to_lowercase(), node_idx);
             }
         }
 
@@ -69,9 +74,10 @@ impl LinkGraph {
         if let Some(&idx) = self.path_index.get(path) {
             // Remove from all indices
             self.path_index.remove(path);
+            self.unresolved_links.remove(path);
 
             if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                self.file_index.remove(stem);
+                self.file_index.remove(&stem.to_lowercase());
             }
 
             // Remove aliases pointing to this node
@@ -97,49 +103,67 @@ impl LinkGraph {
             idx
         };
 
-        // Remove old outgoing edges
+        // Remove old outgoing edges and unresolved links for this source
         let outgoing: Vec<_> = self.graph.edges(source_idx).map(|e| e.id()).collect();
         for edge_id in outgoing {
             self.graph.remove_edge(edge_id);
         }
+        self.unresolved_links.remove(source_path);
 
         // Add edges for each internal link (wikilinks and embeds)
         for link in &file.links {
-            if matches!(link.type_, LinkType::WikiLink | LinkType::Embed)
-                && let Some(target_idx) = self.resolve_link(&link.target)
-            {
-                // Add edge (both nodes already exist from add_file)
-                self.graph.add_edge(source_idx, target_idx, link.clone());
+            if matches!(link.type_, LinkType::WikiLink | LinkType::Embed) {
+                if let Some(target_idx) = self.resolve_link(&link.target) {
+                    self.graph.add_edge(source_idx, target_idx, link.clone());
+                } else {
+                    // Track unresolved links for broken link detection
+                    let mut broken = link.clone();
+                    broken.is_valid = false;
+                    self.unresolved_links
+                        .entry(source_path.clone())
+                        .or_default()
+                        .push(broken);
+                }
             }
         }
 
         Ok(())
     }
 
-    /// Resolve a wikilink target to a file path and node index
+    /// Resolve a wikilink target to a file path and node index.
+    /// Resolution is case-insensitive to match Obsidian's behaviour.
     fn resolve_link(&self, target: &str) -> Option<NodeIndex> {
         // Remove block/heading references
         let clean_target = target.split('#').next()?.trim();
+        let clean_lower = clean_target.to_lowercase();
 
-        // Try direct stem match
-        if let Some(&idx) = self.file_index.get(clean_target) {
+        // Try direct stem match (case-insensitive)
+        if let Some(&idx) = self.file_index.get(&clean_lower) {
             return Some(idx);
         }
 
-        // Try alias match
-        if let Some(&idx) = self.alias_index.get(clean_target) {
+        // Try alias match (case-insensitive)
+        if let Some(&idx) = self.alias_index.get(&clean_lower) {
             return Some(idx);
         }
 
-        // Try path-like match (folder/Note)
-        let target_parts: Vec<&str> = clean_target.split('/').filter(|p| !p.is_empty()).collect();
+        // Try path-like match (folder/Note) with case-insensitive comparison
+        let target_parts: Vec<String> = clean_target
+            .split('/')
+            .filter(|p| !p.is_empty())
+            .map(|p| p.to_lowercase())
+            .collect();
         if target_parts.is_empty() {
             return None;
         }
 
         // Find file path that matches the tail of the target path
         for (path, &idx) in self.path_index.iter() {
-            let path_parts: Vec<&str> = path.iter().filter_map(|p| p.to_str()).collect();
+            let path_parts: Vec<String> = path
+                .iter()
+                .filter_map(|p| p.to_str())
+                .map(|p| p.to_lowercase())
+                .collect();
 
             if path_parts.len() >= target_parts.len() {
                 let start = path_parts.len() - target_parts.len();
@@ -347,6 +371,13 @@ impl LinkGraph {
         result
     }
 
+    /// Get all unresolved links, grouped by source file.
+    /// Each link has `is_valid == false` and represents a wikilink or embed
+    /// whose target could not be resolved to an existing vault file.
+    pub fn all_unresolved_links(&self) -> &HashMap<PathBuf, Vec<Link>> {
+        &self.unresolved_links
+    }
+
     /// Find connected components in the graph (using undirected view)
     pub fn connected_components(&self) -> Result<Vec<Vec<PathBuf>>> {
         use petgraph::algo::tarjan_scc;
@@ -483,5 +514,65 @@ mod tests {
         assert_eq!(stats.total_files, 2);
         assert_eq!(stats.total_links, 1);
         assert_eq!(stats.orphaned_files, 0); // Both notes have links: note1 has incoming, note2 has outgoing
+    }
+
+    #[test]
+    fn test_unresolved_links_tracked() {
+        let mut graph = LinkGraph::new();
+        let file1 = create_test_file("note1.md", vec![]);
+        // note2 links to note1 (exists) and nonexistent (doesn't exist)
+        let file2 = create_test_file("note2.md", vec!["note1", "nonexistent"]);
+
+        graph.add_file(&file1).unwrap();
+        graph.add_file(&file2).unwrap();
+        graph.update_links(&file2).unwrap();
+
+        // Resolved link should be in the graph
+        assert_eq!(graph.edge_count(), 1);
+
+        // Unresolved link should be tracked
+        let unresolved = graph.all_unresolved_links();
+        let note2_path = PathBuf::from("note2.md");
+        assert!(unresolved.contains_key(&note2_path));
+        assert_eq!(unresolved[&note2_path].len(), 1);
+        assert_eq!(unresolved[&note2_path][0].target, "nonexistent");
+        assert!(!unresolved[&note2_path][0].is_valid);
+    }
+
+    #[test]
+    fn test_case_insensitive_resolution() {
+        let mut graph = LinkGraph::new();
+        let file1 = create_test_file("My Note.md", vec![]);
+        // Link uses different case
+        let file2 = create_test_file("linker.md", vec!["my note"]);
+
+        graph.add_file(&file1).unwrap();
+        graph.add_file(&file2).unwrap();
+        graph.update_links(&file2).unwrap();
+
+        // Should resolve despite case mismatch
+        assert_eq!(graph.edge_count(), 1);
+        assert!(graph.all_unresolved_links().is_empty());
+    }
+
+    #[test]
+    fn test_unresolved_links_cleared_on_update() {
+        let mut graph = LinkGraph::new();
+        let file1 = create_test_file("note1.md", vec![]);
+        let file2_broken = create_test_file("note2.md", vec!["nonexistent"]);
+
+        graph.add_file(&file1).unwrap();
+        graph.add_file(&file2_broken).unwrap();
+        graph.update_links(&file2_broken).unwrap();
+
+        assert_eq!(graph.all_unresolved_links().len(), 1);
+
+        // Now update note2 to link to note1 instead
+        let file2_fixed = create_test_file("note2.md", vec!["note1"]);
+        graph.update_links(&file2_fixed).unwrap();
+
+        // Unresolved links should be cleared
+        assert!(graph.all_unresolved_links().is_empty());
+        assert_eq!(graph.edge_count(), 1);
     }
 }

--- a/crates/turbovault-graph/src/health.rs
+++ b/crates/turbovault-graph/src/health.rs
@@ -65,23 +65,23 @@ impl HealthReport {
             return;
         }
 
-        let mut score = 100;
+        let mut score: u8 = 100;
 
         // Penalize broken links (up to -30 points)
         let broken_ratio = self.broken_links.len() as f32 / self.total_links.max(1) as f32;
-        score -= (broken_ratio * 30.0) as u8;
+        score = score.saturating_sub((broken_ratio * 30.0) as u8);
 
         // Penalize orphaned notes (up to -20 points)
         let orphaned_ratio = self.orphaned_notes.len() as f32 / self.total_notes as f32;
-        score -= (orphaned_ratio * 20.0) as u8;
+        score = score.saturating_sub((orphaned_ratio * 20.0) as u8);
 
         // Penalize isolated clusters (up to -15 points)
         let isolated_ratio = self.isolated_clusters.len() as f32 / self.total_notes as f32;
-        score -= (isolated_ratio * 15.0) as u8;
+        score = score.saturating_sub((isolated_ratio * 15.0) as u8);
 
         // Penalize dead ends (up to -10 points)
         let dead_end_ratio = self.dead_end_notes.len() as f32 / self.total_notes as f32;
-        score -= (dead_end_ratio * 10.0) as u8;
+        score = score.saturating_sub((dead_end_ratio * 10.0) as u8);
 
         self.health_score = score;
     }
@@ -98,24 +98,51 @@ impl Default for HealthReport {
     }
 }
 
+/// Configuration for health analysis
+#[derive(Debug, Clone)]
+pub struct AnalysisConfig {
+    /// Maximum number of hub notes to include in the report (default: 10)
+    pub hub_notes_limit: usize,
+}
+
+impl Default for AnalysisConfig {
+    fn default() -> Self {
+        Self {
+            hub_notes_limit: 10,
+        }
+    }
+}
+
 /// Vault health analyzer
 pub struct HealthAnalyzer<'a> {
     graph: &'a LinkGraph,
     files: Option<&'a HashMap<PathBuf, Vec<Link>>>,
+    config: AnalysisConfig,
 }
 
 impl<'a> HealthAnalyzer<'a> {
-    /// Create a new health analyzer
+    /// Create a new health analyzer (graph-only, no broken link detection)
     pub fn new(graph: &'a LinkGraph) -> Self {
-        Self { graph, files: None }
+        Self::with_config(graph, None, AnalysisConfig::default())
     }
 
-    /// Create a new health analyzer with access to file links
+    /// Create a new health analyzer with access to unresolved links.
+    /// Uses [`AnalysisConfig::default`] for analysis parameters.
     /// (needed for detecting broken links that aren't in the graph)
     pub fn with_files(graph: &'a LinkGraph, files: &'a HashMap<PathBuf, Vec<Link>>) -> Self {
+        Self::with_config(graph, Some(files), AnalysisConfig::default())
+    }
+
+    /// Create a health analyzer with full configuration
+    pub fn with_config(
+        graph: &'a LinkGraph,
+        files: Option<&'a HashMap<PathBuf, Vec<Link>>>,
+        config: AnalysisConfig,
+    ) -> Self {
         Self {
             graph,
-            files: Some(files),
+            files,
+            config,
         }
     }
 
@@ -137,7 +164,7 @@ impl<'a> HealthAnalyzer<'a> {
         report.dead_end_notes = self.find_dead_end_notes()?;
 
         // Find hub notes (highly connected)
-        report.hub_notes = self.find_hub_notes(5)?;
+        report.hub_notes = self.find_hub_notes(self.config.hub_notes_limit)?;
 
         // Find isolated clusters
         report.isolated_clusters = self.find_isolated_clusters()?;

--- a/crates/turbovault-graph/src/lib.rs
+++ b/crates/turbovault-graph/src/lib.rs
@@ -101,11 +101,11 @@ pub mod graph;
 pub mod health;
 
 pub use graph::{GraphStats, LinkGraph};
-pub use health::{BrokenLink, HealthAnalyzer, HealthReport};
+pub use health::{AnalysisConfig, BrokenLink, HealthAnalyzer, HealthReport};
 pub use turbovault_core::prelude::*;
 
 pub mod prelude {
     pub use crate::graph::{GraphStats, LinkGraph};
-    pub use crate::health::{BrokenLink, HealthAnalyzer, HealthReport};
+    pub use crate::health::{AnalysisConfig, BrokenLink, HealthAnalyzer, HealthReport};
     pub use turbovault_core::prelude::*;
 }

--- a/crates/turbovault-tools/src/graph_tools.rs
+++ b/crates/turbovault-tools/src/graph_tools.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use turbovault_core::prelude::*;
-use turbovault_graph::HealthAnalyzer;
+use turbovault_graph::{AnalysisConfig, HealthAnalyzer};
 use turbovault_vault::VaultManager;
 
 /// Graph tools context
@@ -43,7 +43,8 @@ impl GraphTools {
     pub async fn get_broken_links(&self) -> Result<Vec<BrokenLinkInfo>> {
         let graph_lock = self.manager.link_graph();
         let graph = graph_lock.read().await;
-        let analyzer = HealthAnalyzer::new(&graph);
+        let unresolved = graph.all_unresolved_links();
+        let analyzer = HealthAnalyzer::with_files(&graph, unresolved);
 
         let report = analyzer.analyze()?;
 
@@ -63,7 +64,8 @@ impl GraphTools {
     pub async fn quick_health_check(&self) -> Result<HealthInfo> {
         let graph_lock = self.manager.link_graph();
         let graph = graph_lock.read().await;
-        let analyzer = HealthAnalyzer::new(&graph);
+        let unresolved = graph.all_unresolved_links();
+        let analyzer = HealthAnalyzer::with_files(&graph, unresolved);
 
         let report = analyzer.quick_check()?;
 
@@ -83,7 +85,8 @@ impl GraphTools {
     pub async fn full_health_analysis(&self) -> Result<HealthInfo> {
         let graph_lock = self.manager.link_graph();
         let graph = graph_lock.read().await;
-        let analyzer = HealthAnalyzer::new(&graph);
+        let unresolved = graph.all_unresolved_links();
+        let analyzer = HealthAnalyzer::with_files(&graph, unresolved);
 
         let report = analyzer.analyze()?;
 
@@ -103,14 +106,16 @@ impl GraphTools {
     pub async fn get_hub_notes(&self, limit: usize) -> Result<Vec<(String, usize)>> {
         let graph_lock = self.manager.link_graph();
         let graph = graph_lock.read().await;
-        let analyzer = HealthAnalyzer::new(&graph);
+        let config = AnalysisConfig {
+            hub_notes_limit: limit,
+        };
+        let analyzer = HealthAnalyzer::with_config(&graph, None, config);
 
         let report = analyzer.analyze()?;
 
         Ok(report
             .hub_notes
             .into_iter()
-            .take(limit)
             .map(|(path, count)| (path.to_string_lossy().to_string(), count))
             .collect())
     }

--- a/crates/turbovault-vault/src/manager.rs
+++ b/crates/turbovault-vault/src/manager.rs
@@ -62,10 +62,16 @@ impl VaultManager {
         let md_files = self.scan_files()?;
         log::info!("Found {} markdown files", md_files.len());
 
+        // Two-pass initialization: first add all files to the graph index,
+        // then resolve links. This ensures every file is discoverable when
+        // resolving wikilink targets, regardless of scan order.
+        let mut parsed_files = Vec::with_capacity(md_files.len());
+        let now = self.current_timestamp();
+
+        // Pass 1: parse all files, populate cache and graph nodes
         for file_path in md_files {
             log::debug!("Processing file: {:?}", file_path);
             if let Ok(content) = tokio::fs::read_to_string(&file_path).await {
-                // Parse file
                 match self.parser.parse_file(&file_path, &content) {
                     Ok(vault_file) => {
                         log::debug!(
@@ -74,8 +80,6 @@ impl VaultManager {
                             vault_file.links.len()
                         );
 
-                        // Cache file
-                        let now = self.current_timestamp();
                         cache.insert(
                             file_path.clone(),
                             CacheEntry {
@@ -84,9 +88,8 @@ impl VaultManager {
                             },
                         );
 
-                        // Add to graph
                         let _ = graph.add_file(&vault_file);
-                        let _ = graph.update_links(&vault_file);
+                        parsed_files.push(vault_file);
                     }
                     Err(e) => {
                         log::warn!("Failed to parse {}: {}", file_path.display(), e);
@@ -95,6 +98,11 @@ impl VaultManager {
             } else {
                 log::warn!("Failed to read file: {:?}", file_path);
             }
+        }
+
+        // Pass 2: resolve links (all files now in the index)
+        for vault_file in &parsed_files {
+            let _ = graph.update_links(vault_file);
         }
 
         log::info!(


### PR DESCRIPTION
### Summary

- Broken link detection was non-functional — get_broken_links, quick_health_check, and full_health_analysis always reported zero broken links. Unresolved links are now tracked in LinkGraph.unresolved_links and wired into HealthAnalyzer::with_files().
- Single-pass initialization caused scan-order-dependent resolution failures — files scanned later were not in the index when earlier files resolved links. Split into two passes: add all files first, then resolve links. On a 1166-file Obsidian vault: links 548→1905, broken 1854→497, orphaned 910→318, health score 0→88.
- Case-insensitive link resolution — resolve_link used exact-match lookups, but Obsidian resolves wikilinks case-insensitively. Lowercase all index keys at insertion and lookup time.
- Hub notes hardcoded cap of 5 — analyze() called find_hub_notes(5) regardless of the user-supplied limit. Introduced AnalysisConfig with configurable hub_notes_limit.

### Test plan

- 3 new unit tests: test_unresolved_links_tracked, test_case_insensitive_resolution, test_unresolved_links_cleared_on_update
- Tested against a 1166-file production Obsidian vault (19/20 scenarios pass; 1 failure is a pre-existing limitation where frontmatter YAML wikilinks are not parsed)
- cargo test --workspace (please verify — we tested on Windows only)