### PR TITLE
fix: render inline code correctly in headings, blockquotes, and tables

### DIFF
--- a/crates/turbovault-parser/src/blocks.rs
+++ b/crates/turbovault-parser/src/blocks.rs
@@ -510,9 +510,26 @@ fn process_event(event: Event, state: &mut BlockParserState, blocks: &mut Vec<Co
             state.in_strikethrough = false;
         }
         Event::Code(text) => {
-            state.in_code_inline = true;
-            state.add_inline_text(&text);
-            state.in_code_inline = false;
+            if state.in_heading {
+                state.heading_buffer.push_str(&text);
+                state.heading_inline.push(InlineElement::Code {
+                    value: text.to_string(),
+                });
+            } else if state.in_blockquote {
+                // Re-emit with delimiters so the buffer is re-parseable as inline code
+                state.blockquote_buffer.push('`');
+                state.blockquote_buffer.push_str(&text);
+                state.blockquote_buffer.push('`');
+            } else if state.in_table {
+                // Re-emit with delimiters so table cell strings carry inline code markers
+                state.paragraph_buffer.push('`');
+                state.paragraph_buffer.push_str(&text);
+                state.paragraph_buffer.push('`');
+            } else {
+                state.in_code_inline = true;
+                state.add_inline_text(&text);
+                state.in_code_inline = false;
+            }
         }
         Event::Start(Tag::Link { dest_url, .. }) => {
             // For nested list items, add newline and indent before the link

--- a/crates/turbovault-parser/src/engine.rs
+++ b/crates/turbovault-parser/src/engine.rs
@@ -287,6 +287,10 @@ impl<'a> ParseEngine<'a> {
                 }
 
                 // === Inline code ===
+                Event::Code(text) if current_heading.is_some() => {
+                    heading_text.push_str(&text);
+                    excluded.add(range.clone());
+                }
                 Event::Code(_) => {
                     excluded.add(range.clone());
                 }


### PR DESCRIPTION
## Summary

- **Headings**: Route `Event::Code` to `heading_buffer`/`heading_inline` instead of paragraph buffers, preventing inline code from leaking into the next paragraph
- **Blockquotes**: Re-emit with backtick delimiters into `blockquote_buffer` so content is preserved and re-parseable as inline code
- **Tables**: Re-emit with backtick delimiters into `paragraph_buffer` so cell strings carry inline code markers for downstream renderers
- **Outline (engine.rs)**: Add `Event::Code` arm guarded by `current_heading.is_some()` so inline code text appears in heading outlines

## Test plan
- [ ] Verify inline code renders correctly in headings (not leaked to next paragraph)
- [ ] Verify inline code renders correctly in blockquotes
- [ ] Verify inline code renders correctly in table cells
- [ ] Verify inline code text appears in heading outline extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)