### PR TITLE
Obsidian Tasks metadata parsing added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5000,6 +5000,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+ "winnow",
 ]
 
 [[package]]
@@ -5781,9 +5782,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ walkdir = "2"
 
 # Parsing utilities
 regex = "1"
+winnow = "1.0.2"
 
 # Error handling
 thiserror = "2.0"

--- a/crates/turbovault-core/Cargo.toml
+++ b/crates/turbovault-core/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { workspace = true, features = ["sync"] }
 parking_lot = "0.12"  # For efficient RwLock in metrics
 sha2 = { workspace = true }
 shellexpand = { workspace = true }
+winnow = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/turbovault-core/src/lib.rs
+++ b/crates/turbovault-core/src/lib.rs
@@ -82,6 +82,7 @@ pub mod models;
 pub mod multi_vault;
 pub mod profiles;
 pub mod resilience;
+pub mod task_parser;
 pub mod utils;
 pub mod validation;
 

--- a/crates/turbovault-core/src/models.rs
+++ b/crates/turbovault-core/src/models.rs
@@ -8,9 +8,13 @@
 //!
 //! The types roughly correspond to Python dataclasses in the reference implementation.
 
+use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::path::PathBuf;
+
+use crate::task_parser::ParsedTaskMetadata;
 
 /// Position in source text (line, column, byte offset)
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -214,32 +218,164 @@ pub struct Tag {
 /// A task item in vault content
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskItem {
+    /// Task description with trailing Obsidian Tasks metadata removed.
     pub content: String,
     pub is_completed: bool,
     pub position: SourcePosition,
-    pub due_date: Option<String>,
+    pub created_date: Option<NaiveDate>,
+    pub scheduled_date: Option<NaiveDate>,
+    pub start_date: Option<NaiveDate>,
+    pub due_date: Option<NaiveDate>,
+    pub done_date: Option<NaiveDate>,
+    pub cancelled_date: Option<NaiveDate>,
+    #[serde(default)]
+    pub priority: TaskPriority,
+    /// Recurrence rule text, for example `every weekday`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recurrence: Option<String>,
+    /// On-completion action, for example `keep` or `delete`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_completion: Option<String>,
+    /// Tasks plugin dependency ID without the leading `🆔` marker.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Tasks plugin dependency IDs from `⛔` or `[dependsOn:: ...]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
+    /// Inline task tags without the leading `#`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    /// Obsidian block reference without the leading `^`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_ref: Option<String>,
+    /// Dataview inline fields parsed from trailing task metadata.
+    ///
+    /// Standard fields are also projected into the typed fields above; custom
+    /// fields remain available here.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
+}
+
+impl TaskItem {
+    /// Build a [`TaskItem`] from parsed Obsidian Tasks metadata.
+    #[must_use]
+    pub fn from_parsed_metadata(
+        parsed: crate::task_parser::ParsedTaskMetadata,
+        is_completed: bool,
+        position: SourcePosition,
+    ) -> Self {
+        Self {
+            content: parsed.description,
+            is_completed,
+            position,
+            created_date: parse_date_opt(parsed.created.as_deref()),
+            scheduled_date: parse_date_opt(parsed.scheduled.as_deref()),
+            start_date: parse_date_opt(parsed.start.as_deref()),
+            due_date: parse_date_opt(parsed.due.as_deref()),
+            done_date: parse_date_opt(parsed.done.as_deref()),
+            cancelled_date: parse_date_opt(parsed.cancelled.as_deref()),
+            priority: parsed
+                .priority
+                .and_then(TaskPriority::from_char)
+                .unwrap_or_default(),
+            recurrence: parsed.recurrence,
+            on_completion: parsed.on_completion,
+            id: parsed.id,
+            depends_on: parsed.depends_on,
+            tags: parsed.tags,
+            block_ref: parsed.block_ref,
+            metadata: parsed.metadata,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TaskPriority {
+    Lowest,
+    Low,
+    Normal,
+    Medium,
+    High,
+    Highest,
+}
+
+impl TaskPriority {
+    pub fn emoji(&self) -> &'static str {
+        match self {
+            TaskPriority::Lowest => "⏬",
+            TaskPriority::Low => "🔽",
+            TaskPriority::Normal => "",
+            TaskPriority::Medium => "🔼",
+            TaskPriority::High => "⏫",
+            TaskPriority::Highest => "🔺",
+        }
+    }
+
+    pub fn from_emoji(s: &str) -> Option<Self> {
+        Some(match s {
+            "⏬" => TaskPriority::Lowest,
+            "🔽" => TaskPriority::Low,
+            "" => TaskPriority::Normal,
+            "🔼" => TaskPriority::Medium,
+            "⏫" => TaskPriority::High,
+            "🔺" => TaskPriority::Highest,
+            _ => return None,
+        })
+    }
+
+    pub fn from_char(c: char) -> Option<Self> {
+        Self::from_emoji(c.encode_utf8(&mut [0; 4]))
+    }
+
+    pub fn is_valid_emoji(s: &str) -> bool {
+        Self::from_emoji(s).is_some()
+    }
+}
+
+impl Default for TaskPriority {
+    fn default() -> Self {
+        TaskPriority::Normal
+    }
+}
+
+impl fmt::Display for TaskPriority {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            TaskPriority::Lowest => "⏬",
+            TaskPriority::Low => "🔽",
+            TaskPriority::Normal => "",
+            TaskPriority::Medium => "🔼",
+            TaskPriority::High => "⏫",
+            TaskPriority::Highest => "🔺",
+        };
+        write!(f, "{}", s)
+    }
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct TaskBuilder{
+pub struct TaskBuilder {
     pub content: String,
     pub is_completed: bool,
     pub position: Option<SourcePosition>,
-    pub due_date: Option<String>,
 }
 
 impl TaskBuilder {
     pub fn build(&mut self) -> TaskItem {
-        let task_item = TaskItem {
-            content: self.content.trim().to_string(),
-            is_completed: std::mem::take(&mut self.is_completed), 
-            position: self.position.expect("Must have posiiton."),
-            due_date: std::mem::take(&mut self.due_date),
-        };
-        self.content.clear(); // = String::new();
+        let parsed: ParsedTaskMetadata = crate::task_parser::parse_task_content(&self.content);
+        let task_item = TaskItem::from_parsed_metadata(
+            parsed,
+            std::mem::take(&mut self.is_completed),
+            self.position.expect("Must have position."),
+        );
+        self.content.clear();
         self.position = None;
         task_item
     }
+}
+
+fn parse_date_opt(value: Option<&str>) -> Option<NaiveDate> {
+    NaiveDate::parse_from_str(value?, "%Y-%m-%d").ok()
 }
 
 /// Type of callout block
@@ -789,5 +925,167 @@ mod tests {
         assert_eq!(index.line_count(), 2); // Line 1 + empty line 2
         assert_eq!(index.line_col(6), (1, 7)); // The newline itself
         assert_eq!(index.line_col(7), (2, 1)); // After newline
+    }
+
+    #[test]
+    fn test_task_item_from_parsed_metadata() {
+        let mut metadata = HashMap::new();
+        metadata.insert("project".to_string(), "[[Team Work]]".to_string());
+
+        let task = TaskItem::from_parsed_metadata(
+            crate::task_parser::ParsedTaskMetadata {
+                description: "Review PR".to_string(),
+                due: Some("2026-05-01".to_string()),
+                scheduled: Some("2026-04-30".to_string()),
+                start: Some("2026-04-29".to_string()),
+                done: None,
+                cancelled: None,
+                created: Some("2026-04-28".to_string()),
+                priority: Some('⏫'),
+                recurrence: Some("every weekday".to_string()),
+                on_completion: Some("delete".to_string()),
+                id: Some("pr-123".to_string()),
+                depends_on: vec!["abc123".to_string(), "def456".to_string()],
+                tags: vec!["review".to_string()],
+                block_ref: Some("pr-123".to_string()),
+                metadata,
+            },
+            false,
+            SourcePosition::start(),
+        );
+
+        assert_eq!(task.content, "Review PR");
+        assert_eq!(
+            task.due_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-05-01")
+        );
+        assert_eq!(
+            task.scheduled_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+        assert_eq!(
+            task.start_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-04-29")
+        );
+        assert_eq!(
+            task.created_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-04-28")
+        );
+        assert_eq!(task.priority, TaskPriority::High);
+        assert_eq!(task.recurrence.as_deref(), Some("every weekday"));
+        assert_eq!(task.on_completion.as_deref(), Some("delete"));
+        assert_eq!(task.id.as_deref(), Some("pr-123"));
+        assert_eq!(
+            task.depends_on,
+            vec!["abc123".to_string(), "def456".to_string()]
+        );
+        assert_eq!(task.tags, vec!["review".to_string()]);
+        assert_eq!(task.block_ref.as_deref(), Some("pr-123"));
+        assert_eq!(
+            task.metadata.get("project").map(String::as_str),
+            Some("[[Team Work]]")
+        );
+    }
+
+    #[test]
+    fn test_task_item_deserializes_without_metadata_fields() {
+        let task: TaskItem = serde_json::from_str(
+            r#"{
+                "content": "Legacy task",
+                "is_completed": false,
+                "position": {
+                    "line": 1,
+                    "column": 1,
+                    "offset": 0,
+                    "length": 13
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(task.content, "Legacy task");
+        assert!(!task.is_completed);
+        assert_eq!(task.priority, TaskPriority::Normal);
+        assert!(task.due_date.is_none());
+        assert!(task.metadata.is_empty());
+    }
+
+    #[test]
+    fn test_task_item_deserializes_with_metadata_fields() {
+        let task: TaskItem = serde_json::from_str(
+            r#"{
+                "content": "Modern task",
+                "is_completed": true,
+                "position": {
+                    "line": 2,
+                    "column": 1,
+                    "offset": 14,
+                    "length": 42
+                },
+                "created_date": "2026-04-28",
+                "scheduled_date": "2026-04-29",
+                "start_date": "2026-04-30",
+                "due_date": "2026-05-01",
+                "done_date": "2026-05-02",
+                "cancelled_date": null,
+                "priority": "HIGH",
+                "recurrence": "every weekday",
+                "on_completion": "delete",
+                "id": "task-123",
+                "depends_on": ["abc123", "def456"],
+                "tags": ["review", "work"],
+                "block_ref": "block-123",
+                "metadata": {
+                    "project": "[[Team Work]]"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(task.content, "Modern task");
+        assert!(task.is_completed);
+        assert_eq!(
+            task.created_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-04-28")
+        );
+        assert_eq!(
+            task.scheduled_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-04-29")
+        );
+        assert_eq!(
+            task.start_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+        assert_eq!(
+            task.due_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-05-01")
+        );
+        assert_eq!(
+            task.done_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-05-02")
+        );
+        assert!(task.cancelled_date.is_none());
+        assert_eq!(task.priority, TaskPriority::High);
+        assert_eq!(task.recurrence.as_deref(), Some("every weekday"));
+        assert_eq!(task.on_completion.as_deref(), Some("delete"));
+        assert_eq!(task.id.as_deref(), Some("task-123"));
+        assert_eq!(
+            task.depends_on,
+            vec!["abc123".to_string(), "def456".to_string()]
+        );
+        assert_eq!(task.tags, vec!["review".to_string(), "work".to_string()]);
+        assert_eq!(task.block_ref.as_deref(), Some("block-123"));
+        assert_eq!(
+            task.metadata.get("project").map(String::as_str),
+            Some("[[Team Work]]")
+        );
+    }
+
+    #[test]
+    fn test_task_priority_serializes_as_stable_api_value() {
+        assert_eq!(
+            serde_json::to_value(TaskPriority::High).unwrap(),
+            serde_json::Value::String("HIGH".to_string())
+        );
     }
 }

--- a/crates/turbovault-core/src/models.rs
+++ b/crates/turbovault-core/src/models.rs
@@ -334,7 +334,6 @@ impl TaskPriority {
     }
 }
 
-
 impl fmt::Display for TaskPriority {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {

--- a/crates/turbovault-core/src/models.rs
+++ b/crates/turbovault-core/src/models.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 use crate::task_parser::ParsedTaskMetadata;
 
 /// Position in source text (line, column, byte offset)
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SourcePosition {
     pub line: usize,
     pub column: usize,
@@ -289,11 +289,12 @@ impl TaskItem {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TaskPriority {
     Lowest,
     Low,
+    #[default]
     Normal,
     Medium,
     High,
@@ -333,11 +334,6 @@ impl TaskPriority {
     }
 }
 
-impl Default for TaskPriority {
-    fn default() -> Self {
-        TaskPriority::Normal
-    }
-}
 
 impl fmt::Display for TaskPriority {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -357,7 +353,7 @@ impl fmt::Display for TaskPriority {
 pub struct TaskBuilder {
     pub content: String,
     pub is_completed: bool,
-    pub position: Option<SourcePosition>,
+    pub position: SourcePosition,
 }
 
 impl TaskBuilder {
@@ -366,10 +362,9 @@ impl TaskBuilder {
         let task_item = TaskItem::from_parsed_metadata(
             parsed,
             std::mem::take(&mut self.is_completed),
-            self.position.expect("Must have position."),
+            std::mem::take(&mut self.position),
         );
         self.content.clear();
-        self.position = None;
         task_item
     }
 }

--- a/crates/turbovault-core/src/models.rs
+++ b/crates/turbovault-core/src/models.rs
@@ -220,6 +220,28 @@ pub struct TaskItem {
     pub due_date: Option<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct TaskBuilder{
+    pub content: String,
+    pub is_completed: bool,
+    pub position: Option<SourcePosition>,
+    pub due_date: Option<String>,
+}
+
+impl TaskBuilder {
+    pub fn build(&mut self) -> TaskItem {
+        let task_item = TaskItem {
+            content: self.content.trim().to_string(),
+            is_completed: std::mem::take(&mut self.is_completed), 
+            position: self.position.expect("Must have posiiton."),
+            due_date: std::mem::take(&mut self.due_date),
+        };
+        self.content.clear(); // = String::new();
+        self.position = None;
+        task_item
+    }
+}
+
 /// Type of callout block
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CalloutType {

--- a/crates/turbovault-core/src/task_parser.rs
+++ b/crates/turbovault-core/src/task_parser.rs
@@ -152,7 +152,11 @@ fn find_metadata_start(content: &str) -> usize {
             in_word = false;
         } else if !in_word {
             in_word = true;
-            if is_pure_metadata(&content[i..]) && !previous_token_is_priority(&content[..i]) {
+            let rest = &content[i..];
+            if starts_metadata_token(rest)
+                && !previous_token_is_priority(&content[..i])
+                && is_pure_metadata(rest)
+            {
                 return i;
             }
         }
@@ -280,9 +284,10 @@ fn parse_recurrence_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
         return Err(ErrMode::Backtrack(ContextError::new()));
     }
 
-    let mut meta = ParsedTaskMetadata::default();
-    meta.recurrence = Some(words.join(" "));
-    Ok(meta)
+    Ok(ParsedTaskMetadata {
+        recurrence: Some(words.join(" ")),
+        ..Default::default()
+    })
 }
 
 fn parse_on_completion_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
@@ -290,9 +295,10 @@ fn parse_on_completion_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata
     let _ = space0.parse_next(input)?;
     let value: &str = take_while(1.., |c: char| !c.is_whitespace()).parse_next(input)?;
 
-    let mut meta = ParsedTaskMetadata::default();
-    meta.on_completion = Some(value.trim().to_ascii_lowercase());
-    Ok(meta)
+    Ok(ParsedTaskMetadata {
+        on_completion: Some(value.trim().to_ascii_lowercase()),
+        ..Default::default()
+    })
 }
 
 fn parse_id_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
@@ -300,9 +306,10 @@ fn parse_id_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
     let _ = space0.parse_next(input)?;
     let id = parse_task_id(input)?;
 
-    let mut meta = ParsedTaskMetadata::default();
-    meta.id = Some(id.to_string());
-    Ok(meta)
+    Ok(ParsedTaskMetadata {
+        id: Some(id.to_string()),
+        ..Default::default()
+    })
 }
 
 fn parse_depends_on_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
@@ -310,9 +317,10 @@ fn parse_depends_on_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
     let _ = space0.parse_next(input)?;
     let value: &str = take_while(1.., |c: char| !c.is_whitespace()).parse_next(input)?;
 
-    let mut meta = ParsedTaskMetadata::default();
-    meta.depends_on = split_dependency_ids(value);
-    Ok(meta)
+    Ok(ParsedTaskMetadata {
+        depends_on: split_dependency_ids(value),
+        ..Default::default()
+    })
 }
 
 fn parse_task_id<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
@@ -404,9 +412,10 @@ fn parse_priority_emoji(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
     ))
     .parse_next(input)?;
 
-    let mut meta = ParsedTaskMetadata::default();
-    meta.priority = Some(priority);
-    Ok(meta)
+    Ok(ParsedTaskMetadata {
+        priority: Some(priority),
+        ..Default::default()
+    })
 }
 
 fn parse_tag_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
@@ -430,9 +439,10 @@ fn parse_block_ref_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
     let id: &str =
         take_while(1.., |c: char| c.is_alphanumeric() || c == '-' || c == '_').parse_next(input)?;
 
-    let mut meta = ParsedTaskMetadata::default();
-    meta.block_ref = Some(id.to_string());
-    Ok(meta)
+    Ok(ParsedTaskMetadata {
+        block_ref: Some(id.to_string()),
+        ..Default::default()
+    })
 }
 
 fn starts_metadata_token(s: &str) -> bool {

--- a/crates/turbovault-core/src/task_parser.rs
+++ b/crates/turbovault-core/src/task_parser.rs
@@ -1,0 +1,719 @@
+//! Winnow parsers for Obsidian task metadata.
+//!
+//! Supports the Obsidian Tasks emoji format and Dataview inline field format.
+//! Metadata is parsed only when it appears in the trailing metadata section of
+//! the task, matching the Tasks plugin behavior described in its task-format
+//! docs.
+//!
+//! This module intentionally exposes two entry points:
+//!
+//! - [`parse_task_content`] parses the text after the checkbox marker. This is
+//!   the path used by the pulldown-cmark parser, because pulldown-cmark already
+//!   recognizes Markdown task list markers and reports the task body separately.
+//! - [`parse_task_line`] parses a raw Markdown task line, including its checkbox.
+//!   It is useful for standalone line parsing, parser tests, and future
+//!   task-focused APIs that do not need to run the full Markdown parser first.
+//!
+//! Keeping both entry points in one module ensures every caller shares the same
+//! metadata parser instead of reimplementing task metadata extraction.
+
+use std::collections::HashMap;
+
+use winnow::{
+    ModalResult, Parser,
+    ascii::space0,
+    combinator::alt,
+    error::{ContextError, ErrMode},
+    token::{literal, one_of, take_while},
+};
+
+const DUE_EMOJI: &str = "📅";
+const SCHEDULED_EMOJI: &str = "⏳";
+const START_EMOJI: &str = "🛫";
+const DONE_EMOJI: &str = "✅";
+const CANCELLED_EMOJI: &str = "❌";
+const CREATED_EMOJI: &str = "➕";
+const RECURRENCE_EMOJI: &str = "🔁";
+const ON_COMPLETION_EMOJI: &str = "🏁";
+const ID_EMOJI: &str = "🆔";
+const DEPENDS_ON_EMOJI: &str = "⛔";
+const PRIORITY_HIGHEST_EMOJI: &str = "🔺";
+const PRIORITY_HIGH_EMOJI: &str = "⏫";
+const PRIORITY_MEDIUM_EMOJI: &str = "🔼";
+const PRIORITY_LOW_EMOJI: &str = "🔽";
+const PRIORITY_LOWEST_EMOJI: &str = "⏬";
+
+/// Parsed content and trailing metadata for an Obsidian task.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParsedTaskMetadata {
+    pub description: String,
+    pub due: Option<String>,
+    pub scheduled: Option<String>,
+    pub start: Option<String>,
+    pub done: Option<String>,
+    pub cancelled: Option<String>,
+    pub created: Option<String>,
+    pub priority: Option<char>,
+    pub recurrence: Option<String>,
+    pub on_completion: Option<String>,
+    pub id: Option<String>,
+    pub depends_on: Vec<String>,
+    pub tags: Vec<String>,
+    pub block_ref: Option<String>,
+    pub metadata: HashMap<String, String>,
+}
+
+/// A parsed Obsidian task line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Task {
+    /// Status character inside the checkbox.
+    pub status: char,
+    /// Human-readable description with trailing metadata removed.
+    pub description: String,
+    pub due: Option<String>,
+    pub scheduled: Option<String>,
+    pub start: Option<String>,
+    pub done: Option<String>,
+    pub cancelled: Option<String>,
+    pub created: Option<String>,
+    pub priority: Option<char>,
+    pub recurrence: Option<String>,
+    pub on_completion: Option<String>,
+    pub id: Option<String>,
+    pub depends_on: Vec<String>,
+    pub tags: Vec<String>,
+    pub block_ref: Option<String>,
+    /// Dataview inline fields, including custom fields.
+    pub metadata: HashMap<String, String>,
+}
+
+/// Parse a complete Obsidian task line, including the checkbox marker.
+///
+/// This is not used by the pulldown-cmark integration path, which receives task
+/// content after Markdown has already identified the checkbox. It exists as a
+/// small standalone API for callers that have a raw task line and want the same
+/// metadata parsing behavior as the full document parser.
+///
+/// # Errors
+///
+/// Returns `Err` when the line does not start with a supported task checkbox.
+pub fn parse_task_line(input: &str) -> Result<Task, String> {
+    let mut input = input.trim();
+    let status = parse_checkbox(&mut input).map_err(|e| format!("expected checkbox: {e}"))?;
+    let parsed = parse_task_content(input);
+
+    Ok(Task {
+        status,
+        description: parsed.description,
+        due: parsed.due,
+        scheduled: parsed.scheduled,
+        start: parsed.start,
+        done: parsed.done,
+        cancelled: parsed.cancelled,
+        created: parsed.created,
+        priority: parsed.priority,
+        recurrence: parsed.recurrence,
+        on_completion: parsed.on_completion,
+        id: parsed.id,
+        depends_on: parsed.depends_on,
+        tags: parsed.tags,
+        block_ref: parsed.block_ref,
+        metadata: parsed.metadata,
+    })
+}
+
+/// Parse task text after the checkbox marker.
+///
+/// The returned description is the original content before the trailing metadata
+/// section. Metadata-like text in the middle of the description is preserved.
+#[must_use]
+pub fn parse_task_content(content: &str) -> ParsedTaskMetadata {
+    let meta_start = find_metadata_start(content);
+    let mut parsed = parse_metadata_section(content[meta_start..].trim_start());
+    parsed.description = content[..meta_start].trim_end().to_string();
+    parsed
+}
+
+fn parse_checkbox(input: &mut &str) -> ModalResult<char> {
+    let _ = space0.parse_next(input)?;
+    let _ = one_of(['-', '*', '+']).parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+    let _ = literal("[").parse_next(input)?;
+    let status = one_of([' ', 'x', 'X', '-', '>', '<', '/']).parse_next(input)?;
+    let _ = literal("]").parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+    Ok(status)
+}
+
+fn find_metadata_start(content: &str) -> usize {
+    let mut in_word = false;
+    for (i, c) in content.char_indices() {
+        if c.is_whitespace() {
+            in_word = false;
+        } else if !in_word {
+            in_word = true;
+            if is_pure_metadata(&content[i..]) && !previous_token_is_priority(&content[..i]) {
+                return i;
+            }
+        }
+    }
+    content.len()
+}
+
+fn previous_token_is_priority(prefix: &str) -> bool {
+    prefix
+        .split_whitespace()
+        .next_back()
+        .is_some_and(is_priority_emoji)
+}
+
+fn is_pure_metadata(s: &str) -> bool {
+    let mut input = s;
+    let mut seen_priority = false;
+    let mut seen_item = false;
+    loop {
+        if input.is_empty() {
+            return seen_item;
+        }
+
+        if consume_metadata_separator(&mut input).is_err() {
+            return false;
+        }
+
+        match parse_one_metadata_item(&mut input) {
+            Ok(item) => {
+                seen_item = true;
+                if item.priority.is_some() {
+                    if seen_priority {
+                        return false;
+                    }
+                    seen_priority = true;
+                }
+            }
+            Err(_) => return false,
+        }
+    }
+}
+
+fn parse_metadata_section(meta_str: &str) -> ParsedTaskMetadata {
+    let mut result = ParsedTaskMetadata::default();
+    let mut input = meta_str;
+
+    loop {
+        if input.is_empty() {
+            break;
+        }
+
+        if consume_metadata_separator(&mut input).is_err() {
+            break;
+        }
+
+        match parse_one_metadata_item(&mut input) {
+            Ok(item) => merge_metadata(&mut result, item),
+            Err(_) => break,
+        }
+    }
+
+    result
+}
+
+fn consume_metadata_separator(input: &mut &str) -> ModalResult<()> {
+    let _ = space0.parse_next(input)?;
+
+    if input.starts_with(',') {
+        let _ = literal(",").parse_next(input)?;
+        let _ = space0.parse_next(input)?;
+    }
+
+    Ok(())
+}
+
+fn parse_one_metadata_item(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
+    alt((
+        parse_emoji_date_field,
+        parse_recurrence_field,
+        parse_on_completion_field,
+        parse_id_field,
+        parse_depends_on_field,
+        parse_dataview_field,
+        parse_priority_emoji,
+        parse_tag_field,
+        parse_block_ref_field,
+    ))
+    .parse_next(input)
+}
+
+fn parse_emoji_date_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
+    let key = alt((
+        literal(DUE_EMOJI).value("due"),
+        literal(SCHEDULED_EMOJI).value("scheduled"),
+        literal(START_EMOJI).value("start"),
+        literal(DONE_EMOJI).value("done"),
+        literal(CANCELLED_EMOJI).value("cancelled"),
+        literal(CREATED_EMOJI).value("created"),
+    ))
+    .parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+    let value: &str = take_while(1.., |c: char| !c.is_whitespace()).parse_next(input)?;
+
+    let mut meta = ParsedTaskMetadata::default();
+    set_standard_field(&mut meta, key, value.trim());
+    Ok(meta)
+}
+
+fn parse_recurrence_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
+    let _ = literal(RECURRENCE_EMOJI).parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+
+    let mut words = Vec::new();
+    loop {
+        let trimmed = input.trim_start();
+        if trimmed.is_empty() || starts_metadata_token(trimmed) {
+            break;
+        }
+        let word: &str = take_while(1.., |c: char| !c.is_whitespace()).parse_next(input)?;
+        words.push(word);
+        let _ = space0.parse_next(input)?;
+    }
+
+    if words.is_empty() {
+        return Err(ErrMode::Backtrack(ContextError::new()));
+    }
+
+    let mut meta = ParsedTaskMetadata::default();
+    meta.recurrence = Some(words.join(" "));
+    Ok(meta)
+}
+
+fn parse_on_completion_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
+    let _ = literal(ON_COMPLETION_EMOJI).parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+    let value: &str = take_while(1.., |c: char| !c.is_whitespace()).parse_next(input)?;
+
+    let mut meta = ParsedTaskMetadata::default();
+    meta.on_completion = Some(value.trim().to_ascii_lowercase());
+    Ok(meta)
+}
+
+fn parse_id_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
+    let _ = literal(ID_EMOJI).parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+    let id = parse_task_id(input)?;
+
+    let mut meta = ParsedTaskMetadata::default();
+    meta.id = Some(id.to_string());
+    Ok(meta)
+}
+
+fn parse_depends_on_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
+    let _ = literal(DEPENDS_ON_EMOJI).parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+    let value: &str = take_while(1.., |c: char| !c.is_whitespace()).parse_next(input)?;
+
+    let mut meta = ParsedTaskMetadata::default();
+    meta.depends_on = split_dependency_ids(value);
+    Ok(meta)
+}
+
+fn parse_task_id<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+    take_while(1.., |c: char| c.is_alphanumeric() || c == '-' || c == '_').parse_next(input)
+}
+
+fn parse_dataview_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
+    let closing = parse_dataview_open(input)?;
+    let key: &str = take_while(1.., is_dataview_key_char).parse_next(input)?;
+    let _ = literal("::").parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+    let value = parse_balanced_inline_value(input, closing)?;
+    let _ = one_of([closing]).parse_next(input)?;
+
+    let key = key.trim().to_ascii_lowercase();
+    let value = value.trim().to_string();
+    let mut meta = ParsedTaskMetadata::default();
+    set_standard_field(&mut meta, &key, &value);
+    meta.metadata.insert(key, value);
+    Ok(meta)
+}
+
+fn parse_dataview_open(input: &mut &str) -> ModalResult<char> {
+    let opening = one_of(['[', '(']).parse_next(input)?;
+    Ok(match opening {
+        '[' => ']',
+        '(' => ')',
+        _ => unreachable!(),
+    })
+}
+
+fn is_dataview_key_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '-'
+}
+
+fn parse_balanced_inline_value<'i>(input: &mut &'i str, closing: char) -> ModalResult<&'i str> {
+    let start = *input;
+    let mut square_depth = 0usize;
+    let mut paren_depth = 0usize;
+    let mut consumed = 0usize;
+    let mut found_close = false;
+
+    for c in start.chars() {
+        match c {
+            '[' => {
+                square_depth += 1;
+                consumed += c.len_utf8();
+            }
+            ']' if closing == ']' && square_depth == 0 && paren_depth == 0 => {
+                found_close = true;
+                break;
+            }
+            ']' => {
+                square_depth = square_depth.saturating_sub(1);
+                consumed += c.len_utf8();
+            }
+            '(' => {
+                paren_depth += 1;
+                consumed += c.len_utf8();
+            }
+            ')' if closing == ')' && square_depth == 0 && paren_depth == 0 => {
+                found_close = true;
+                break;
+            }
+            ')' => {
+                paren_depth = paren_depth.saturating_sub(1);
+                consumed += c.len_utf8();
+            }
+            _ => consumed += c.len_utf8(),
+        }
+    }
+
+    if !found_close {
+        return Err(ErrMode::Backtrack(ContextError::new()));
+    }
+
+    let value = &start[..consumed];
+    *input = &start[consumed..];
+    Ok(value)
+}
+
+fn parse_priority_emoji(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
+    let priority = alt((
+        literal(PRIORITY_HIGH_EMOJI).value('⏫'),
+        literal(PRIORITY_HIGHEST_EMOJI).value('🔺'),
+        literal(PRIORITY_MEDIUM_EMOJI).value('🔼'),
+        literal(PRIORITY_LOW_EMOJI).value('🔽'),
+        literal(PRIORITY_LOWEST_EMOJI).value('⏬'),
+    ))
+    .parse_next(input)?;
+
+    let mut meta = ParsedTaskMetadata::default();
+    meta.priority = Some(priority);
+    Ok(meta)
+}
+
+fn parse_tag_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
+    let _ = literal("#").parse_next(input)?;
+    let name: &str = take_while(1.., |c: char| {
+        c.is_alphanumeric() || c == '-' || c == '_' || c == '/'
+    })
+    .parse_next(input)?;
+
+    if !name.chars().any(|c| c.is_alphabetic()) {
+        return Err(ErrMode::Backtrack(ContextError::new()));
+    }
+
+    let mut meta = ParsedTaskMetadata::default();
+    meta.tags.push(name.to_string());
+    Ok(meta)
+}
+
+fn parse_block_ref_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
+    let _ = literal("^").parse_next(input)?;
+    let id: &str =
+        take_while(1.., |c: char| c.is_alphanumeric() || c == '-' || c == '_').parse_next(input)?;
+
+    let mut meta = ParsedTaskMetadata::default();
+    meta.block_ref = Some(id.to_string());
+    Ok(meta)
+}
+
+fn starts_metadata_token(s: &str) -> bool {
+    s.starts_with(DUE_EMOJI)
+        || s.starts_with(SCHEDULED_EMOJI)
+        || s.starts_with(START_EMOJI)
+        || s.starts_with(DONE_EMOJI)
+        || s.starts_with(CANCELLED_EMOJI)
+        || s.starts_with(CREATED_EMOJI)
+        || s.starts_with(RECURRENCE_EMOJI)
+        || s.starts_with(ON_COMPLETION_EMOJI)
+        || s.starts_with(ID_EMOJI)
+        || s.starts_with(DEPENDS_ON_EMOJI)
+        || is_priority_metadata_start(s)
+        || s.starts_with('#')
+        || s.starts_with('^')
+        || ((s.starts_with('[') || s.starts_with('(')) && s.contains("::"))
+}
+
+fn is_priority_metadata_start(s: &str) -> bool {
+    s.starts_with(PRIORITY_HIGH_EMOJI)
+        || s.starts_with(PRIORITY_HIGHEST_EMOJI)
+        || s.starts_with(PRIORITY_MEDIUM_EMOJI)
+        || s.starts_with(PRIORITY_LOW_EMOJI)
+        || s.starts_with(PRIORITY_LOWEST_EMOJI)
+}
+
+fn is_priority_emoji(s: &str) -> bool {
+    matches!(
+        s,
+        PRIORITY_HIGH_EMOJI
+            | PRIORITY_HIGHEST_EMOJI
+            | PRIORITY_MEDIUM_EMOJI
+            | PRIORITY_LOW_EMOJI
+            | PRIORITY_LOWEST_EMOJI
+    )
+}
+
+fn set_standard_field(meta: &mut ParsedTaskMetadata, key: &str, value: &str) {
+    match key {
+        "due" => meta.due = Some(value.to_string()),
+        "scheduled" => meta.scheduled = Some(value.to_string()),
+        "start" => meta.start = Some(value.to_string()),
+        "done" | "completion" => meta.done = Some(value.to_string()),
+        "cancelled" | "canceled" => meta.cancelled = Some(value.to_string()),
+        "created" => meta.created = Some(value.to_string()),
+        "recurrence" | "repeat" => meta.recurrence = Some(value.to_string()),
+        "oncompletion" => meta.on_completion = Some(value.to_ascii_lowercase()),
+        "id" => meta.id = Some(value.to_string()),
+        "dependson" => meta.depends_on = split_dependency_ids(value),
+        "priority" => meta.priority = priority_from_dataview_value(value),
+        _ => {}
+    }
+}
+
+fn split_dependency_ids(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn priority_from_dataview_value(value: &str) -> Option<char> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "highest" => Some('🔺'),
+        "high" => Some('⏫'),
+        "medium" => Some('🔼'),
+        "low" => Some('🔽'),
+        "lowest" => Some('⏬'),
+        "normal" | "none" => None,
+        _ => None,
+    }
+}
+
+fn merge_metadata(dst: &mut ParsedTaskMetadata, src: ParsedTaskMetadata) {
+    if src.due.is_some() {
+        dst.due = src.due;
+    }
+    if src.scheduled.is_some() {
+        dst.scheduled = src.scheduled;
+    }
+    if src.start.is_some() {
+        dst.start = src.start;
+    }
+    if src.done.is_some() {
+        dst.done = src.done;
+    }
+    if src.cancelled.is_some() {
+        dst.cancelled = src.cancelled;
+    }
+    if src.created.is_some() {
+        dst.created = src.created;
+    }
+    if src.priority.is_some() {
+        dst.priority = src.priority;
+    }
+    if src.recurrence.is_some() {
+        dst.recurrence = src.recurrence;
+    }
+    if src.on_completion.is_some() {
+        dst.on_completion = src.on_completion;
+    }
+    if src.id.is_some() {
+        dst.id = src.id;
+    }
+    if !src.depends_on.is_empty() {
+        dst.depends_on = src.depends_on;
+    }
+    if src.block_ref.is_some() {
+        dst.block_ref = src.block_ref;
+    }
+    dst.tags.extend(src.tags);
+    dst.metadata.extend(src.metadata);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_basic_emoji_metadata() {
+        let task = parse_task_line("- [ ] Buy milk 📅 2025-05-15").unwrap();
+        assert_eq!(task.description, "Buy milk");
+        assert_eq!(task.due.as_deref(), Some("2025-05-15"));
+    }
+
+    #[test]
+    fn parses_dataview_metadata() {
+        let task = parse_task_line("- [ ] Finish report [due:: 2025-06-01]").unwrap();
+        assert_eq!(task.description, "Finish report");
+        assert_eq!(task.due.as_deref(), Some("2025-06-01"));
+        assert_eq!(
+            task.metadata.get("due").map(String::as_str),
+            Some("2025-06-01")
+        );
+    }
+
+    #[test]
+    fn parses_mixed_emoji_and_dataview() {
+        let task = parse_task_line(
+            "- [x] Do the thing 📅 2025-05-01 [scheduled:: 2025-05-03] 🔁 every weekday",
+        )
+        .unwrap();
+        assert_eq!(task.description, "Do the thing");
+        assert_eq!(task.due.as_deref(), Some("2025-05-01"));
+        assert_eq!(task.scheduled.as_deref(), Some("2025-05-03"));
+        assert_eq!(task.recurrence.as_deref(), Some("every weekday"));
+        assert_eq!(task.status, 'x');
+    }
+
+    #[test]
+    fn parses_comma_separated_dataview_fields() {
+        let task = parse_task_line(
+            "- [ ] This is a task [priority:: high], [start:: 2023-04-24], [due:: 2023-05-01]",
+        )
+        .unwrap();
+
+        assert_eq!(task.description, "This is a task");
+        assert_eq!(task.priority, Some('⏫'));
+        assert_eq!(task.start.as_deref(), Some("2023-04-24"));
+        assert_eq!(task.due.as_deref(), Some("2023-05-01"));
+    }
+
+    #[test]
+    fn parses_dataview_completion_repeat_and_priority() {
+        let task = parse_task_line(
+            "- [ ] Ship it [completion:: 2025-07-01] [repeat:: every month] [priority:: high]",
+        )
+        .unwrap();
+        assert_eq!(task.description, "Ship it");
+        assert_eq!(task.done.as_deref(), Some("2025-07-01"));
+        assert_eq!(task.recurrence.as_deref(), Some("every month"));
+        assert_eq!(task.priority, Some('⏫'));
+    }
+
+    #[test]
+    fn parses_dataview_on_completion_and_dependencies() {
+        let task = parse_task_line(
+            "- [ ] Blocked work [repeat:: every day], [onCompletion:: delete], [id:: dcf64c], [dependsOn:: abc123,def456]",
+        )
+        .unwrap();
+
+        assert_eq!(task.description, "Blocked work");
+        assert_eq!(task.recurrence.as_deref(), Some("every day"));
+        assert_eq!(task.on_completion.as_deref(), Some("delete"));
+        assert_eq!(task.id.as_deref(), Some("dcf64c"));
+        assert_eq!(
+            task.depends_on,
+            vec!["abc123".to_string(), "def456".to_string()]
+        );
+    }
+
+    #[test]
+    fn parses_emoji_on_completion_and_dependencies() {
+        let task =
+            parse_task_line("- [ ] Blocked work 🏁 keep 🆔 dcf64c ⛔ abc123,def456").unwrap();
+
+        assert_eq!(task.description, "Blocked work");
+        assert_eq!(task.on_completion.as_deref(), Some("keep"));
+        assert_eq!(task.id.as_deref(), Some("dcf64c"));
+        assert_eq!(
+            task.depends_on,
+            vec!["abc123".to_string(), "def456".to_string()]
+        );
+    }
+
+    #[test]
+    fn parses_tags_and_block_ref_after_metadata() {
+        let task = parse_task_line("- [ ] Task description 📅 2025-05-10 #urgent #work ^task-123")
+            .unwrap();
+        assert_eq!(task.description, "Task description");
+        assert_eq!(task.due.as_deref(), Some("2025-05-10"));
+        assert_eq!(task.tags, vec!["urgent".to_string(), "work".to_string()]);
+        assert_eq!(task.block_ref.as_deref(), Some("task-123"));
+    }
+
+    #[test]
+    fn ignores_false_positive_in_description() {
+        let task =
+            parse_task_line("- [ ] Review the [due date] section and 📅 2025-04-30").unwrap();
+        assert_eq!(task.description, "Review the [due date] section and");
+        assert_eq!(task.due.as_deref(), Some("2025-04-30"));
+    }
+
+    #[test]
+    fn duplicate_fields_rightmost_wins() {
+        let task = parse_task_line("- [ ] Task 📅 2025-05-01 📅 2025-06-15").unwrap();
+        assert_eq!(task.due.as_deref(), Some("2025-06-15"));
+    }
+
+    #[test]
+    fn parses_priority() {
+        let task = parse_task_line("- [ ] High priority task ⏫").unwrap();
+        assert_eq!(task.priority, Some('⏫'));
+        assert_eq!(task.description, "High priority task");
+    }
+
+    #[test]
+    fn keeps_middle_metadata_in_description() {
+        let task = parse_task_line(
+            "- [ ] 📅 2025-05-01 This date in middle should be ignored ⏳ 2025-05-10",
+        )
+        .unwrap();
+        assert_eq!(
+            task.description,
+            "📅 2025-05-01 This date in middle should be ignored"
+        );
+        assert_eq!(task.scheduled.as_deref(), Some("2025-05-10"));
+        assert!(task.due.is_none());
+    }
+
+    #[test]
+    fn parses_dataview_value_with_wikilink() {
+        let task = parse_task_line(
+            "- [ ] Review PR #123 [project:: [[Team Work]]] 📅 2025-05-20 🔼 #review ^pr-123",
+        )
+        .unwrap();
+        assert_eq!(task.description, "Review PR #123");
+        assert_eq!(task.due.as_deref(), Some("2025-05-20"));
+        assert_eq!(task.priority, Some('🔼'));
+        assert_eq!(task.tags, vec!["review".to_string()]);
+        assert_eq!(task.block_ref.as_deref(), Some("pr-123"));
+        assert_eq!(
+            task.metadata.get("project").map(String::as_str),
+            Some("[[Team Work]]")
+        );
+    }
+
+    #[test]
+    fn supports_parenthesized_dataview_fields() {
+        let task = parse_task_line("- [ ] Call Alex (due:: 2025-06-01)").unwrap();
+        assert_eq!(task.description, "Call Alex");
+        assert_eq!(task.due.as_deref(), Some("2025-06-01"));
+    }
+
+    #[test]
+    fn keeps_bare_recurrence_marker_in_description() {
+        let task = parse_task_line("- [ ] Decide recurrence 🔁").unwrap();
+        assert_eq!(task.description, "Decide recurrence 🔁");
+        assert!(task.recurrence.is_none());
+    }
+}

--- a/crates/turbovault-parser/src/engine.rs
+++ b/crates/turbovault-parser/src/engine.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 use turbovault_core::{
     Callout, CalloutType, Frontmatter, Heading, LineIndex, Link, LinkType, SourcePosition,
-    Tag as OFMTag, TaskItem,
+    Tag as OFMTag, TaskItem, TaskBuilder,
 };
 
 use crate::ParseOptions;
@@ -266,10 +266,14 @@ impl<'a> ParseEngine<'a> {
         let mut current_heading: Option<(HeadingLevel, Option<String>)> = None;
         let mut heading_text = String::new();
         let mut heading_start: usize = 0;
+
         let mut in_task_item = false;
         let mut task_checked = false;
         let mut task_content = String::new();
         let mut task_start: usize = 0;
+
+        let mut task_builder: TaskBuilder = TaskBuilder::default();
+
         let mut current_link: Option<(String, String)> = None; // (url, title)
         let mut link_text = String::new();
         let mut link_start: usize = 0;
@@ -365,7 +369,7 @@ impl<'a> ParseEngine<'a> {
                 Event::TaskListMarker(_checked) if options.parse_tasks => {
                     in_task_item = true;
                     // Read raw marker byte to detect extended states [/] [-]
-                    task_checked = {
+                    task_builder.is_completed = {
                         let raw_marker = self
                             .content
                             .as_bytes()
@@ -374,27 +378,20 @@ impl<'a> ParseEngine<'a> {
                             .unwrap_or(b' ') as char;
                         crate::models::TaskStatus::from_marker(raw_marker).is_completed()
                     };
-                    task_content.clear();
-                    task_start = range.start;
+                    // task_content.clear();
+                    task_builder.position = Some(SourcePosition::from_offset_indexed(&self.index, range.start, range.end - range.start));
+                    // task_start = range.start;
                 }
                 Event::End(TagEnd::Item) if in_task_item => {
                     in_task_item = false;
                     if !task_content.is_empty() {
-                        result.tasks.push(TaskItem {
-                            content: task_content.trim().to_string(),
-                            is_completed: task_checked,
-                            position: SourcePosition::from_offset_indexed(
-                                &self.index,
-                                task_start,
-                                range.end - task_start,
-                            ),
-                            due_date: None,
-                        });
+                        result.tasks.push(task_builder.build());
                     }
-                    task_content.clear();
+                    // task_content.clear();
                 }
                 Event::Text(text) if in_task_item => {
-                    task_content.push_str(&text);
+                    task_builder.content.push_str(&text);
+                    // task_content.push_str(&text);
                 }
 
                 // === Markdown Links ===
@@ -439,6 +436,8 @@ impl<'a> ParseEngine<'a> {
         excluded.optimize();
         (excluded, body_start)
     }
+
+    fn parse_task_content(&self, )
 
     /// Parse wikilinks, respecting excluded ranges.
     fn parse_wikilinks(

--- a/crates/turbovault-parser/src/engine.rs
+++ b/crates/turbovault-parser/src/engine.rs
@@ -374,11 +374,11 @@ impl<'a> ParseEngine<'a> {
                             .unwrap_or(b' ') as char;
                         crate::models::TaskStatus::from_marker(raw_marker).is_completed()
                     };
-                    task_builder.position = Some(SourcePosition::from_offset_indexed(
+                    task_builder.position = SourcePosition::from_offset_indexed(
                         &self.index,
                         range.start,
                         range.end - range.start,
-                    ));
+                    );
                 }
 
                 Event::End(TagEnd::Item) if in_task_item => {

--- a/crates/turbovault-parser/src/engine.rs
+++ b/crates/turbovault-parser/src/engine.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 use turbovault_core::{
     Callout, CalloutType, Frontmatter, Heading, LineIndex, Link, LinkType, SourcePosition,
-    Tag as OFMTag, TaskItem, TaskBuilder,
+    Tag as OFMTag, TaskBuilder, TaskItem,
 };
 
 use crate::ParseOptions;
@@ -267,11 +267,7 @@ impl<'a> ParseEngine<'a> {
         let mut heading_text = String::new();
         let mut heading_start: usize = 0;
 
-        let mut in_task_item = false;
-        let mut task_checked = false;
-        let mut task_content = String::new();
-        let mut task_start: usize = 0;
-
+        let mut in_task_item: bool = false;
         let mut task_builder: TaskBuilder = TaskBuilder::default();
 
         let mut current_link: Option<(String, String)> = None; // (url, title)
@@ -378,20 +374,22 @@ impl<'a> ParseEngine<'a> {
                             .unwrap_or(b' ') as char;
                         crate::models::TaskStatus::from_marker(raw_marker).is_completed()
                     };
-                    // task_content.clear();
-                    task_builder.position = Some(SourcePosition::from_offset_indexed(&self.index, range.start, range.end - range.start));
-                    // task_start = range.start;
+                    task_builder.position = Some(SourcePosition::from_offset_indexed(
+                        &self.index,
+                        range.start,
+                        range.end - range.start,
+                    ));
                 }
+
                 Event::End(TagEnd::Item) if in_task_item => {
                     in_task_item = false;
-                    if !task_content.is_empty() {
+                    if !task_builder.content.is_empty() {
                         result.tasks.push(task_builder.build());
                     }
-                    // task_content.clear();
                 }
+
                 Event::Text(text) if in_task_item => {
                     task_builder.content.push_str(&text);
-                    // task_content.push_str(&text);
                 }
 
                 // === Markdown Links ===
@@ -436,8 +434,6 @@ impl<'a> ParseEngine<'a> {
         excluded.optimize();
         (excluded, body_start)
     }
-
-    fn parse_task_content(&self, )
 
     /// Parse wikilinks, respecting excluded ranges.
     fn parse_wikilinks(
@@ -1492,6 +1488,102 @@ Back to normal [[Valid]]
             0,
             "pulldown-cmark does not recognise [-] as a task marker; \
              non-standard markers are not emitted as TaskListMarker events"
+        );
+    }
+
+    #[test]
+    fn test_task_priority_parsing() {
+        use turbovault_core::TaskPriority;
+
+        let content = "\
+# Some header
+
+Some text here.
+- [ ] A lowest priority task ⏬
+- [ ] A low priority task 🔽
+- [ ] A task with double priority ⏬ 🔺
+- [ ] A normal priority task
+- [ ] A medium priority task 🔼
+- [ ] A high priority task ⏫
+- [ ] A highest priority task 🔺
+";
+        let engine = ParseEngine::new(content);
+        let result = engine.parse(&ParseOptions::all());
+
+        assert_eq!(result.tasks.len(), 7,);
+
+        assert_eq!(
+            result.tasks[0].priority,
+            TaskPriority::Lowest,
+            "Should parse ⏬ as lowest priority marker"
+        );
+        assert_eq!(result.tasks[0].content, "A lowest priority task");
+
+        assert_eq!(
+            result.tasks[1].priority,
+            TaskPriority::Low,
+            "Should parse 🔽 as low priority marker"
+        );
+        assert_eq!(result.tasks[1].content, "A low priority task");
+
+        assert_eq!(
+            result.tasks[2].priority,
+            TaskPriority::Normal,
+            "Should parse double marker as normal priority"
+        );
+        assert_eq!(result.tasks[2].content, "A task with double priority ⏬ 🔺");
+
+        assert_eq!(
+            result.tasks[3].priority,
+            TaskPriority::Normal,
+            "Should parse no marker as normal priority"
+        );
+
+        assert_eq!(
+            result.tasks[4].priority,
+            TaskPriority::Medium,
+            "Should parse 🔼 marker as medium priority"
+        );
+
+        assert_eq!(
+            result.tasks[5].priority,
+            TaskPriority::High,
+            "Should parse ⏫ marker as high priority"
+        );
+
+        assert_eq!(
+            result.tasks[6].priority,
+            TaskPriority::Highest,
+            "Should parse 🔺 marker as highest priority"
+        );
+    }
+
+    #[test]
+    fn test_task_metadata_parsing() {
+        let content = "- [ ] Review PR [due:: 2026-05-01], [project:: [[Team Work]]], [id:: pr-123], [dependsOn:: abc123,def456] 🔁 every weekday #review ^pr-123";
+        let engine = ParseEngine::new(content);
+        let result = engine.parse(&ParseOptions::all());
+
+        assert_eq!(result.tasks.len(), 1);
+        assert_eq!(result.tasks[0].content, "Review PR");
+        assert_eq!(
+            result.tasks[0]
+                .due_date
+                .map(|date| date.to_string())
+                .as_deref(),
+            Some("2026-05-01")
+        );
+        assert_eq!(result.tasks[0].recurrence.as_deref(), Some("every weekday"));
+        assert_eq!(result.tasks[0].id.as_deref(), Some("pr-123"));
+        assert_eq!(
+            result.tasks[0].depends_on,
+            vec!["abc123".to_string(), "def456".to_string()]
+        );
+        assert_eq!(result.tasks[0].tags, vec!["review".to_string()]);
+        assert_eq!(result.tasks[0].block_ref.as_deref(), Some("pr-123"));
+        assert_eq!(
+            result.tasks[0].metadata.get("project").map(String::as_str),
+            Some("[[Team Work]]")
         );
     }
 }

--- a/crates/turbovault-parser/src/parsers/tasks.rs
+++ b/crates/turbovault-parser/src/parsers/tasks.rs
@@ -5,7 +5,7 @@
 
 use regex::Regex;
 use std::sync::LazyLock;
-use turbovault_core::{LineIndex, SourcePosition, TaskItem};
+use turbovault_core::{LineIndex, SourcePosition, TaskItem, task_parser};
 
 /// Matches - [ ] or - [x] followed by task text
 static TASK_PATTERN: LazyLock<Regex> =
@@ -40,17 +40,18 @@ pub fn parse_tasks(content: &str) -> Vec<TaskItem> {
                 let task_content = caps.get(3).unwrap().as_str();
                 let full_match = caps.get(0).unwrap();
 
-                TaskItem {
-                    content: task_content.to_string(),
+                let parsed = task_parser::parse_task_content(task_content);
+
+                TaskItem::from_parsed_metadata(
+                    parsed,
                     is_completed,
-                    position: SourcePosition::new(
+                    SourcePosition::new(
                         idx + 1,
                         indent.len() + 1, // column accounts for indentation
                         line_start + indent.len(),
                         full_match.len() - indent.len(),
                     ),
-                    due_date: None,
-                }
+                )
             })
         })
         .collect()
@@ -155,5 +156,25 @@ mod tests {
             assert_eq!(r.position.line, i.position.line);
             assert_eq!(r.position.offset, i.position.offset);
         }
+    }
+
+    #[test]
+    fn test_task_metadata() {
+        let content = "- [ ] Review PR [due:: 2026-05-01], [project:: [[Team Work]]], [onCompletion:: delete] 🔁 every weekday #review";
+        let tasks = parse_tasks(content);
+
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].content, "Review PR");
+        assert_eq!(
+            tasks[0].due_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-05-01")
+        );
+        assert_eq!(tasks[0].recurrence.as_deref(), Some("every weekday"));
+        assert_eq!(tasks[0].on_completion.as_deref(), Some("delete"));
+        assert_eq!(tasks[0].tags, vec!["review".to_string()]);
+        assert_eq!(
+            tasks[0].metadata.get("project").map(String::as_str),
+            Some("[[Team Work]]")
+        );
     }
 }

--- a/crates/turbovault/tests/integration_test.rs
+++ b/crates/turbovault/tests/integration_test.rs
@@ -206,33 +206,69 @@ mod tests {
         assert!(!t.is_completed);
         assert_eq!(t.priority, TaskPriority::Highest);
         assert_eq!(t.recurrence.as_deref(), Some("every day"));
-        assert_eq!(t.start_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
-        assert_eq!(t.scheduled_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
-        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(
+            t.start_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+        assert_eq!(
+            t.scheduled_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+        assert_eq!(
+            t.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
 
         let t = find("Feed the cat");
         assert!(!t.is_completed);
         assert_eq!(t.priority, TaskPriority::High);
         assert_eq!(t.recurrence.as_deref(), Some("every day"));
-        assert_eq!(t.start_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
-        assert_eq!(t.scheduled_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
-        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(
+            t.start_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+        assert_eq!(
+            t.scheduled_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+        assert_eq!(
+            t.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
 
         let t = find("Clean the kitchen");
         assert_eq!(t.priority, TaskPriority::Normal);
         assert_eq!(t.recurrence.as_deref(), Some("every week"));
-        assert_eq!(t.start_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
-        assert_eq!(t.scheduled_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
-        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(
+            t.start_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+        assert_eq!(
+            t.scheduled_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+        assert_eq!(
+            t.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
         assert_eq!(t.tags, vec!["task_type_1"]);
 
         // task_type_2 task also tests the double-space after 🛫 (🛫  2026-04-30)
         let t = find("Clean the baseboards");
         assert_eq!(t.priority, TaskPriority::Low);
         assert_eq!(t.recurrence.as_deref(), Some("every week"));
-        assert_eq!(t.start_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
-        assert_eq!(t.scheduled_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
-        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(
+            t.start_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+        assert_eq!(
+            t.scheduled_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+        assert_eq!(
+            t.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
         assert_eq!(t.tags, vec!["task_type_2"]);
 
         // --- Dataview format ---
@@ -240,30 +276,51 @@ mod tests {
         let t = find("Buy groceries");
         assert!(!t.is_completed);
         assert_eq!(t.priority, TaskPriority::Medium);
-        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-05-01"));
+        assert_eq!(
+            t.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-01")
+        );
         assert_eq!(t.tags, vec!["errands"]);
 
         // --- Mixed emoji + Dataview ---
 
         let t = find("Write weekly report");
         assert!(!t.is_completed);
-        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-05-10"));
-        assert_eq!(t.scheduled_date.map(|d| d.to_string()).as_deref(), Some("2026-05-08"));
+        assert_eq!(
+            t.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-10")
+        );
+        assert_eq!(
+            t.scheduled_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-08")
+        );
         assert_eq!(t.recurrence.as_deref(), Some("every week"));
 
         // --- Completed task with done date ---
 
         let t = find("Submit expense report");
         assert!(t.is_completed);
-        assert_eq!(t.done_date.map(|d| d.to_string()).as_deref(), Some("2026-04-29"));
-        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-04-28"));
+        assert_eq!(
+            t.done_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-29")
+        );
+        assert_eq!(
+            t.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-28")
+        );
 
         // --- Comma-separated Dataview fields with ID ---
 
         let t = find("Plan sprint");
         assert_eq!(t.priority, TaskPriority::High);
-        assert_eq!(t.start_date.map(|d| d.to_string()).as_deref(), Some("2026-05-01"));
-        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-05-07"));
+        assert_eq!(
+            t.start_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-01")
+        );
+        assert_eq!(
+            t.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-07")
+        );
         assert_eq!(t.id.as_deref(), Some("sprint-42"));
     }
 }

--- a/crates/turbovault/tests/integration_test.rs
+++ b/crates/turbovault/tests/integration_test.rs
@@ -6,7 +6,7 @@ mod tests {
     use tempfile::TempDir;
     use tokio::fs;
     use turbovault::ObsidianMcpServer;
-    use turbovault_core::{ConfigProfile, VaultConfig};
+    use turbovault_core::{ConfigProfile, TaskPriority, VaultConfig};
     use turbovault_vault::VaultManager;
 
     /// Helper to create a test vault
@@ -140,5 +140,130 @@ mod tests {
 
         assert!(report.contains("\"vault_name\""));
         assert!(report.contains("\"recommendations\""));
+    }
+
+    // ==================== Task Metadata Parsing Tests ====================
+
+    /// Tasks.md content covering every metadata format the parser supports:
+    /// emoji-only, dataview-only, mixed emoji+dataview, completed tasks,
+    /// comma-separated dataview fields, and inline tags.
+    const TASKS_MD: &str = "# Test Header
+- [ ] Take out the trash 🔁 every day 🛫 2026-04-30 ⏳ 2026-04-30 📅 2026-04-30 🔺
+- [ ] Feed the cat ⏫ 🔁 every day 🛫 2026-04-30 ⏳ 2026-04-30 📅 2026-04-30
+- [ ] Clean the kitchen 🔁 every week 🛫 2026-04-30 ⏳ 2026-04-30 📅 2026-04-30 #task_type_1
+- [ ] Clean the baseboards 🔁 every week 🔽 🛫  2026-04-30 ⏳ 2026-04-30 📅 2026-04-30 #task_type_2
+- [ ] Buy groceries [due:: 2026-05-01] [priority:: medium] #errands
+- [ ] Write weekly report 📅 2026-05-10 [scheduled:: 2026-05-08] 🔁 every week
+- [x] Submit expense report ✅ 2026-04-29 📅 2026-04-28
+- [ ] Plan sprint [priority:: high], [start:: 2026-05-01], [due:: 2026-05-07] [id:: sprint-42]
+";
+
+    async fn create_task_vault() -> (TempDir, VaultManager) {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let vault_path = temp_dir.path();
+
+        fs::create_dir_all(vault_path.join("TestFolder"))
+            .await
+            .expect("create TestFolder");
+        fs::write(vault_path.join("TestFolder/Tasks.md"), TASKS_MD)
+            .await
+            .expect("write Tasks.md");
+
+        let mut config = ConfigProfile::Development.create_config();
+        let vault_config = VaultConfig::builder("test", vault_path)
+            .build()
+            .expect("vault config");
+        config.vaults.push(vault_config);
+
+        let manager = VaultManager::new(config).expect("vault manager");
+        manager.initialize().await.expect("initialize");
+
+        (temp_dir, manager)
+    }
+
+    #[tokio::test]
+    async fn test_task_metadata_parsing() {
+        let (_temp, manager) = create_task_vault().await;
+
+        let vault_file = manager
+            .parse_file(&PathBuf::from("TestFolder/Tasks.md"))
+            .await
+            .expect("parse Tasks.md");
+
+        assert_eq!(vault_file.tasks.len(), 8, "expected 8 tasks in Tasks.md");
+
+        let find = |desc: &str| {
+            vault_file
+                .tasks
+                .iter()
+                .find(|t| t.content == desc)
+                .unwrap_or_else(|| panic!("task not found: {desc:?}"))
+        };
+
+        // --- Emoji format ---
+
+        let t = find("Take out the trash");
+        assert!(!t.is_completed);
+        assert_eq!(t.priority, TaskPriority::Highest);
+        assert_eq!(t.recurrence.as_deref(), Some("every day"));
+        assert_eq!(t.start_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(t.scheduled_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+
+        let t = find("Feed the cat");
+        assert!(!t.is_completed);
+        assert_eq!(t.priority, TaskPriority::High);
+        assert_eq!(t.recurrence.as_deref(), Some("every day"));
+        assert_eq!(t.start_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(t.scheduled_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+
+        let t = find("Clean the kitchen");
+        assert_eq!(t.priority, TaskPriority::Normal);
+        assert_eq!(t.recurrence.as_deref(), Some("every week"));
+        assert_eq!(t.start_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(t.scheduled_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(t.tags, vec!["task_type_1"]);
+
+        // task_type_2 task also tests the double-space after 🛫 (🛫  2026-04-30)
+        let t = find("Clean the baseboards");
+        assert_eq!(t.priority, TaskPriority::Low);
+        assert_eq!(t.recurrence.as_deref(), Some("every week"));
+        assert_eq!(t.start_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(t.scheduled_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-04-30"));
+        assert_eq!(t.tags, vec!["task_type_2"]);
+
+        // --- Dataview format ---
+
+        let t = find("Buy groceries");
+        assert!(!t.is_completed);
+        assert_eq!(t.priority, TaskPriority::Medium);
+        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-05-01"));
+        assert_eq!(t.tags, vec!["errands"]);
+
+        // --- Mixed emoji + Dataview ---
+
+        let t = find("Write weekly report");
+        assert!(!t.is_completed);
+        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-05-10"));
+        assert_eq!(t.scheduled_date.map(|d| d.to_string()).as_deref(), Some("2026-05-08"));
+        assert_eq!(t.recurrence.as_deref(), Some("every week"));
+
+        // --- Completed task with done date ---
+
+        let t = find("Submit expense report");
+        assert!(t.is_completed);
+        assert_eq!(t.done_date.map(|d| d.to_string()).as_deref(), Some("2026-04-29"));
+        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-04-28"));
+
+        // --- Comma-separated Dataview fields with ID ---
+
+        let t = find("Plan sprint");
+        assert_eq!(t.priority, TaskPriority::High);
+        assert_eq!(t.start_date.map(|d| d.to_string()).as_deref(), Some("2026-05-01"));
+        assert_eq!(t.due_date.map(|d| d.to_string()).as_deref(), Some("2026-05-07"));
+        assert_eq!(t.id.as_deref(), Some("sprint-42"));
     }
 }


### PR DESCRIPTION
## Summary

Adds structured parsing for Obsidian Tasks metadata on parsed task items.

This introduces a shared Winnow-based task parser in `turbovault-core` that can read both emoji format and dataview format task metadata.

Unlike the current Obsidian Tasks plugin setting, Turbovault intentionally reads both formats without requiring vault-level configuration.

## What Changed

- Added `TaskItem` fields for structured metadata:
  - created, scheduled, start, due, done, and cancelled dates
  - priority
  - recurrence
  - on-completion behavior
  - task id and dependencies
  - tags, block refs, and custom Dataview metadata
- Added a shared `task_parser` module using `winnow`.
- Integrated metadata parsing into the pulldown-cmark parser path.
- Updated the legacy task line parser to reuse the same metadata parser.
- Added TaskBuilder struct to extract logic from `pulldown_pass()`
- Added compatibility coverage for:
  - Tasks emoji metadata
  - Dataview bracketed and parenthesized fields
  - comma-separated Dataview fields
  - priorities
  - recurrence
  - on-completion metadata
  - task ids and dependencies
  - trailing metadata ordering behavior
  - serde compatibility for older `TaskItem` JSON

## Notes

This does not add new MCP task tools yet. The parsed metadata is now available on `TaskItem`, which should make future task listing/filtering/editing tools easier to build without requiring models or callers to parse raw Markdown themselves.

## Next

- Add / extend task MCP tooling so that the models can easily view, filter, and edit tasks.
    - Including `#hashtag` based filtering like Obsidian Tasks has. I'm thinking it should support more than one hashtag (unlike the plugin). 

## Verification

- `cargo fmt`
- `git diff --check`
- `cargo test -p turbovault-core --lib`
- `cargo test -p turbovault-parser --lib`
- `cargo test`

Please let me know what you think! Happy to adjust future work to feedback. And thank you for Turbovault! It's so useful that I'm extending the task compatibility for selfish reasons.