### PR TITLE
Hashtag parsing now aligned with Obsidian Tasks plugin behavior.

### DIFF
--- a/crates/turbovault-core/src/task_parser.rs
+++ b/crates/turbovault-core/src/task_parser.rs
@@ -19,6 +19,7 @@
 
 use std::collections::HashMap;
 
+use chrono::NaiveDate;
 use winnow::{
     ModalResult, Parser,
     ascii::space0,
@@ -130,7 +131,8 @@ pub fn parse_task_line(input: &str) -> Result<Task, String> {
 pub fn parse_task_content(content: &str) -> ParsedTaskMetadata {
     let meta_start = find_metadata_start(content);
     let mut parsed = parse_metadata_section(content[meta_start..].trim_start());
-    parsed.description = content[..meta_start].trim_end().to_string();
+    parsed.tags = extract_tags(content);
+    parsed.description = build_description(content, meta_start);
     parsed
 }
 
@@ -221,6 +223,71 @@ fn parse_metadata_section(meta_str: &str) -> ParsedTaskMetadata {
     result
 }
 
+fn build_description(content: &str, meta_start: usize) -> String {
+    let mut description = content[..meta_start].trim_end().to_string();
+
+    for tag in extract_tag_literals(&content[meta_start..]) {
+        if !description.is_empty() {
+            description.push(' ');
+        }
+        description.push_str(tag);
+    }
+
+    description
+}
+
+fn extract_tags(content: &str) -> Vec<String> {
+    extract_tag_literals(content)
+        .into_iter()
+        .map(|tag| tag.trim_start_matches('#').to_string())
+        .collect()
+}
+
+fn extract_tag_literals(content: &str) -> Vec<&str> {
+    let mut tags = Vec::new();
+
+    for (i, c) in content.char_indices() {
+        if c == '#'
+            && is_tag_boundary(content, i)
+            && let Some((_, end)) = parse_tag_literal(&content[i..])
+        {
+            tags.push(&content[i..i + end]);
+        }
+    }
+
+    tags
+}
+
+fn is_tag_boundary(content: &str, index: usize) -> bool {
+    content[..index]
+        .chars()
+        .next_back()
+        .is_none_or(|c| c.is_whitespace())
+}
+
+fn parse_tag_literal(s: &str) -> Option<(&str, usize)> {
+    let rest = s.strip_prefix('#')?;
+    let mut end = 1usize;
+    let mut has_alpha = false;
+    let mut has_name = false;
+
+    for c in rest.chars() {
+        if c.is_alphanumeric() || c == '-' || c == '_' || c == '/' {
+            has_name = true;
+            has_alpha |= c.is_alphabetic();
+            end += c.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    if has_name && has_alpha {
+        Some((&s[1..end], end))
+    } else {
+        None
+    }
+}
+
 fn consume_metadata_separator(input: &mut &str) -> ModalResult<()> {
     let _ = space0.parse_next(input)?;
 
@@ -259,9 +326,14 @@ fn parse_emoji_date_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
     .parse_next(input)?;
     let _ = space0.parse_next(input)?;
     let value: &str = take_while(1.., |c: char| !c.is_whitespace()).parse_next(input)?;
+    let value = value.trim();
+
+    if !is_valid_task_date(value) {
+        return Err(ErrMode::Backtrack(ContextError::new()));
+    }
 
     let mut meta = ParsedTaskMetadata::default();
-    set_standard_field(&mut meta, key, value.trim());
+    set_standard_field(&mut meta, key, value);
     Ok(meta)
 }
 
@@ -483,12 +555,14 @@ fn is_priority_emoji(s: &str) -> bool {
 
 fn set_standard_field(meta: &mut ParsedTaskMetadata, key: &str, value: &str) {
     match key {
-        "due" => meta.due = Some(value.to_string()),
-        "scheduled" => meta.scheduled = Some(value.to_string()),
-        "start" => meta.start = Some(value.to_string()),
-        "done" | "completion" => meta.done = Some(value.to_string()),
-        "cancelled" | "canceled" => meta.cancelled = Some(value.to_string()),
-        "created" => meta.created = Some(value.to_string()),
+        "due" if is_valid_task_date(value) => meta.due = Some(value.to_string()),
+        "scheduled" if is_valid_task_date(value) => meta.scheduled = Some(value.to_string()),
+        "start" if is_valid_task_date(value) => meta.start = Some(value.to_string()),
+        "done" | "completion" if is_valid_task_date(value) => meta.done = Some(value.to_string()),
+        "cancelled" | "canceled" if is_valid_task_date(value) => {
+            meta.cancelled = Some(value.to_string());
+        }
+        "created" if is_valid_task_date(value) => meta.created = Some(value.to_string()),
         "recurrence" | "repeat" => meta.recurrence = Some(value.to_string()),
         "oncompletion" => meta.on_completion = Some(value.to_ascii_lowercase()),
         "id" => meta.id = Some(value.to_string()),
@@ -496,6 +570,10 @@ fn set_standard_field(meta: &mut ParsedTaskMetadata, key: &str, value: &str) {
         "priority" => meta.priority = priority_from_dataview_value(value),
         _ => {}
     }
+}
+
+fn is_valid_task_date(value: &str) -> bool {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").is_ok()
 }
 
 fn split_dependency_ids(value: &str) -> Vec<String> {
@@ -569,6 +647,26 @@ mod tests {
         let task = parse_task_line("- [ ] Buy milk 📅 2025-05-15").unwrap();
         assert_eq!(task.description, "Buy milk");
         assert_eq!(task.due.as_deref(), Some("2025-05-15"));
+    }
+
+    #[test]
+    fn non_iso_date_metadata_is_parsed_but_not_converted_to_task_date() {
+        // This test ensures that the parser behaves like the Obsidian Tasks plugin does
+        let parsed = parse_task_content("Buy milk 📅 05-01-2026 ⏳ 2026-05-02");
+        assert_eq!(parsed.description, "Buy milk 📅 05-01-2026");
+        assert_eq!(parsed.due.as_deref(), None);
+        assert_eq!(parsed.scheduled.as_deref(), Some("2026-05-02"));
+
+        let task = crate::models::TaskItem::from_parsed_metadata(
+            parsed,
+            false,
+            crate::models::SourcePosition::start(),
+        );
+        assert!(task.due_date.is_none());
+        assert_eq!(
+            task.scheduled_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-05-02")
+        );
     }
 
     #[test]
@@ -655,7 +753,7 @@ mod tests {
     fn parses_tags_and_block_ref_after_metadata() {
         let task = parse_task_line("- [ ] Task description 📅 2025-05-10 #urgent #work ^task-123")
             .unwrap();
-        assert_eq!(task.description, "Task description");
+        assert_eq!(task.description, "Task description #urgent #work");
         assert_eq!(task.due.as_deref(), Some("2025-05-10"));
         assert_eq!(task.tags, vec!["urgent".to_string(), "work".to_string()]);
         assert_eq!(task.block_ref.as_deref(), Some("task-123"));
@@ -663,11 +761,40 @@ mod tests {
 
     #[test]
     fn parses_tag_at_start_of_task_content() {
-        let task = parse_task_line("- [ ] #task This is the task content 📅 2026-05-01 🔺").unwrap();
+        let task =
+            parse_task_line("- [ ] #task This is the task content 📅 2026-05-01 🔺").unwrap();
 
-        assert_eq!(task.description, "This is the task content");
+        assert_eq!(task.description, "#task This is the task content");
         assert_eq!(task.due.as_deref(), Some("2026-05-01"));
         assert_eq!(task.priority, Some('🔺'));
+        assert_eq!(task.tags, vec!["task".to_string()]);
+    }
+
+    #[test]
+    fn parses_two_tags_at_start_of_task_content() {
+        let task = parse_task_line("- [ ] #task #urgent This is the task content 📅 2026-05-01 🔺")
+            .unwrap();
+
+        assert_eq!(task.description, "#task #urgent This is the task content");
+        assert_eq!(task.due.as_deref(), Some("2026-05-01"));
+        assert_eq!(task.priority, Some('🔺'));
+        assert_eq!(task.tags, vec!["task".to_string(), "urgent".to_string()]);
+    }
+
+    #[test]
+    fn indexes_tags_without_metadata_and_keeps_them_in_description() {
+        let task = parse_task_line("- [ ] Read #book chapter #research").unwrap();
+
+        assert_eq!(task.description, "Read #book chapter #research");
+        assert_eq!(task.tags, vec!["book".to_string(), "research".to_string()]);
+    }
+
+    #[test]
+    fn stops_tag_at_dot_and_keeps_full_text_in_description() {
+        // The Obsidian Tasks plugin treats #task.foo as #task tag with .foo as part of the description. This test demonstrates mirroring that behavior.
+        let task = parse_task_line("- [ ] Update #task.foo before standup").unwrap();
+
+        assert_eq!(task.description, "Update #task.foo before standup");
         assert_eq!(task.tags, vec!["task".to_string()]);
     }
 
@@ -708,11 +835,12 @@ mod tests {
 
     #[test]
     fn parses_dataview_value_with_wikilink() {
+        // #123 is not a valid tag, but should be preserved in the description.
         let task = parse_task_line(
             "- [ ] Review PR #123 [project:: [[Team Work]]] 📅 2025-05-20 🔼 #review ^pr-123",
         )
         .unwrap();
-        assert_eq!(task.description, "Review PR #123");
+        assert_eq!(task.description, "Review PR #123 #review");
         assert_eq!(task.due.as_deref(), Some("2025-05-20"));
         assert_eq!(task.priority, Some('🔼'));
         assert_eq!(task.tags, vec!["review".to_string()]);

--- a/crates/turbovault-core/src/task_parser.rs
+++ b/crates/turbovault-core/src/task_parser.rs
@@ -662,6 +662,16 @@ mod tests {
     }
 
     #[test]
+    fn parses_tag_at_start_of_task_content() {
+        let task = parse_task_line("- [ ] #task This is the task content 📅 2026-05-01 🔺").unwrap();
+
+        assert_eq!(task.description, "This is the task content");
+        assert_eq!(task.due.as_deref(), Some("2026-05-01"));
+        assert_eq!(task.priority, Some('🔺'));
+        assert_eq!(task.tags, vec!["task".to_string()]);
+    }
+
+    #[test]
     fn ignores_false_positive_in_description() {
         let task =
             parse_task_line("- [ ] Review the [due date] section and 📅 2025-04-30").unwrap();

--- a/crates/turbovault-parser/src/engine.rs
+++ b/crates/turbovault-parser/src/engine.rs
@@ -1565,7 +1565,7 @@ Some text here.
         let result = engine.parse(&ParseOptions::all());
 
         assert_eq!(result.tasks.len(), 1);
-        assert_eq!(result.tasks[0].content, "Review PR");
+        assert_eq!(result.tasks[0].content, "Review PR #review");
         assert_eq!(
             result.tasks[0]
                 .due_date

--- a/crates/turbovault-parser/src/parsers/tasks.rs
+++ b/crates/turbovault-parser/src/parsers/tasks.rs
@@ -164,7 +164,7 @@ mod tests {
         let tasks = parse_tasks(content);
 
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].content, "Review PR");
+        assert_eq!(tasks[0].content, "Review PR #review");
         assert_eq!(
             tasks[0].due_date.map(|date| date.to_string()).as_deref(),
             Some("2026-05-01")

--- a/crates/turbovault/tests/integration_test.rs
+++ b/crates/turbovault/tests/integration_test.rs
@@ -236,7 +236,7 @@ mod tests {
             Some("2026-04-30")
         );
 
-        let t = find("Clean the kitchen");
+        let t = find("Clean the kitchen #task_type_1");
         assert_eq!(t.priority, TaskPriority::Normal);
         assert_eq!(t.recurrence.as_deref(), Some("every week"));
         assert_eq!(
@@ -254,7 +254,7 @@ mod tests {
         assert_eq!(t.tags, vec!["task_type_1"]);
 
         // task_type_2 task also tests the double-space after 🛫 (🛫  2026-04-30)
-        let t = find("Clean the baseboards");
+        let t = find("Clean the baseboards #task_type_2");
         assert_eq!(t.priority, TaskPriority::Low);
         assert_eq!(t.recurrence.as_deref(), Some("every week"));
         assert_eq!(
@@ -273,7 +273,7 @@ mod tests {
 
         // --- Dataview format ---
 
-        let t = find("Buy groceries");
+        let t = find("Buy groceries #errands");
         assert!(!t.is_completed);
         assert_eq!(t.priority, TaskPriority::Medium);
         assert_eq!(


### PR DESCRIPTION
Changed Obsidian task hashtag parsing to align with the behavior of the Obsidian Tasks plugin.

## Before

The parser assumed that `#hashtags` would be in the metadata section after the task description. It also consumed them. That's not actually how the Obsidian Tasks plugin parser works. Hashtags can appear anywhere in the Obsidian Tasks line, and they are parsed but not consumed. The Tasks plugin leaves them in the description field.

## After

The parser now accepts hashtags anywhere after the `- [ ]` portion of the line. It gathers the tags and saves them to the TaskItem `tags` vector and leaves them in the description field. The tags positioning in the metadata is not maintained, but the ordering is. If the tag does not appear in the metadata section it is left in the description untouched. If the tag appears in the metadata section, it is appended to the description in the order it was found. This behavior is aligns with how the Tasks plugin renders the description in Obsidian.

## Gaps

Since the tag position in the metadata section for tags that appear after the description is not recorded, implementing a to_string() method for the TaskItem struct would shift the tags to the lefthand side of the metadata. Probably not an issue since parsing and presenting the task info is the current projected use-case, but if one wanted to edit a file by placing a TaskItem instance as a line, the tags would always be in the description section. However, that seems best from a human-readability standpoint in my opinion.

## Checks

`cargo build`
`cargo test`
`cargo fmt`
`cargo clippy`

All pass.