### PR TITLE
Feature/task mcp tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5161,6 +5161,7 @@ name = "turbovault"
 version = "1.5.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "config",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5086,6 +5086,7 @@ name = "turbovault"
 version = "1.5.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "config",
  "criterion",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -317,5 +317,45 @@ performance:
 #   security_auditing: true
 
 # ==============================================================================
+# TOOL VISIBILITY
+# ==============================================================================
+# Control which MCP tools are exposed to clients.
+# All name lists accept exact tool names (case-sensitive).
+# Available tags: read, write, delete, admin, graph, search,
+#                 frontmatter, template, batch, export, audit,
+#                 health, semantic, sql
+
+# tool_visibility:
+#   # Whitelist — if set, only these tools are listed and callable.
+#   allowed:
+#     - read_note
+#     - search
+#     - write_note
+#
+#   # Hide from tools/list, still callable by exact name.
+#   hidden:
+#     - full_health_analysis
+#     - vault_quality_report
+#
+#   # Remove from tools/list and reject direct calls.
+#   disabled:
+#     - delete_note
+#     - rollback_note
+#
+#   # Disable ALL tools carrying any of these tags.
+#   disabled_tags:
+#     - delete
+#     - admin
+#
+#   # Hide all tools with these tags from tools/list (still callable by name).
+#   # NOTE: requires turbomcp hide_tags() support (pending); set for forward-compatibility.
+#   hidden_tags:
+#     - semantic
+#     - export
+#
+#   # Hide all tools not annotated read_only = true.
+#   require_read_only: false
+
+# ==============================================================================
 # END OF CONFIGURATION
 # ==============================================================================

--- a/crates/turbovault-core/src/models.rs
+++ b/crates/turbovault-core/src/models.rs
@@ -254,6 +254,10 @@ pub struct TaskItem {
     /// fields remain available here.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub metadata: HashMap<String, String>,
+    /// Whether this task's metadata was written in emoji or dataview notation.
+    /// Detected at parse time; used to round-trip writes in the original format.
+    #[serde(default)]
+    pub metadata_format: TaskMetadataFormat,
 }
 
 impl TaskItem {
@@ -264,6 +268,7 @@ impl TaskItem {
         is_completed: bool,
         position: SourcePosition,
     ) -> Self {
+        let metadata_format = TaskMetadataFormat::detect(&parsed.metadata);
         Self {
             content: parsed.description,
             is_completed,
@@ -285,6 +290,96 @@ impl TaskItem {
             tags: parsed.tags,
             block_ref: parsed.block_ref,
             metadata: parsed.metadata,
+            metadata_format,
+        }
+    }
+
+    /// Serialize this task back to an Obsidian Tasks markdown line.
+    ///
+    /// Dispatches to emoji or dataview format based on the format detected at parse time.
+    /// Tags are emitted as part of `content` (where the parser left them).
+    /// Canonical field order: content priority 🔁 🛫 ⏳ 📅 ✅ ❌
+    pub fn to_markdown_line(&self) -> String {
+        match self.metadata_format {
+            TaskMetadataFormat::Emoji => self.to_markdown_line_emoji(),
+            TaskMetadataFormat::Dataview => self.to_markdown_line_dataview(),
+        }
+    }
+
+    fn to_markdown_line_emoji(&self) -> String {
+        let checkbox = if self.is_completed { "[x]" } else { "[ ]" };
+        let content = self.content.trim();
+        let mut meta: Vec<String> = Vec::new();
+
+        let priority_emoji = self.priority.emoji();
+        if !priority_emoji.is_empty() {
+            meta.push(priority_emoji.to_string());
+        }
+        if let Some(ref rec) = self.recurrence {
+            meta.push(format!("🔁 {}", rec));
+        }
+        if let Some(d) = self.start_date {
+            meta.push(format!("🛫 {}", d));
+        }
+        if let Some(d) = self.scheduled_date {
+            meta.push(format!("⏳ {}", d));
+        }
+        if let Some(d) = self.due_date {
+            meta.push(format!("📅 {}", d));
+        }
+        if let Some(d) = self.done_date {
+            meta.push(format!("✅ {}", d));
+        }
+        if let Some(d) = self.cancelled_date {
+            meta.push(format!("❌ {}", d));
+        }
+
+        if meta.is_empty() {
+            format!("- {} {}", checkbox, content)
+        } else {
+            format!("- {} {} {}", checkbox, content, meta.join(" "))
+        }
+    }
+
+    fn to_markdown_line_dataview(&self) -> String {
+        let checkbox = if self.is_completed { "[x]" } else { "[ ]" };
+        let content = self.content.trim();
+        let mut meta: Vec<String> = Vec::new();
+
+        if self.priority != TaskPriority::Normal {
+            let prio_text = match self.priority {
+                TaskPriority::Lowest => "lowest",
+                TaskPriority::Low => "low",
+                TaskPriority::Medium => "medium",
+                TaskPriority::High => "high",
+                TaskPriority::Highest => "highest",
+                TaskPriority::Normal => unreachable!(),
+            };
+            meta.push(format!("[priority:: {}]", prio_text));
+        }
+        if let Some(ref rec) = self.recurrence {
+            meta.push(format!("[recurrence:: {}]", rec));
+        }
+        if let Some(d) = self.start_date {
+            meta.push(format!("[start:: {}]", d));
+        }
+        if let Some(d) = self.scheduled_date {
+            meta.push(format!("[scheduled:: {}]", d));
+        }
+        if let Some(d) = self.due_date {
+            meta.push(format!("[due:: {}]", d));
+        }
+        if let Some(d) = self.done_date {
+            meta.push(format!("[done:: {}]", d));
+        }
+        if let Some(d) = self.cancelled_date {
+            meta.push(format!("[cancelled:: {}]", d));
+        }
+
+        if meta.is_empty() {
+            format!("- {} {}", checkbox, content)
+        } else {
+            format!("- {} {} {}", checkbox, content, meta.join(" "))
         }
     }
 }
@@ -345,6 +440,42 @@ impl fmt::Display for TaskPriority {
             TaskPriority::Highest => "🔺",
         };
         write!(f, "{}", s)
+    }
+}
+
+/// Whether a task's metadata uses emoji notation (📅 ⏫) or Dataview notation ([due:: …]).
+///
+/// Detected at parse time by checking whether any standard field keys appear in the
+/// raw `metadata` HashMap (dataview fields are stored there; emoji fields are not).
+/// Used by `TaskItem::to_markdown_line()` to round-trip writes without converting format.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskMetadataFormat {
+    #[default]
+    Emoji,
+    Dataview,
+}
+
+impl TaskMetadataFormat {
+    fn detect(metadata: &HashMap<String, String>) -> Self {
+        const DATAVIEW_KEYS: &[&str] = &[
+            "due",
+            "scheduled",
+            "start",
+            "done",
+            "completion",
+            "cancelled",
+            "canceled",
+            "created",
+            "recurrence",
+            "repeat",
+            "priority",
+        ];
+        if DATAVIEW_KEYS.iter().any(|k| metadata.contains_key(*k)) {
+            Self::Dataview
+        } else {
+            Self::Emoji
+        }
     }
 }
 
@@ -1080,6 +1211,142 @@ mod tests {
         assert_eq!(
             serde_json::to_value(TaskPriority::High).unwrap(),
             serde_json::Value::String("HIGH".to_string())
+        );
+    }
+
+    // ==================== TaskItem::to_markdown_line() ====================
+
+    fn make_task(content: &str, is_completed: bool) -> TaskItem {
+        TaskItem {
+            content: content.to_string(),
+            is_completed,
+            position: SourcePosition::default(),
+            created_date: None,
+            scheduled_date: None,
+            start_date: None,
+            due_date: None,
+            done_date: None,
+            cancelled_date: None,
+            priority: TaskPriority::Normal,
+            recurrence: None,
+            on_completion: None,
+            id: None,
+            depends_on: Vec::new(),
+            tags: Vec::new(),
+            block_ref: None,
+            metadata: HashMap::new(),
+            metadata_format: TaskMetadataFormat::Emoji,
+        }
+    }
+
+    #[test]
+    fn test_to_markdown_line_simple_pending() {
+        let task = make_task("Take out the trash", false);
+        assert_eq!(task.to_markdown_line(), "- [ ] Take out the trash");
+    }
+
+    #[test]
+    fn test_to_markdown_line_simple_completed() {
+        let task = make_task("Submit expense report", true);
+        assert_eq!(task.to_markdown_line(), "- [x] Submit expense report");
+    }
+
+    #[test]
+    fn test_to_markdown_line_emoji_full() {
+        use chrono::NaiveDate;
+        let mut task = make_task("Take out the trash", false);
+        task.priority = TaskPriority::Highest;
+        task.recurrence = Some("every day".to_string());
+        task.start_date = NaiveDate::from_ymd_opt(2026, 4, 30);
+        task.scheduled_date = NaiveDate::from_ymd_opt(2026, 4, 30);
+        task.due_date = NaiveDate::from_ymd_opt(2026, 4, 30);
+        assert_eq!(
+            task.to_markdown_line(),
+            "- [ ] Take out the trash 🔺 🔁 every day 🛫 2026-04-30 ⏳ 2026-04-30 📅 2026-04-30"
+        );
+    }
+
+    #[test]
+    fn test_to_markdown_line_emoji_completed_with_dates() {
+        use chrono::NaiveDate;
+        let mut task = make_task("Submit expense report", true);
+        task.due_date = NaiveDate::from_ymd_opt(2026, 4, 28);
+        task.done_date = NaiveDate::from_ymd_opt(2026, 4, 29);
+        assert_eq!(
+            task.to_markdown_line(),
+            "- [x] Submit expense report 📅 2026-04-28 ✅ 2026-04-29"
+        );
+    }
+
+    #[test]
+    fn test_to_markdown_line_emoji_with_tag_in_content() {
+        use chrono::NaiveDate;
+        let mut task = make_task("Clean the kitchen #task_type_1", false);
+        task.tags = vec!["task_type_1".to_string()];
+        task.recurrence = Some("every week".to_string());
+        task.start_date = NaiveDate::from_ymd_opt(2026, 4, 30);
+        task.scheduled_date = NaiveDate::from_ymd_opt(2026, 4, 30);
+        task.due_date = NaiveDate::from_ymd_opt(2026, 4, 30);
+        assert_eq!(
+            task.to_markdown_line(),
+            "- [ ] Clean the kitchen #task_type_1 🔁 every week 🛫 2026-04-30 ⏳ 2026-04-30 📅 2026-04-30"
+        );
+    }
+
+    #[test]
+    fn test_to_markdown_line_dataview_format() {
+        use chrono::NaiveDate;
+        let mut task = make_task("Buy groceries #errands", false);
+        task.metadata_format = TaskMetadataFormat::Dataview;
+        task.priority = TaskPriority::Medium;
+        task.due_date = NaiveDate::from_ymd_opt(2026, 5, 1);
+        task.tags = vec!["errands".to_string()];
+        assert_eq!(
+            task.to_markdown_line(),
+            "- [ ] Buy groceries #errands [priority:: medium] [due:: 2026-05-01]"
+        );
+    }
+
+    #[test]
+    fn test_to_markdown_line_dataview_full() {
+        use chrono::NaiveDate;
+        let mut task = make_task("Plan sprint", false);
+        task.metadata_format = TaskMetadataFormat::Dataview;
+        task.priority = TaskPriority::High;
+        task.start_date = NaiveDate::from_ymd_opt(2026, 5, 1);
+        task.due_date = NaiveDate::from_ymd_opt(2026, 5, 7);
+        assert_eq!(
+            task.to_markdown_line(),
+            "- [ ] Plan sprint [priority:: high] [start:: 2026-05-01] [due:: 2026-05-07]"
+        );
+    }
+
+    #[test]
+    fn test_metadata_format_detection_emoji() {
+        let metadata = HashMap::new();
+        assert_eq!(
+            TaskMetadataFormat::detect(&metadata),
+            TaskMetadataFormat::Emoji
+        );
+    }
+
+    #[test]
+    fn test_metadata_format_detection_dataview_due() {
+        let mut metadata = HashMap::new();
+        metadata.insert("due".to_string(), "2026-05-01".to_string());
+        assert_eq!(
+            TaskMetadataFormat::detect(&metadata),
+            TaskMetadataFormat::Dataview
+        );
+    }
+
+    #[test]
+    fn test_metadata_format_detection_custom_key_not_dataview() {
+        let mut metadata = HashMap::new();
+        metadata.insert("project".to_string(), "myproject".to_string());
+        assert_eq!(
+            TaskMetadataFormat::detect(&metadata),
+            TaskMetadataFormat::Emoji
         );
     }
 }

--- a/crates/turbovault-core/src/task_parser.rs
+++ b/crates/turbovault-core/src/task_parser.rs
@@ -19,6 +19,7 @@
 
 use std::collections::HashMap;
 
+use chrono::NaiveDate;
 use winnow::{
     ModalResult, Parser,
     ascii::space0,
@@ -130,7 +131,8 @@ pub fn parse_task_line(input: &str) -> Result<Task, String> {
 pub fn parse_task_content(content: &str) -> ParsedTaskMetadata {
     let meta_start = find_metadata_start(content);
     let mut parsed = parse_metadata_section(content[meta_start..].trim_start());
-    parsed.description = content[..meta_start].trim_end().to_string();
+    parsed.tags = extract_tags(content);
+    parsed.description = build_description(content, meta_start);
     parsed
 }
 
@@ -221,6 +223,71 @@ fn parse_metadata_section(meta_str: &str) -> ParsedTaskMetadata {
     result
 }
 
+fn build_description(content: &str, meta_start: usize) -> String {
+    let mut description = content[..meta_start].trim_end().to_string();
+
+    for tag in extract_tag_literals(&content[meta_start..]) {
+        if !description.is_empty() {
+            description.push(' ');
+        }
+        description.push_str(tag);
+    }
+
+    description
+}
+
+fn extract_tags(content: &str) -> Vec<String> {
+    extract_tag_literals(content)
+        .into_iter()
+        .map(|tag| tag.trim_start_matches('#').to_string())
+        .collect()
+}
+
+fn extract_tag_literals(content: &str) -> Vec<&str> {
+    let mut tags = Vec::new();
+
+    for (i, c) in content.char_indices() {
+        if c == '#'
+            && is_tag_boundary(content, i)
+            && let Some((_, end)) = parse_tag_literal(&content[i..])
+        {
+            tags.push(&content[i..i + end]);
+        }
+    }
+
+    tags
+}
+
+fn is_tag_boundary(content: &str, index: usize) -> bool {
+    content[..index]
+        .chars()
+        .next_back()
+        .is_none_or(|c| c.is_whitespace())
+}
+
+fn parse_tag_literal(s: &str) -> Option<(&str, usize)> {
+    let rest = s.strip_prefix('#')?;
+    let mut end = 1usize;
+    let mut has_alpha = false;
+    let mut has_name = false;
+
+    for c in rest.chars() {
+        if c.is_alphanumeric() || c == '-' || c == '_' || c == '/' {
+            has_name = true;
+            has_alpha |= c.is_alphabetic();
+            end += c.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    if has_name && has_alpha {
+        Some((&s[1..end], end))
+    } else {
+        None
+    }
+}
+
 fn consume_metadata_separator(input: &mut &str) -> ModalResult<()> {
     let _ = space0.parse_next(input)?;
 
@@ -259,9 +326,14 @@ fn parse_emoji_date_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
     .parse_next(input)?;
     let _ = space0.parse_next(input)?;
     let value: &str = take_while(1.., |c: char| !c.is_whitespace()).parse_next(input)?;
+    let value = value.trim();
+
+    if !is_valid_task_date(value) {
+        return Err(ErrMode::Backtrack(ContextError::new()));
+    }
 
     let mut meta = ParsedTaskMetadata::default();
-    set_standard_field(&mut meta, key, value.trim());
+    set_standard_field(&mut meta, key, value);
     Ok(meta)
 }
 
@@ -483,12 +555,14 @@ fn is_priority_emoji(s: &str) -> bool {
 
 fn set_standard_field(meta: &mut ParsedTaskMetadata, key: &str, value: &str) {
     match key {
-        "due" => meta.due = Some(value.to_string()),
-        "scheduled" => meta.scheduled = Some(value.to_string()),
-        "start" => meta.start = Some(value.to_string()),
-        "done" | "completion" => meta.done = Some(value.to_string()),
-        "cancelled" | "canceled" => meta.cancelled = Some(value.to_string()),
-        "created" => meta.created = Some(value.to_string()),
+        "due" if is_valid_task_date(value) => meta.due = Some(value.to_string()),
+        "scheduled" if is_valid_task_date(value) => meta.scheduled = Some(value.to_string()),
+        "start" if is_valid_task_date(value) => meta.start = Some(value.to_string()),
+        "done" | "completion" if is_valid_task_date(value) => meta.done = Some(value.to_string()),
+        "cancelled" | "canceled" if is_valid_task_date(value) => {
+            meta.cancelled = Some(value.to_string());
+        }
+        "created" if is_valid_task_date(value) => meta.created = Some(value.to_string()),
         "recurrence" | "repeat" => meta.recurrence = Some(value.to_string()),
         "oncompletion" => meta.on_completion = Some(value.to_ascii_lowercase()),
         "id" => meta.id = Some(value.to_string()),
@@ -496,6 +570,10 @@ fn set_standard_field(meta: &mut ParsedTaskMetadata, key: &str, value: &str) {
         "priority" => meta.priority = priority_from_dataview_value(value),
         _ => {}
     }
+}
+
+fn is_valid_task_date(value: &str) -> bool {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").is_ok()
 }
 
 fn split_dependency_ids(value: &str) -> Vec<String> {
@@ -569,6 +647,26 @@ mod tests {
         let task = parse_task_line("- [ ] Buy milk 📅 2025-05-15").unwrap();
         assert_eq!(task.description, "Buy milk");
         assert_eq!(task.due.as_deref(), Some("2025-05-15"));
+    }
+
+    #[test]
+    fn non_iso_date_metadata_is_parsed_but_not_converted_to_task_date() {
+        // This test ensures that the parser behaves like the Obsidian Tasks plugin does
+        let parsed = parse_task_content("Buy milk 📅 05-01-2026 ⏳ 2026-05-02");
+        assert_eq!(parsed.description, "Buy milk 📅 05-01-2026");
+        assert_eq!(parsed.due.as_deref(), None);
+        assert_eq!(parsed.scheduled.as_deref(), Some("2026-05-02"));
+
+        let task = crate::models::TaskItem::from_parsed_metadata(
+            parsed,
+            false,
+            crate::models::SourcePosition::start(),
+        );
+        assert!(task.due_date.is_none());
+        assert_eq!(
+            task.scheduled_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-05-02")
+        );
     }
 
     #[test]
@@ -655,7 +753,7 @@ mod tests {
     fn parses_tags_and_block_ref_after_metadata() {
         let task = parse_task_line("- [ ] Task description 📅 2025-05-10 #urgent #work ^task-123")
             .unwrap();
-        assert_eq!(task.description, "Task description");
+        assert_eq!(task.description, "Task description #urgent #work");
         assert_eq!(task.due.as_deref(), Some("2025-05-10"));
         assert_eq!(task.tags, vec!["urgent".to_string(), "work".to_string()]);
         assert_eq!(task.block_ref.as_deref(), Some("task-123"));
@@ -663,11 +761,40 @@ mod tests {
 
     #[test]
     fn parses_tag_at_start_of_task_content() {
-        let task = parse_task_line("- [ ] #task This is the task content 📅 2026-05-01 🔺").unwrap();
+        let task =
+            parse_task_line("- [ ] #task This is the task content 📅 2026-05-01 🔺").unwrap();
 
-        assert_eq!(task.description, "This is the task content");
+        assert_eq!(task.description, "#task This is the task content");
         assert_eq!(task.due.as_deref(), Some("2026-05-01"));
         assert_eq!(task.priority, Some('🔺'));
+        assert_eq!(task.tags, vec!["task".to_string()]);
+    }
+
+    #[test]
+    fn parses_two_tags_at_start_of_task_content() {
+        let task = parse_task_line("- [ ] #task #urgent This is the task content 📅 2026-05-01 🔺")
+            .unwrap();
+
+        assert_eq!(task.description, "#task #urgent This is the task content");
+        assert_eq!(task.due.as_deref(), Some("2026-05-01"));
+        assert_eq!(task.priority, Some('🔺'));
+        assert_eq!(task.tags, vec!["task".to_string(), "urgent".to_string()]);
+    }
+
+    #[test]
+    fn indexes_tags_without_metadata_and_keeps_them_in_description() {
+        let task = parse_task_line("- [ ] Read #book chapter #research").unwrap();
+
+        assert_eq!(task.description, "Read #book chapter #research");
+        assert_eq!(task.tags, vec!["book".to_string(), "research".to_string()]);
+    }
+
+    #[test]
+    fn stops_tag_at_dot_and_keeps_full_text_in_description() {
+        // The Obsidian Tasks plugin treats #task.foo as #task tag with .foo as part of the description. This test demonstrates mirroring that behavior.
+        let task = parse_task_line("- [ ] Update #task.foo before standup").unwrap();
+
+        assert_eq!(task.description, "Update #task.foo before standup");
         assert_eq!(task.tags, vec!["task".to_string()]);
     }
 
@@ -708,11 +835,12 @@ mod tests {
 
     #[test]
     fn parses_dataview_value_with_wikilink() {
+        // #123 is not a valid tag, but should be preserved in the description.
         let task = parse_task_line(
             "- [ ] Review PR #123 [project:: [[Team Work]]] 📅 2025-05-20 🔼 #review ^pr-123",
         )
         .unwrap();
-        assert_eq!(task.description, "Review PR #123");
+        assert_eq!(task.description, "Review PR #123 #review");
         assert_eq!(task.due.as_deref(), Some("2025-05-20"));
         assert_eq!(task.priority, Some('🔼'));
         assert_eq!(task.tags, vec!["review".to_string()]);

--- a/crates/turbovault-core/src/task_parser.rs
+++ b/crates/turbovault-core/src/task_parser.rs
@@ -662,6 +662,16 @@ mod tests {
     }
 
     #[test]
+    fn parses_tag_at_start_of_task_content() {
+        let task = parse_task_line("- [ ] #task This is the task content 📅 2026-05-01 🔺").unwrap();
+
+        assert_eq!(task.description, "This is the task content");
+        assert_eq!(task.due.as_deref(), Some("2026-05-01"));
+        assert_eq!(task.priority, Some('🔺'));
+        assert_eq!(task.tags, vec!["task".to_string()]);
+    }
+
+    #[test]
     fn ignores_false_positive_in_description() {
         let task =
             parse_task_line("- [ ] Review the [due date] section and 📅 2025-04-30").unwrap();

--- a/crates/turbovault-core/src/task_parser.rs
+++ b/crates/turbovault-core/src/task_parser.rs
@@ -19,6 +19,7 @@
 
 use std::collections::HashMap;
 
+use chrono::NaiveDate;
 use winnow::{
     ModalResult, Parser,
     ascii::space0,
@@ -130,7 +131,8 @@ pub fn parse_task_line(input: &str) -> Result<Task, String> {
 pub fn parse_task_content(content: &str) -> ParsedTaskMetadata {
     let meta_start = find_metadata_start(content);
     let mut parsed = parse_metadata_section(content[meta_start..].trim_start());
-    parsed.description = content[..meta_start].trim_end().to_string();
+    parsed.tags = extract_tags(content);
+    parsed.description = build_description(content, meta_start);
     parsed
 }
 
@@ -221,6 +223,71 @@ fn parse_metadata_section(meta_str: &str) -> ParsedTaskMetadata {
     result
 }
 
+fn build_description(content: &str, meta_start: usize) -> String {
+    let mut description = content[..meta_start].trim_end().to_string();
+
+    for tag in extract_tag_literals(&content[meta_start..]) {
+        if !description.is_empty() {
+            description.push(' ');
+        }
+        description.push_str(tag);
+    }
+
+    description
+}
+
+fn extract_tags(content: &str) -> Vec<String> {
+    extract_tag_literals(content)
+        .into_iter()
+        .map(|tag| tag.trim_start_matches('#').to_string())
+        .collect()
+}
+
+fn extract_tag_literals(content: &str) -> Vec<&str> {
+    let mut tags = Vec::new();
+
+    for (i, c) in content.char_indices() {
+        if c == '#'
+            && is_tag_boundary(content, i)
+            && let Some((_, end)) = parse_tag_literal(&content[i..])
+        {
+            tags.push(&content[i..i + end]);
+        }
+    }
+
+    tags
+}
+
+fn is_tag_boundary(content: &str, index: usize) -> bool {
+    content[..index]
+        .chars()
+        .next_back()
+        .is_none_or(|c| c.is_whitespace())
+}
+
+fn parse_tag_literal(s: &str) -> Option<(&str, usize)> {
+    let rest = s.strip_prefix('#')?;
+    let mut end = 1usize;
+    let mut has_alpha = false;
+    let mut has_name = false;
+
+    for c in rest.chars() {
+        if c.is_alphanumeric() || c == '-' || c == '_' || c == '/' {
+            has_name = true;
+            has_alpha |= c.is_alphabetic();
+            end += c.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    if has_name && has_alpha {
+        Some((&s[1..end], end))
+    } else {
+        None
+    }
+}
+
 fn consume_metadata_separator(input: &mut &str) -> ModalResult<()> {
     let _ = space0.parse_next(input)?;
 
@@ -259,9 +326,14 @@ fn parse_emoji_date_field(input: &mut &str) -> ModalResult<ParsedTaskMetadata> {
     .parse_next(input)?;
     let _ = space0.parse_next(input)?;
     let value: &str = take_while(1.., |c: char| !c.is_whitespace()).parse_next(input)?;
+    let value = value.trim();
+
+    if !is_valid_task_date(value) {
+        return Err(ErrMode::Backtrack(ContextError::new()));
+    }
 
     let mut meta = ParsedTaskMetadata::default();
-    set_standard_field(&mut meta, key, value.trim());
+    set_standard_field(&mut meta, key, value);
     Ok(meta)
 }
 
@@ -483,12 +555,14 @@ fn is_priority_emoji(s: &str) -> bool {
 
 fn set_standard_field(meta: &mut ParsedTaskMetadata, key: &str, value: &str) {
     match key {
-        "due" => meta.due = Some(value.to_string()),
-        "scheduled" => meta.scheduled = Some(value.to_string()),
-        "start" => meta.start = Some(value.to_string()),
-        "done" | "completion" => meta.done = Some(value.to_string()),
-        "cancelled" | "canceled" => meta.cancelled = Some(value.to_string()),
-        "created" => meta.created = Some(value.to_string()),
+        "due" if is_valid_task_date(value) => meta.due = Some(value.to_string()),
+        "scheduled" if is_valid_task_date(value) => meta.scheduled = Some(value.to_string()),
+        "start" if is_valid_task_date(value) => meta.start = Some(value.to_string()),
+        "done" | "completion" if is_valid_task_date(value) => meta.done = Some(value.to_string()),
+        "cancelled" | "canceled" if is_valid_task_date(value) => {
+            meta.cancelled = Some(value.to_string());
+        }
+        "created" if is_valid_task_date(value) => meta.created = Some(value.to_string()),
         "recurrence" | "repeat" => meta.recurrence = Some(value.to_string()),
         "oncompletion" => meta.on_completion = Some(value.to_ascii_lowercase()),
         "id" => meta.id = Some(value.to_string()),
@@ -496,6 +570,10 @@ fn set_standard_field(meta: &mut ParsedTaskMetadata, key: &str, value: &str) {
         "priority" => meta.priority = priority_from_dataview_value(value),
         _ => {}
     }
+}
+
+fn is_valid_task_date(value: &str) -> bool {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").is_ok()
 }
 
 fn split_dependency_ids(value: &str) -> Vec<String> {
@@ -569,6 +647,26 @@ mod tests {
         let task = parse_task_line("- [ ] Buy milk 📅 2025-05-15").unwrap();
         assert_eq!(task.description, "Buy milk");
         assert_eq!(task.due.as_deref(), Some("2025-05-15"));
+    }
+
+    #[test]
+    fn non_iso_date_metadata_is_parsed_but_not_converted_to_task_date() {
+        // This test ensures that the parser behaves like the Obsidian Tasks plugin does
+        let parsed = parse_task_content("Buy milk 📅 05-01-2026 ⏳ 2026-05-02");
+        assert_eq!(parsed.description, "Buy milk 📅 05-01-2026");
+        assert_eq!(parsed.due.as_deref(), None);
+        assert_eq!(parsed.scheduled.as_deref(), Some("2026-05-02"));
+
+        let task = crate::models::TaskItem::from_parsed_metadata(
+            parsed,
+            false,
+            crate::models::SourcePosition::start(),
+        );
+        assert!(task.due_date.is_none());
+        assert_eq!(
+            task.scheduled_date.map(|date| date.to_string()).as_deref(),
+            Some("2026-05-02")
+        );
     }
 
     #[test]
@@ -655,10 +753,49 @@ mod tests {
     fn parses_tags_and_block_ref_after_metadata() {
         let task = parse_task_line("- [ ] Task description 📅 2025-05-10 #urgent #work ^task-123")
             .unwrap();
-        assert_eq!(task.description, "Task description");
+        assert_eq!(task.description, "Task description #urgent #work");
         assert_eq!(task.due.as_deref(), Some("2025-05-10"));
         assert_eq!(task.tags, vec!["urgent".to_string(), "work".to_string()]);
         assert_eq!(task.block_ref.as_deref(), Some("task-123"));
+    }
+
+    #[test]
+    fn parses_tag_at_start_of_task_content() {
+        let task =
+            parse_task_line("- [ ] #task This is the task content 📅 2026-05-01 🔺").unwrap();
+
+        assert_eq!(task.description, "#task This is the task content");
+        assert_eq!(task.due.as_deref(), Some("2026-05-01"));
+        assert_eq!(task.priority, Some('🔺'));
+        assert_eq!(task.tags, vec!["task".to_string()]);
+    }
+
+    #[test]
+    fn parses_two_tags_at_start_of_task_content() {
+        let task = parse_task_line("- [ ] #task #urgent This is the task content 📅 2026-05-01 🔺")
+            .unwrap();
+
+        assert_eq!(task.description, "#task #urgent This is the task content");
+        assert_eq!(task.due.as_deref(), Some("2026-05-01"));
+        assert_eq!(task.priority, Some('🔺'));
+        assert_eq!(task.tags, vec!["task".to_string(), "urgent".to_string()]);
+    }
+
+    #[test]
+    fn indexes_tags_without_metadata_and_keeps_them_in_description() {
+        let task = parse_task_line("- [ ] Read #book chapter #research").unwrap();
+
+        assert_eq!(task.description, "Read #book chapter #research");
+        assert_eq!(task.tags, vec!["book".to_string(), "research".to_string()]);
+    }
+
+    #[test]
+    fn stops_tag_at_dot_and_keeps_full_text_in_description() {
+        // The Obsidian Tasks plugin treats #task.foo as #task tag with .foo as part of the description. This test demonstrates mirroring that behavior.
+        let task = parse_task_line("- [ ] Update #task.foo before standup").unwrap();
+
+        assert_eq!(task.description, "Update #task.foo before standup");
+        assert_eq!(task.tags, vec!["task".to_string()]);
     }
 
     #[test]
@@ -698,11 +835,12 @@ mod tests {
 
     #[test]
     fn parses_dataview_value_with_wikilink() {
+        // #123 is not a valid tag, but should be preserved in the description.
         let task = parse_task_line(
             "- [ ] Review PR #123 [project:: [[Team Work]]] 📅 2025-05-20 🔼 #review ^pr-123",
         )
         .unwrap();
-        assert_eq!(task.description, "Review PR #123");
+        assert_eq!(task.description, "Review PR #123 #review");
         assert_eq!(task.due.as_deref(), Some("2025-05-20"));
         assert_eq!(task.priority, Some('🔼'));
         assert_eq!(task.tags, vec!["review".to_string()]);

--- a/crates/turbovault-parser/src/engine.rs
+++ b/crates/turbovault-parser/src/engine.rs
@@ -1565,7 +1565,7 @@ Some text here.
         let result = engine.parse(&ParseOptions::all());
 
         assert_eq!(result.tasks.len(), 1);
-        assert_eq!(result.tasks[0].content, "Review PR");
+        assert_eq!(result.tasks[0].content, "Review PR #review");
         assert_eq!(
             result.tasks[0]
                 .due_date

--- a/crates/turbovault-parser/src/engine.rs
+++ b/crates/turbovault-parser/src/engine.rs
@@ -1790,7 +1790,7 @@ Some text here.
         let result = engine.parse(&ParseOptions::all());
 
         assert_eq!(result.tasks.len(), 1);
-        assert_eq!(result.tasks[0].content, "Review PR");
+        assert_eq!(result.tasks[0].content, "Review PR #review");
         assert_eq!(
             result.tasks[0]
                 .due_date

--- a/crates/turbovault-parser/src/parsers/tasks.rs
+++ b/crates/turbovault-parser/src/parsers/tasks.rs
@@ -164,7 +164,7 @@ mod tests {
         let tasks = parse_tasks(content);
 
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].content, "Review PR");
+        assert_eq!(tasks[0].content, "Review PR #review");
         assert_eq!(
             tasks[0].due_date.map(|date| date.to_string()).as_deref(),
             Some("2026-05-01")

--- a/crates/turbovault-parser/src/parsers/tasks.rs
+++ b/crates/turbovault-parser/src/parsers/tasks.rs
@@ -119,7 +119,7 @@ mod tests {
         let tasks = parse_tasks(content);
 
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].content, "Review PR");
+        assert_eq!(tasks[0].content, "Review PR #review");
         assert_eq!(
             tasks[0].due_date.map(|date| date.to_string()).as_deref(),
             Some("2026-05-01")

--- a/crates/turbovault/Cargo.toml
+++ b/crates/turbovault/Cargo.toml
@@ -68,6 +68,7 @@ serde_yaml = { workspace = true }
 config = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
+chrono = { workspace = true }
 log = { workspace = true }
 simple_logger = "5.0"
 tracing = { workspace = true }
@@ -76,6 +77,8 @@ tracing-subscriber = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 tempfile = { workspace = true }
+chrono = { workspace = true }
+turbovault-vault = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio", "html_reports"] }
 
 [package.metadata.docs.rs]

--- a/crates/turbovault/Cargo.toml
+++ b/crates/turbovault/Cargo.toml
@@ -68,6 +68,7 @@ yaml_serde = { workspace = true }
 config = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
+chrono = { workspace = true }
 log = { workspace = true }
 simple_logger = "5.2"
 tracing = { workspace = true }
@@ -76,6 +77,8 @@ tracing-subscriber = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 tempfile = { workspace = true }
+chrono = { workspace = true }
+turbovault-vault = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio", "html_reports"] }
 
 [[bench]]

--- a/crates/turbovault/src/bin/main.rs
+++ b/crates/turbovault/src/bin/main.rs
@@ -57,6 +57,15 @@ struct Args {
     #[arg(long, value_delimiter = ',', env = "TURBOVAULT_DISABLED_TOOLS")]
     disabled_tools: Vec<String>,
 
+    /// Comma-separated tags — all tools carrying any of these tags are disabled.
+    #[arg(long, value_delimiter = ',', env = "TURBOVAULT_DISABLED_TAGS")]
+    disabled_tags: Vec<String>,
+
+    /// Comma-separated tags — hidden from tools/list but callable by name.
+    /// NOTE: no-op until turbomcp hide_tags() is available; a warning is logged at startup.
+    #[arg(long, value_delimiter = ',', env = "TURBOVAULT_HIDDEN_TAGS")]
+    hidden_tags: Vec<String>,
+
     /// Hide all tools not annotated as read-only by TurboMCP.
     #[arg(
         long,
@@ -313,16 +322,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     log::info!("Starting TurboVault Server (multi-version MCP protocol)");
     if tool_visibility.has_rules() {
         log::info!(
-            "Tool visibility configured: allowed={} hidden={} disabled={} require_read_only={}",
+            "Tool visibility configured: allowed={} hidden={} disabled={} \
+             disabled_tags={} hidden_tags={} require_read_only={}",
             tool_visibility.allowed.len(),
             tool_visibility.hidden.len(),
             tool_visibility.disabled.len(),
+            tool_visibility.disabled_tags.len(),
+            tool_visibility.hidden_tags.len(),
             tool_visibility.require_read_only
         );
     }
 
-    let server = VisibilityLayer::new(server)
-        .with_visibility_config(tool_visibility.into_visibility_config());
+    let server = tool_visibility.apply_to_layer(VisibilityLayer::new(server));
 
     match args.transport.as_str() {
         "stdio" => {
@@ -436,6 +447,8 @@ async fn load_tool_visibility(
         allowed: args.allowed_tools.clone(),
         hidden: args.hidden_tools.clone(),
         disabled: args.disabled_tools.clone(),
+        disabled_tags: args.disabled_tags.clone(),
+        hidden_tags: args.hidden_tags.clone(),
         require_read_only: args.require_read_only_tools,
     });
 

--- a/crates/turbovault/src/tool_visibility.rs
+++ b/crates/turbovault/src/tool_visibility.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use turbomcp::VisibilityConfig;
+use turbomcp::{McpHandler, VisibilityConfig, VisibilityLayer};
 
 /// User-facing tool visibility settings loaded from TurboVault config.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -13,6 +13,14 @@ pub struct ToolVisibilitySettings {
     pub hidden: Vec<String>,
     /// Exact tool names omitted from `tools/list` and rejected on direct calls.
     pub disabled: Vec<String>,
+    /// Disable ALL tools carrying any of these tags (e.g. `["delete", "admin"]`).
+    pub disabled_tags: Vec<String>,
+    /// Hide tools with these tags from `tools/list` (still callable by name).
+    ///
+    /// NOTE: tag-based hiding requires `VisibilityLayer::hide_tags()` which is not
+    /// yet available in turbomcp. This field is parsed and stored for forward
+    /// compatibility; a warning is logged at startup if it is non-empty.
+    pub hidden_tags: Vec<String>,
     /// Hide tools that are not annotated read-only by TurboMCP.
     pub require_read_only: bool,
 }
@@ -23,6 +31,8 @@ pub struct ToolVisibilityOverrides {
     pub allowed: Vec<String>,
     pub hidden: Vec<String>,
     pub disabled: Vec<String>,
+    pub disabled_tags: Vec<String>,
+    pub hidden_tags: Vec<String>,
     pub require_read_only: bool,
 }
 
@@ -55,10 +65,36 @@ impl ToolVisibilitySettings {
         extend_clean(&mut self.allowed, overrides.allowed);
         extend_clean(&mut self.hidden, overrides.hidden);
         extend_clean(&mut self.disabled, overrides.disabled);
+        extend_clean(&mut self.disabled_tags, overrides.disabled_tags);
+        extend_clean(&mut self.hidden_tags, overrides.hidden_tags);
         self.require_read_only |= overrides.require_read_only;
     }
 
-    /// Convert TurboVault settings to TurboMCP's runtime visibility config.
+    /// Apply all visibility rules (name-based and tag-based) to a `VisibilityLayer`.
+    ///
+    /// Prefer this over `into_visibility_config` in application code; it handles
+    /// both the `VisibilityConfig` (name rules) and `disable_tags` (tag rules).
+    pub fn apply_to_layer<H: McpHandler>(self, layer: VisibilityLayer<H>) -> VisibilityLayer<H> {
+        if !self.hidden_tags.is_empty() {
+            log::warn!(
+                "tool_visibility.hidden_tags is set but tag-based hiding is not yet supported \
+                 by turbomcp (hide_tags() API pending). The setting will be ignored. \
+                 Use disabled_tags to fully block tagged tools instead."
+            );
+        }
+        let disabled_tags = self.disabled_tags.clone();
+        let layer = layer.with_visibility_config(self.into_visibility_config());
+        if !disabled_tags.is_empty() {
+            layer.disable_tags(disabled_tags)
+        } else {
+            layer
+        }
+    }
+
+    /// Convert name-based settings to TurboMCP's `VisibilityConfig`.
+    ///
+    /// Tag rules are not represented in `VisibilityConfig`; use `apply_to_layer`
+    /// to apply the full set of rules including tag-based ones.
     pub fn into_visibility_config(self) -> VisibilityConfig {
         let mut config = VisibilityConfig::new();
 
@@ -85,6 +121,8 @@ impl ToolVisibilitySettings {
         !self.allowed.is_empty()
             || !self.hidden.is_empty()
             || !self.disabled.is_empty()
+            || !self.disabled_tags.is_empty()
+            || !self.hidden_tags.is_empty()
             || self.require_read_only
     }
 }
@@ -160,6 +198,8 @@ tool_visibility:
             allowed: vec!["read_note".to_string()],
             hidden: vec!["query_frontmatter_sql".to_string()],
             disabled: vec!["write_note".to_string()],
+            disabled_tags: vec![],
+            hidden_tags: vec![],
             require_read_only: true,
         });
 
@@ -171,5 +211,84 @@ tool_visibility:
         assert!(!config.tools.is_listed("full_health_analysis"));
         assert!(!config.tools.is_listed("query_frontmatter_sql"));
         assert!(config.require_read_only_tools);
+    }
+
+    #[test]
+    fn disabled_tags_round_trips_through_yaml() {
+        let yaml = r#"
+tool_visibility:
+  disabled_tags:
+    - delete
+    - admin
+"#;
+        let settings = ToolVisibilitySettings::from_yaml_str(yaml).unwrap();
+        assert_eq!(settings.disabled_tags, vec!["delete", "admin"]);
+        assert!(settings.hidden_tags.is_empty());
+    }
+
+    #[test]
+    fn hidden_tags_round_trips_through_yaml() {
+        let yaml = r#"
+tool_visibility:
+  hidden_tags:
+    - semantic
+    - export
+"#;
+        let settings = ToolVisibilitySettings::from_yaml_str(yaml).unwrap();
+        assert_eq!(settings.hidden_tags, vec!["semantic", "export"]);
+        assert!(settings.disabled_tags.is_empty());
+    }
+
+    #[test]
+    fn cli_overrides_merge_disabled_tags() {
+        let yaml = r#"
+tool_visibility:
+  disabled_tags:
+    - delete
+"#;
+        let mut settings = ToolVisibilitySettings::from_yaml_str(yaml).unwrap();
+        settings.merge_cli(ToolVisibilityOverrides {
+            disabled_tags: vec!["admin".to_string(), "delete".to_string()], // "delete" is duplicate
+            ..Default::default()
+        });
+        // "delete" must not be added twice
+        assert_eq!(settings.disabled_tags, vec!["delete", "admin"]);
+    }
+
+    #[test]
+    fn has_rules_true_when_disabled_tags_set() {
+        let settings = ToolVisibilitySettings {
+            disabled_tags: vec!["delete".to_string()],
+            ..Default::default()
+        };
+        assert!(settings.has_rules());
+    }
+
+    #[test]
+    fn has_rules_true_when_hidden_tags_set() {
+        let settings = ToolVisibilitySettings {
+            hidden_tags: vec!["semantic".to_string()],
+            ..Default::default()
+        };
+        assert!(settings.has_rules());
+    }
+
+    #[test]
+    fn has_rules_false_when_all_empty() {
+        assert!(!ToolVisibilitySettings::default().has_rules());
+    }
+
+    #[test]
+    fn tag_deduplication_in_merge() {
+        let mut settings = ToolVisibilitySettings {
+            disabled_tags: vec!["write".to_string()],
+            ..Default::default()
+        };
+        // Merging the same tag twice should result in it appearing once.
+        settings.merge_cli(ToolVisibilityOverrides {
+            disabled_tags: vec!["write".to_string(), "write".to_string()],
+            ..Default::default()
+        });
+        assert_eq!(settings.disabled_tags, vec!["write"]);
     }
 }

--- a/crates/turbovault/src/tools.rs
+++ b/crates/turbovault/src/tools.rs
@@ -2125,6 +2125,118 @@ impl ObsidianMcpServer {
         response.to_json()
     }
 
+    // ==================== Tasks ====================
+
+    /// List all tasks in the active vault
+    #[tool(
+        description = "List all task items from markdown files in the vault with their status, priority, dates, and metadata",
+        usage = "Use to get a complete overview of all tasks across all notes in the vault. Supports filtering by status (completed, pending, all)",
+        performance = "Moderate - parses all markdown files in vault",
+        related = ["read_note"],
+        examples = [
+            "List all tasks",
+            "Get all pending tasks only",
+            "Show completed tasks"
+        ]
+    )]
+    async fn list_tasks(
+        &self,
+        status_filter: Option<String>,
+        tag_filters: Option<Vec<String>>,
+    ) -> McpResult<serde_json::Value> {
+        let (vault_name, manager) = self.get_vault_pair().await?;
+        let files = manager.scan_vault().await.map_err(to_mcp_error)?;
+
+        let status = status_filter.unwrap_or_else(|| "all".to_string());
+        let status_lowercase = status.to_lowercase();
+
+        let normalize_tag = |tf: String| -> Option<String> {
+            let mut tag = if tf.starts_with('#') {
+                tf
+            } else {
+                format!("#{}", tf)
+            };
+            tag = tag.to_lowercase();
+            tag.retain(|c| !c.is_whitespace());
+
+            if tag.len() <= 1 || tag[1..].chars().all(|c| c.is_ascii_digit()) {
+                None
+            } else {
+                Some(tag)
+            }
+        };
+
+        let tag_filters: Vec<String> = tag_filters
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(normalize_tag)
+            .collect();
+
+        let mut all_tasks: Vec<serde_json::Value> = Vec::new();
+
+        for file_path in files {
+            if !file_path.to_string_lossy().ends_with(".md") {
+                continue;
+            }
+
+            let vault_file = match manager.parse_file(&file_path).await {
+                Ok(vf) => vf,
+                Err(_) => continue,
+            };
+
+            for task in vault_file.tasks {
+                let is_completed = task.is_completed;
+
+                let passes_status = match status_lowercase.as_str() {
+                    "completed" => is_completed,
+                    "pending" | "open" | "todo" => !is_completed,
+                    _ => true,
+                };
+
+                if !passes_status {
+                    continue;
+                }
+
+                let passes_tags = tag_filters.is_empty()
+                    || tag_filters.iter().all(|required| {
+                        let bare = required.trim_start_matches('#');
+                        task.tags.iter().any(|t| t.eq_ignore_ascii_case(bare))
+                    });
+
+                if passes_tags {
+                    all_tasks.push(serde_json::json!({
+                        "content": task.content,
+                        "is_completed": is_completed,
+                        "path": file_path.to_string_lossy().to_string(),
+                        "position": task.position,
+                        "priority": task.priority,
+                        "due_date": task.due_date.map(|d| d.to_string()),
+                        "scheduled_date": task.scheduled_date.map(|d| d.to_string()),
+                        "start_date": task.start_date.map(|d| d.to_string()),
+                        "done_date": task.done_date.map(|d| d.to_string()),
+                        "recurrence": task.recurrence,
+                        "tags": task.tags,
+                        "depends_on": task.depends_on,
+                    }));
+                }
+            }
+        }
+
+        let count = all_tasks.len();
+        let response = StandardResponse::new(
+            vault_name,
+            "list_tasks",
+            serde_json::json!({
+                "tasks": all_tasks,
+                "status_filter": status,
+                "tag_filters": tag_filters,
+            }),
+        )
+        .with_count(count)
+        .with_next_step("read_note");
+
+        response.to_json()
+    }
     // ==================== Resources (OFM Knowledge Injection) ====================
 
     /// Complete Obsidian Flavored Markdown syntax guide

--- a/crates/turbovault/src/tools.rs
+++ b/crates/turbovault/src/tools.rs
@@ -72,6 +72,164 @@ fn apply_date_field(
     Ok(())
 }
 
+/// Load raw file content and locate the typed `TaskItem` at `position` for in-place editing.
+///
+/// Validates the hash if provided, splits lines preserving the original line-ending style,
+/// bounds-checks `position`, confirms the line is a task checkbox, extracts leading indentation,
+/// and parses the file to return the typed task. Shared by `update_task` and `complete_task`.
+///
+/// Returns `(line_sep, raw_lines, indent, task)`.
+async fn read_task_for_update(
+    manager: &std::sync::Arc<VaultManager>,
+    file_path: &Path,
+    position: usize,
+    expected_hash: Option<&str>,
+) -> McpResult<(String, Vec<String>, String, turbovault_core::TaskItem)> {
+    let content = manager.read_file(file_path).await.map_err(to_mcp_error)?;
+
+    if let Some(expected) = expected_hash {
+        let actual = turbovault_vault::compute_hash(&content);
+        if actual != expected {
+            return Err(McpError::internal(
+                "File modified since last read (hash mismatch). Re-read with read_note and retry."
+                    .to_string(),
+            ));
+        }
+    }
+
+    let line_sep = if content.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    let raw_lines: Vec<String> = content.split(line_sep).map(|s| s.to_string()).collect();
+
+    let line_idx = position
+        .checked_sub(1)
+        .ok_or_else(|| McpError::internal("position must be >= 1".to_string()))?;
+
+    if line_idx >= raw_lines.len() {
+        return Err(McpError::internal(format!(
+            "position {} is beyond end of file ({} lines)",
+            position,
+            raw_lines.len()
+        )));
+    }
+
+    let trimmed = raw_lines[line_idx].trim();
+    if !trimmed.starts_with("- [ ]")
+        && !trimmed.starts_with("- [x]")
+        && !trimmed.starts_with("- [X]")
+    {
+        return Err(McpError::internal(format!(
+            "line {} is not a task checkbox: {:?}",
+            position, raw_lines[line_idx]
+        )));
+    }
+
+    let indent = {
+        let original = &raw_lines[line_idx];
+        let trimmed_len = original.trim_start().len();
+        original[..original.len() - trimmed_len].to_string()
+    };
+
+    let vault_file = manager.parse_file(file_path).await.map_err(to_mcp_error)?;
+    let task = vault_file
+        .tasks
+        .into_iter()
+        .find(|t| t.position.line == position)
+        .ok_or_else(|| McpError::internal(format!("no parsed task found at line {}", position)))?;
+
+    Ok((line_sep.to_string(), raw_lines, indent, task))
+}
+
+/// Compute next-occurrence dates for a recurring task using the Obsidian Tasks plugin convention.
+///
+/// Returns `(due_date, scheduled_date, start_date)` for the next instance, offset by the same
+/// interval as `due_date`. Returns `None` when the recurrence rule is not recognized.
+///
+/// Supported units: `day(s)`, `week(s)`, `month(s)`, `year(s)`, `weekday(s)`, `weekend(s)`.
+/// An optional leading count (e.g. `"every 2 weeks"`) is supported.
+fn compute_next_occurrence(
+    recurrence: &str,
+    due_date: Option<chrono::NaiveDate>,
+    scheduled_date: Option<chrono::NaiveDate>,
+    start_date: Option<chrono::NaiveDate>,
+    done_date: chrono::NaiveDate,
+) -> Option<(
+    Option<chrono::NaiveDate>,
+    Option<chrono::NaiveDate>,
+    Option<chrono::NaiveDate>,
+)> {
+    use chrono::Datelike;
+
+    let lower = recurrence.trim().to_lowercase();
+    let rest = lower.strip_prefix("every ").unwrap_or(&lower).trim();
+    // "!" prefix signals "when done" scheduling in Tasks plugin; treat identically for our purposes
+    let rest = rest.trim_start_matches('!').trim();
+
+    let (n, unit_str): (i64, &str) = match rest.find(' ') {
+        Some(pos) => match rest[..pos].parse::<i64>() {
+            Ok(n) => (n, rest[pos + 1..].trim()),
+            Err(_) => (1, rest),
+        },
+        None => (1, rest),
+    };
+
+    // Use due_date as the reference if set; otherwise fall back to done_date
+    let reference = due_date.unwrap_or(done_date);
+
+    let next_due: chrono::NaiveDate = match unit_str {
+        "day" | "days" => reference + chrono::Duration::days(n),
+        "week" | "weeks" => reference + chrono::Duration::days(n * 7),
+        "month" | "months" => advance_by_months(reference, n as u32)?,
+        "year" | "years" => advance_by_months(reference, (n * 12) as u32)?,
+        "weekday" | "weekdays" => {
+            let mut d = reference + chrono::Duration::days(1);
+            while matches!(d.weekday(), chrono::Weekday::Sat | chrono::Weekday::Sun) {
+                d += chrono::Duration::days(1);
+            }
+            d
+        }
+        "weekend" | "weekends" => {
+            let mut d = reference + chrono::Duration::days(1);
+            while !matches!(d.weekday(), chrono::Weekday::Sat | chrono::Weekday::Sun) {
+                d += chrono::Duration::days(1);
+            }
+            d
+        }
+        _ => return None,
+    };
+
+    let offset = next_due.signed_duration_since(reference);
+    let next_scheduled = scheduled_date.map(|d| d + offset);
+    let next_start = start_date.map(|d| d + offset);
+
+    Some((Some(next_due), next_scheduled, next_start))
+}
+
+/// Advance a date by `months` calendar months, clamping the day to the last valid day if needed.
+fn advance_by_months(date: chrono::NaiveDate, months: u32) -> Option<chrono::NaiveDate> {
+    use chrono::Datelike;
+    let total = date.month0() + months;
+    let new_year = date.year() + (total / 12) as i32;
+    let new_month = total % 12 + 1;
+    let last_day = days_in_month(new_year, new_month);
+    chrono::NaiveDate::from_ymd_opt(new_year, new_month, date.day().min(last_day))
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    let (ny, nm) = if month == 12 {
+        (year + 1, 1)
+    } else {
+        (year, month + 1)
+    };
+    chrono::NaiveDate::from_ymd_opt(ny, nm, 1)
+        .and_then(|d| d.pred_opt())
+        .map(|d| chrono::Datelike::day(&d))
+        .unwrap_or(28)
+}
+
 /// Extract count from serde_json::Value array (eliminates DRY violation)
 #[inline]
 fn extract_count(value: &serde_json::Value) -> usize {
@@ -2304,70 +2462,12 @@ impl ObsidianMcpServer {
         add_tags: Option<Vec<String>>,
         remove_tags: Option<Vec<String>>,
     ) -> McpResult<serde_json::Value> {
-        use turbovault_vault::compute_hash;
-
         let (vault_name, manager) = self.get_vault_pair().await?;
         let file_path = std::path::Path::new(&path);
 
-        // Read raw file content
-        let content = manager.read_file(file_path).await.map_err(to_mcp_error)?;
-
-        // Validate optimistic concurrency hash if provided
-        if let Some(ref expected) = expected_hash {
-            let actual = compute_hash(&content);
-            if actual != *expected {
-                return Err(McpError::internal(
-                    "File modified since last read (hash mismatch). Re-read with read_note and retry.".to_string(),
-                ));
-            }
-        }
-
-        // Detect line ending style and split
-        let line_sep = if content.contains("\r\n") {
-            "\r\n"
-        } else {
-            "\n"
-        };
-        let raw_lines: Vec<&str> = if line_sep == "\r\n" {
-            content.split("\r\n").collect()
-        } else {
-            content.split('\n').collect()
-        };
-
-        // Convert 1-indexed position to 0-indexed array access
-        let line_idx = position
-            .checked_sub(1)
-            .ok_or_else(|| McpError::internal("position must be >= 1".to_string()))?;
-
-        if line_idx >= raw_lines.len() {
-            return Err(McpError::internal(format!(
-                "position {} is beyond end of file ({} lines)",
-                position,
-                raw_lines.len()
-            )));
-        }
-
-        // Sanity-check that the target line looks like a task
-        let trimmed = raw_lines[line_idx].trim();
-        if !trimmed.starts_with("- [ ]")
-            && !trimmed.starts_with("- [x]")
-            && !trimmed.starts_with("- [X]")
-        {
-            return Err(McpError::internal(format!(
-                "line {} is not a task checkbox: {:?}",
-                position, raw_lines[line_idx]
-            )));
-        }
-
-        // Parse the full file to get a typed TaskItem at this position
-        let vault_file = manager.parse_file(file_path).await.map_err(to_mcp_error)?;
-        let mut task = vault_file
-            .tasks
-            .into_iter()
-            .find(|t| t.position.line == position)
-            .ok_or_else(|| {
-                McpError::internal(format!("no parsed task found at line {}", position))
-            })?;
+        let (line_sep, mut raw_lines, indent, mut task) =
+            read_task_for_update(&manager, file_path, position, expected_hash.as_deref()).await?;
+        let line_idx = position - 1;
 
         let mut warnings: Vec<String> = Vec::new();
 
@@ -2449,17 +2549,9 @@ impl ObsidianMcpServer {
             }
         }
 
-        // Serialize updated task to markdown and replace the line
-        let indent = {
-            let original = raw_lines[line_idx];
-            let trimmed_len = original.trim_start().len();
-            &original[..original.len() - trimmed_len]
-        };
         let new_line = format!("{}{}", indent, task.to_markdown_line());
-
-        let mut new_lines: Vec<String> = raw_lines.iter().map(|s| s.to_string()).collect();
-        new_lines[line_idx] = new_line.clone();
-        let new_content = new_lines.join(line_sep);
+        raw_lines[line_idx] = new_line.clone();
+        let new_content = raw_lines.join(&line_sep);
 
         // Write back — pass original expected_hash so write_file re-validates atomically
         manager
@@ -2491,6 +2583,194 @@ impl ObsidianMcpServer {
             response = response.with_warning(w);
         }
         response.with_next_step("list_tasks").to_json()
+    }
+
+    /// Mark a task as done and spawn the next recurrence if applicable
+    #[tool(
+        description = "Mark a task as completed, stamp today's done date, and spawn the next pending occurrence for recurring tasks",
+        usage = "Preferred shorthand over update_task when completing a task. Automatically stamps done_date with today. For recurring tasks, inserts a new pending occurrence immediately after the completed line (Tasks plugin convention) so the chain stays intact. Pass done_date to override today's date.",
+        performance = "Fast - reads and writes a single file",
+        related = ["list_tasks", "update_task", "get_overdue_tasks"],
+        examples = [
+            "path: 'daily/2026-05-01.md', position: 5",
+            "path: 'tasks.md', position: 3, done_date: '2026-05-01'"
+        ]
+    )]
+    async fn complete_task(
+        &self,
+        path: String,
+        position: usize,
+        expected_hash: Option<String>,
+        done_date: Option<String>,
+    ) -> McpResult<serde_json::Value> {
+        let (vault_name, manager) = self.get_vault_pair().await?;
+        let file_path = std::path::Path::new(&path);
+
+        let (line_sep, mut raw_lines, indent, mut task) =
+            read_task_for_update(&manager, file_path, position, expected_hash.as_deref()).await?;
+        let line_idx = position - 1;
+
+        let stamp = if let Some(ref s) = done_date {
+            if s.is_empty() {
+                chrono::Local::now().date_naive()
+            } else {
+                chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").map_err(|_| {
+                    McpError::internal(format!("invalid done_date: {s:?} — use YYYY-MM-DD"))
+                })?
+            }
+        } else {
+            chrono::Local::now().date_naive()
+        };
+
+        task.is_completed = true;
+        task.done_date = Some(stamp);
+
+        let completed_line = format!("{}{}", indent, task.to_markdown_line());
+        raw_lines[line_idx] = completed_line.clone();
+
+        let mut spawned = false;
+        let mut next_occurrence_line: Option<String> = None;
+        let mut next_occurrence_position: Option<usize> = None;
+
+        if let Some(ref rec) = task.recurrence.clone()
+            && let Some((next_due, next_sched, next_start)) = compute_next_occurrence(
+                rec,
+                task.due_date,
+                task.scheduled_date,
+                task.start_date,
+                stamp,
+            )
+        {
+            let mut next_task = task.clone();
+            next_task.is_completed = false;
+            next_task.done_date = None;
+            next_task.cancelled_date = None;
+            next_task.due_date = next_due;
+            next_task.scheduled_date = next_sched;
+            next_task.start_date = next_start;
+
+            let next_line = format!("{}{}", indent, next_task.to_markdown_line());
+            raw_lines.insert(line_idx + 1, next_line.clone());
+            next_occurrence_line = Some(next_line);
+            next_occurrence_position = Some(position + 1);
+            spawned = true;
+        }
+
+        let new_content = raw_lines.join(&line_sep);
+        manager
+            .write_file(file_path, &new_content, expected_hash.as_deref())
+            .await
+            .map_err(to_mcp_error)?;
+
+        let mut data = serde_json::json!({
+            "path": path,
+            "position": position,
+            "completed_line": completed_line,
+            "done_date": stamp.to_string(),
+            "spawned_next_occurrence": spawned,
+            "task": {
+                "content": task.content,
+                "is_completed": task.is_completed,
+                "priority": task.priority,
+                "due_date": task.due_date.map(|d| d.to_string()),
+                "scheduled_date": task.scheduled_date.map(|d| d.to_string()),
+                "start_date": task.start_date.map(|d| d.to_string()),
+                "done_date": task.done_date.map(|d| d.to_string()),
+                "recurrence": task.recurrence,
+                "tags": task.tags,
+            },
+        });
+        if let Some(ref line) = next_occurrence_line {
+            data["next_occurrence_line"] = serde_json::Value::String(line.clone());
+        }
+        if let Some(pos) = next_occurrence_position {
+            data["next_occurrence_position"] = serde_json::json!(pos);
+        }
+
+        StandardResponse::new(vault_name, "complete_task", data)
+            .with_next_step("list_tasks")
+            .to_json()
+    }
+
+    /// List pending tasks whose due date is in the past
+    #[tool(
+        description = "List all pending tasks whose due date is before today (or a specified date), sorted oldest-first",
+        usage = "Use to surface tasks that need immediate attention. Returns only pending (not completed) tasks with a due_date set. Each result includes a days_overdue field. Optionally pass as_of_date (YYYY-MM-DD) to check overdue status relative to a specific date instead of today — useful for weekly reviews.",
+        performance = "Moderate - parses all markdown files in vault",
+        related = ["list_tasks", "complete_task", "update_task"],
+        examples = [
+            "No arguments — returns all tasks overdue as of today",
+            "as_of_date: '2026-05-07' — returns tasks overdue on that date"
+        ]
+    )]
+    async fn get_overdue_tasks(&self, as_of_date: Option<String>) -> McpResult<serde_json::Value> {
+        let (vault_name, manager) = self.get_vault_pair().await?;
+
+        let today = if let Some(ref s) = as_of_date {
+            chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").map_err(|_| {
+                McpError::internal(format!("invalid as_of_date: {s:?} — use YYYY-MM-DD"))
+            })?
+        } else {
+            chrono::Local::now().date_naive()
+        };
+
+        let files = manager.scan_vault().await.map_err(to_mcp_error)?;
+        let mut overdue: Vec<serde_json::Value> = Vec::new();
+
+        for file_path in files {
+            if !file_path.to_string_lossy().ends_with(".md") {
+                continue;
+            }
+            let vault_file = match manager.parse_file(&file_path).await {
+                Ok(vf) => vf,
+                Err(_) => continue,
+            };
+            for task in vault_file.tasks {
+                if task.is_completed {
+                    continue;
+                }
+                if let Some(due) = task.due_date
+                    && due < today
+                {
+                    let days_overdue = (today - due).num_days();
+                    overdue.push(serde_json::json!({
+                        "content": task.content,
+                        "is_completed": false,
+                        "path": file_path.to_string_lossy(),
+                        "position": task.position,
+                        "priority": task.priority,
+                        "due_date": due.to_string(),
+                        "days_overdue": days_overdue,
+                        "scheduled_date": task.scheduled_date.map(|d| d.to_string()),
+                        "start_date": task.start_date.map(|d| d.to_string()),
+                        "recurrence": task.recurrence,
+                        "tags": task.tags,
+                    }));
+                }
+            }
+        }
+
+        // Oldest overdue first
+        overdue.sort_by(|a, b| {
+            a["due_date"]
+                .as_str()
+                .unwrap_or("")
+                .cmp(b["due_date"].as_str().unwrap_or(""))
+        });
+
+        let count = overdue.len();
+        StandardResponse::new(
+            vault_name,
+            "get_overdue_tasks",
+            serde_json::json!({
+                "tasks": overdue,
+                "as_of": today.to_string(),
+            }),
+        )
+        .with_count(count)
+        .with_next_step("complete_task")
+        .with_next_step("update_task")
+        .to_json()
     }
 
     // ==================== Resources (OFM Knowledge Injection) ====================

--- a/crates/turbovault/src/tools.rs
+++ b/crates/turbovault/src/tools.rs
@@ -37,6 +37,41 @@ fn to_mcp_error(e: Error) -> McpError {
     McpError::internal(e.to_string())
 }
 
+/// Parse a human-readable priority string to `TaskPriority`.
+fn parse_task_priority(s: &str) -> Option<turbovault_core::TaskPriority> {
+    use turbovault_core::TaskPriority;
+    match s.to_lowercase().as_str() {
+        "lowest" => Some(TaskPriority::Lowest),
+        "low" => Some(TaskPriority::Low),
+        "normal" | "none" | "" => Some(TaskPriority::Normal),
+        "medium" => Some(TaskPriority::Medium),
+        "high" => Some(TaskPriority::High),
+        "highest" => Some(TaskPriority::Highest),
+        _ => None,
+    }
+}
+
+/// Apply an optional date string update to a `NaiveDate` field.
+/// `None` → leave unchanged; `Some("")` → clear; `Some("YYYY-MM-DD")` → set.
+fn apply_date_field(
+    field: &mut Option<chrono::NaiveDate>,
+    update: Option<&str>,
+    name: &str,
+) -> McpResult<()> {
+    if let Some(s) = update {
+        if s.is_empty() || s.eq_ignore_ascii_case("clear") || s.eq_ignore_ascii_case("none") {
+            *field = None;
+        } else {
+            *field = Some(
+                chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").map_err(|_| {
+                    McpError::internal(format!("invalid date for {name}: {s:?} — use YYYY-MM-DD"))
+                })?,
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Extract count from serde_json::Value array (eliminates DRY violation)
 #[inline]
 fn extract_count(value: &serde_json::Value) -> usize {
@@ -2239,6 +2274,225 @@ impl ObsidianMcpServer {
 
         response.to_json()
     }
+    /// Update fields of a specific task in the vault
+    #[tool(
+        description = "Update one or more fields of a task identified by its file path and line position",
+        usage = "Use to modify a task in-place. Identify the task using path and position from list_tasks. Only fields you provide are changed — omitted fields are left as-is. Pass expected_hash (from read_note) for concurrency safety. To clear a date or recurrence, pass an empty string \"\". Completing a task (is_completed: true) auto-stamps done_date with today; marking incomplete clears it.",
+        performance = "Fast - reads and writes a single file",
+        related = ["list_tasks", "read_note"],
+        examples = [
+            "is_completed: true",
+            "priority: 'high'",
+            "due_date: '2026-05-10'",
+            "due_date: '' (clears the date)",
+            "add_tags: ['urgent'], remove_tags: ['someday']",
+            "recurrence: 'every week'"
+        ]
+    )]
+    #[allow(clippy::too_many_arguments)]
+    async fn update_task(
+        &self,
+        path: String,
+        position: usize,
+        expected_hash: Option<String>,
+        is_completed: Option<bool>,
+        priority: Option<String>,
+        due_date: Option<String>,
+        scheduled_date: Option<String>,
+        start_date: Option<String>,
+        recurrence: Option<String>,
+        add_tags: Option<Vec<String>>,
+        remove_tags: Option<Vec<String>>,
+    ) -> McpResult<serde_json::Value> {
+        use turbovault_vault::compute_hash;
+
+        let (vault_name, manager) = self.get_vault_pair().await?;
+        let file_path = std::path::Path::new(&path);
+
+        // Read raw file content
+        let content = manager.read_file(file_path).await.map_err(to_mcp_error)?;
+
+        // Validate optimistic concurrency hash if provided
+        if let Some(ref expected) = expected_hash {
+            let actual = compute_hash(&content);
+            if actual != *expected {
+                return Err(McpError::internal(
+                    "File modified since last read (hash mismatch). Re-read with read_note and retry.".to_string(),
+                ));
+            }
+        }
+
+        // Detect line ending style and split
+        let line_sep = if content.contains("\r\n") {
+            "\r\n"
+        } else {
+            "\n"
+        };
+        let raw_lines: Vec<&str> = if line_sep == "\r\n" {
+            content.split("\r\n").collect()
+        } else {
+            content.split('\n').collect()
+        };
+
+        // Convert 1-indexed position to 0-indexed array access
+        let line_idx = position
+            .checked_sub(1)
+            .ok_or_else(|| McpError::internal("position must be >= 1".to_string()))?;
+
+        if line_idx >= raw_lines.len() {
+            return Err(McpError::internal(format!(
+                "position {} is beyond end of file ({} lines)",
+                position,
+                raw_lines.len()
+            )));
+        }
+
+        // Sanity-check that the target line looks like a task
+        let trimmed = raw_lines[line_idx].trim();
+        if !trimmed.starts_with("- [ ]")
+            && !trimmed.starts_with("- [x]")
+            && !trimmed.starts_with("- [X]")
+        {
+            return Err(McpError::internal(format!(
+                "line {} is not a task checkbox: {:?}",
+                position, raw_lines[line_idx]
+            )));
+        }
+
+        // Parse the full file to get a typed TaskItem at this position
+        let vault_file = manager.parse_file(file_path).await.map_err(to_mcp_error)?;
+        let mut task = vault_file
+            .tasks
+            .into_iter()
+            .find(|t| t.position.line == position)
+            .ok_or_else(|| {
+                McpError::internal(format!("no parsed task found at line {}", position))
+            })?;
+
+        let mut warnings: Vec<String> = Vec::new();
+
+        // --- Apply mutations ---
+
+        if let Some(completed) = is_completed {
+            task.is_completed = completed;
+            if completed && task.done_date.is_none() {
+                task.done_date = Some(chrono::Local::now().date_naive());
+            } else if !completed {
+                task.done_date = None;
+            }
+        }
+
+        if let Some(ref p) = priority {
+            task.priority = parse_task_priority(p).ok_or_else(|| {
+                McpError::internal(format!(
+                    "unknown priority {:?} — use: lowest, low, normal, medium, high, highest",
+                    p
+                ))
+            })?;
+        }
+
+        apply_date_field(&mut task.due_date, due_date.as_deref(), "due_date")?;
+        apply_date_field(
+            &mut task.scheduled_date,
+            scheduled_date.as_deref(),
+            "scheduled_date",
+        )?;
+        apply_date_field(&mut task.start_date, start_date.as_deref(), "start_date")?;
+
+        if let Some(ref rec) = recurrence {
+            task.recurrence = if rec.is_empty() {
+                None
+            } else {
+                Some(rec.clone())
+            };
+        }
+
+        if let Some(tags) = add_tags {
+            for tag in tags {
+                let bare = tag.trim_start_matches('#').to_string();
+                if !task.tags.iter().any(|t| t.eq_ignore_ascii_case(&bare)) {
+                    task.content.push(' ');
+                    task.content.push('#');
+                    task.content.push_str(&bare);
+                    task.tags.push(bare);
+                }
+            }
+        }
+
+        if let Some(tags) = remove_tags {
+            for tag in tags {
+                let bare = tag.trim_start_matches('#').to_lowercase();
+                let pattern = format!("#{}", bare);
+                let lower = task.content.to_lowercase();
+                if let Some(pos) = lower.find(&pattern) {
+                    let end = pos + pattern.len();
+                    // Check word boundary — don't remove #work from #work-hard
+                    let is_boundary = lower[end..]
+                        .chars()
+                        .next()
+                        .map(|c| !c.is_alphanumeric() && c != '-' && c != '_')
+                        .unwrap_or(true);
+                    if is_boundary {
+                        let start =
+                            if pos > 0 && task.content.as_bytes().get(pos - 1) == Some(&b' ') {
+                                pos - 1
+                            } else {
+                                pos
+                            };
+                        task.content.drain(start..end);
+                        task.content = task.content.trim_end().to_string();
+                        task.tags.retain(|t| !t.eq_ignore_ascii_case(&bare));
+                        continue;
+                    }
+                }
+                warnings.push(format!("tag {:?} not found on task", tag));
+            }
+        }
+
+        // Serialize updated task to markdown and replace the line
+        let indent = {
+            let original = raw_lines[line_idx];
+            let trimmed_len = original.trim_start().len();
+            &original[..original.len() - trimmed_len]
+        };
+        let new_line = format!("{}{}", indent, task.to_markdown_line());
+
+        let mut new_lines: Vec<String> = raw_lines.iter().map(|s| s.to_string()).collect();
+        new_lines[line_idx] = new_line.clone();
+        let new_content = new_lines.join(line_sep);
+
+        // Write back — pass original expected_hash so write_file re-validates atomically
+        manager
+            .write_file(file_path, &new_content, expected_hash.as_deref())
+            .await
+            .map_err(to_mcp_error)?;
+
+        let mut response = StandardResponse::new(
+            vault_name,
+            "update_task",
+            serde_json::json!({
+                "path": path,
+                "position": position,
+                "new_line": new_line,
+                "task": {
+                    "content": task.content,
+                    "is_completed": task.is_completed,
+                    "priority": task.priority,
+                    "due_date": task.due_date.map(|d| d.to_string()),
+                    "scheduled_date": task.scheduled_date.map(|d| d.to_string()),
+                    "start_date": task.start_date.map(|d| d.to_string()),
+                    "done_date": task.done_date.map(|d| d.to_string()),
+                    "recurrence": task.recurrence,
+                    "tags": task.tags,
+                },
+            }),
+        );
+        for w in warnings {
+            response = response.with_warning(w);
+        }
+        response.with_next_step("list_tasks").to_json()
+    }
+
     // ==================== Resources (OFM Knowledge Injection) ====================
 
     /// Complete Obsidian Flavored Markdown syntax guide

--- a/crates/turbovault/src/tools.rs
+++ b/crates/turbovault/src/tools.rs
@@ -2130,13 +2130,15 @@ impl ObsidianMcpServer {
     /// List all tasks in the active vault
     #[tool(
         description = "List all task items from markdown files in the vault with their status, priority, dates, and metadata",
-        usage = "Use to get a complete overview of all tasks across all notes in the vault. Supports filtering by status (completed, pending, all)",
+        usage = "Use to get a complete overview of all tasks across all notes in the vault. Filter by status using status_filter: 'completed' or 'done' for finished tasks; 'pending', 'incomplete', 'open', or 'todo' for unfinished tasks; omit or pass 'all' to return everything. Filter by one or more tags using tag_filters (# prefix optional, AND logic — all tags must match).",
         performance = "Moderate - parses all markdown files in vault",
         related = ["read_note"],
         examples = [
-            "List all tasks",
-            "Get all pending tasks only",
-            "Show completed tasks"
+            "status_filter: 'pending'",
+            "status_filter: 'completed'",
+            "status_filter: 'incomplete'",
+            "tag_filters: ['work', 'urgent']",
+            "status_filter: 'pending', tag_filters: ['#errands']"
         ]
     )]
     async fn list_tasks(
@@ -2188,8 +2190,8 @@ impl ObsidianMcpServer {
                 let is_completed = task.is_completed;
 
                 let passes_status = match status_lowercase.as_str() {
-                    "completed" => is_completed,
-                    "pending" | "open" | "todo" => !is_completed,
+                    "completed" | "done" => is_completed,
+                    "pending" | "open" | "todo" | "incomplete" => !is_completed,
                     _ => true,
                 };
 

--- a/crates/turbovault/src/tools.rs
+++ b/crates/turbovault/src/tools.rs
@@ -429,7 +429,9 @@ impl ObsidianMcpServer {
         usage = "Use as first call after connecting to understand server state and capabilities. Essential for initial orientation",
         performance = "Fast (<10ms typical), no filesystem operations if no active vault",
         related = ["explain_vault", "list_vaults", "quick_health_check"],
-        examples = ["Check available vaults", "Verify server readiness", "Get OFM syntax resources"]
+        examples = ["Check available vaults", "Verify server readiness", "Get OFM syntax resources"],
+        tags = ["read"],
+        read_only = true,
     )]
     async fn get_vault_context(&self) -> McpResult<serde_json::Value> {
         let active_vault = self.multi_vault_mgr.get_active_vault().await;
@@ -538,7 +540,9 @@ impl ObsidianMcpServer {
         usage = "Use before editing, analyzing, or displaying notes. Supports all Obsidian Flavored Markdown syntax including wikilinks [[note]], embeds ![[image.png]], and block references ^block-id",
         performance = "Fast (<10ms typical). Returns path, content, and content hash for conflict detection",
         related = ["write_note", "edit_note", "get_backlinks"],
-        examples = ["daily/2024-01-15.md", "projects/website-redesign.md"]
+        examples = ["daily/2024-01-15.md", "projects/website-redesign.md"],
+        tags = ["read"],
+        read_only = true,
     )]
     async fn read_note(&self, path: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -564,7 +568,9 @@ impl ObsidianMcpServer {
         usage = "Use for creating new notes, replacing existing ones, or appending/prepending content. Append mode is ideal for daily notes and journals. Prepend inserts after frontmatter if present. Accepts Obsidian Flavored Markdown. For targeted edits, use edit_note instead. Pass expected_hash to detect concurrent modifications",
         performance = "Moderate (<50ms typical). Includes filesystem write and link graph update",
         related = ["read_note", "edit_note", "create_from_template"],
-        examples = ["mode: overwrite (default)", "mode: append (add to end)", "mode: prepend (add after frontmatter)", "expected_hash: <hash from read_note>"]
+        examples = ["mode: overwrite (default)", "mode: append (add to end)", "mode: prepend (add after frontmatter)", "expected_hash: <hash from read_note>"],
+        tags = ["write"],
+        destructive = true,
     )]
     async fn write_note(
         &self,
@@ -599,7 +605,9 @@ impl ObsidianMcpServer {
         usage = "Use for precise modifications without reading/writing entire file. Requires exact match of search text. Supports optional content hash for conflict detection and dry_run mode for preview. Returns applied changes, rejected changes, and new hash",
         performance = "Fast (<30ms typical). More efficient than read+write cycle for small edits",
         related = ["read_note", "write_note"],
-        examples = []
+        examples = [],
+        tags = ["write"],
+        destructive = true,
     )]
     async fn edit_note(
         &self,
@@ -633,7 +641,9 @@ impl ObsidianMcpServer {
         usage = "Use to remove unwanted notes. REQUIRES confirm_path parameter matching path exactly to prevent accidental deletion. Removes file from filesystem and updates link graph. Any links to this note become broken links. Use get_backlinks first to understand impact. Pass expected_hash for concurrency protection",
         performance = "Fast (<20ms typical). Includes filesystem delete and link graph update",
         related = ["get_backlinks", "get_broken_links", "move_note"],
-        examples = ["path: drafts/old-idea.md, confirm_path: drafts/old-idea.md"]
+        examples = ["path: drafts/old-idea.md, confirm_path: drafts/old-idea.md"],
+        tags = ["write", "delete"],
+        destructive = true,
     )]
     async fn delete_note(
         &self,
@@ -673,7 +683,9 @@ impl ObsidianMcpServer {
         usage = "Use to reorganize vault structure or rename notes. This performs a filesystem move only. Links pointing to the old path will become broken. Always call get_backlinks before moving to understand impact, then manually update references if needed. Pass expected_hash for concurrency protection",
         performance = "Fast (<20ms typical). Filesystem rename, falls back to copy+delete for cross-filesystem moves",
         related = ["get_backlinks", "get_forward_links", "search"],
-        examples = []
+        examples = [],
+        tags = ["write"],
+        destructive = true,
     )]
     async fn move_note(
         &self,
@@ -708,7 +720,9 @@ impl ObsidianMcpServer {
         usage = "Use to understand note importance in knowledge graph, discover related content, and analyze impact before deletion. Essential for bidirectional link analysis.",
         performance = "Fast retrieval from pre-built link graph (<50ms typical)",
         related = ["get_forward_links", "get_related_notes", "get_hub_notes"],
-        examples = []
+        examples = [],
+        tags = ["read", "graph"],
+        read_only = true,
     )]
     async fn get_backlinks(&self, path: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -737,7 +751,9 @@ impl ObsidianMcpServer {
         usage = "Use to understand note dependencies, validate link integrity, and explore connection patterns. Pair with get_backlinks for bidirectional link analysis.",
         performance = "Fast retrieval from pre-built link graph (<50ms typical)",
         related = ["get_backlinks", "get_related_notes", "get_broken_links"],
-        examples = []
+        examples = [],
+        tags = ["read", "graph"],
+        read_only = true,
     )]
     async fn get_forward_links(&self, path: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -763,7 +779,9 @@ impl ObsidianMcpServer {
         usage = "Use to discover non-obvious relationships through graph traversal. Ideal for recommendations, cluster analysis, and exploring knowledge neighborhoods. Configurable max_hops parameter.",
         performance = "Graph traversal speed varies by depth: 2 hops <100ms typical, 3+ hops may take longer on large vaults",
         related = ["recommend_related", "get_hub_notes", "suggest_links"],
-        examples = []
+        examples = [],
+        tags = ["read", "graph"],
+        read_only = true,
     )]
     async fn get_related_notes(
         &self,
@@ -795,7 +813,9 @@ impl ObsidianMcpServer {
         usage = "Identify knowledge centers, validate vault organization, discover MOCs (Maps of Content)",
         performance = "<50ms typical, scales linearly with vault size",
         related = ["get_centrality_ranking", "get_dead_end_notes", "explain_vault"],
-        examples = []
+        examples = [],
+        tags = ["read", "graph"],
+        read_only = true,
     )]
     async fn get_hub_notes(&self, top_n: Option<usize>) -> McpResult<serde_json::Value> {
         let top_n = top_n.unwrap_or(10);
@@ -821,7 +841,9 @@ impl ObsidianMcpServer {
         usage = "Identify incomplete notes needing expansion, discover topics lacking context, prioritize linking work",
         performance = "<100ms typical, graph traversal O(N)",
         related = ["suggest_links", "get_hub_notes", "get_isolated_clusters"],
-        examples = []
+        examples = [],
+        tags = ["read", "graph"],
+        read_only = true,
     )]
     async fn get_dead_end_notes(&self) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -845,7 +867,9 @@ impl ObsidianMcpServer {
         usage = "Improve vault connectivity, discover orphaned content, validate vault structure",
         performance = "<200ms typical, uses union-find algorithm O(N)",
         related = ["suggest_links", "get_dead_end_notes", "full_health_analysis"],
-        examples = []
+        examples = [],
+        tags = ["read", "graph"],
+        read_only = true,
     )]
     async fn get_isolated_clusters(&self) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -871,7 +895,9 @@ impl ObsidianMcpServer {
         usage = "Use as first diagnostic before deeper analysis. Score <60 suggests issues needing attention",
         performance = "Fast - optimized for speed with <100ms typical response using heuristics not exhaustive analysis",
         related = ["full_health_analysis", "get_broken_links", "detect_cycles"],
-        examples = ["quick vault check", "is my vault healthy?", "vault health score"]
+        examples = ["quick vault check", "is my vault healthy?", "vault health score"],
+        tags = ["read", "health"],
+        read_only = true,
     )]
     async fn quick_health_check(&self) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -899,7 +925,9 @@ impl ObsidianMcpServer {
         usage = "Use when quick_health_check reveals issues or before major vault refactoring. Provides actionable insights for vault improvement",
         performance = "Slow - may take several seconds on large vaults. Significantly slower than quick_health_check due to exhaustive analysis",
         related = ["quick_health_check", "export_health_report", "explain_vault"],
-        examples = ["detailed health analysis", "comprehensive vault check", "what are all my vault issues?"]
+        examples = ["detailed health analysis", "comprehensive vault check", "what are all my vault issues?"],
+        tags = ["read", "health"],
+        read_only = true,
     )]
     async fn full_health_analysis(&self) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -932,7 +960,9 @@ impl ObsidianMcpServer {
         usage = "Use to identify notes to create or links to fix. Broken links harm navigation and indicate incomplete knowledge graph",
         performance = "Moderate - scans all notes and validates link targets, scales with vault size",
         related = ["suggest_links", "full_health_analysis", "export_broken_links"],
-        examples = ["find broken links", "which links are broken?", "show missing note targets"]
+        examples = ["find broken links", "which links are broken?", "show missing note targets"],
+        tags = ["read", "health"],
+        read_only = true,
     )]
     async fn get_broken_links(&self) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -961,7 +991,9 @@ impl ObsidianMcpServer {
         usage = "Use for graph topology analysis. Cycles aren't necessarily bad (many knowledge domains are naturally circular) but may indicate redundant structure or need for hub notes",
         performance = "Moderate - performs graph traversal to detect cycles, scales with vault complexity and link density",
         related = ["get_hub_notes", "full_health_analysis", "get_related_notes"],
-        examples = ["find circular links", "detect reference cycles", "A→B→C→A patterns"]
+        examples = ["find circular links", "detect reference cycles", "A→B→C→A patterns"],
+        tags = ["read", "graph"],
+        read_only = true,
     )]
     async fn detect_cycles(&self) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -991,7 +1023,9 @@ impl ObsidianMcpServer {
         usage = "Use as comprehensive diagnostic or for presenting complete vault state. Replaces 5+ separate calls (scan + health + hubs + orphans + stats)",
         performance = "SLOW (1-5 seconds on large vaults) - aggregates multiple analyses. Use quick_health_check for fast diagnostics",
         related = ["get_vault_context", "full_health_analysis", "get_hub_notes", "quick_health_check"],
-        examples = ["Get complete vault status before refactoring", "Present vault health to user", "Generate comprehensive diagnostic report"]
+        examples = ["Get complete vault status before refactoring", "Present vault health to user", "Generate comprehensive diagnostic report"],
+        tags = ["read"],
+        read_only = true,
     )]
     async fn explain_vault(&self) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1108,7 +1142,9 @@ impl ObsidianMcpServer {
         usage = "Use for discovering content by keywords. Case-insensitive, supports phrase queries with quotes. For filtered searches, use advanced_search",
         performance = "<100ms on 10k notes, <500ms on 100k notes",
         related = ["advanced_search", "recommend_related", "query_metadata"],
-        examples = ["\"project alpha\"", "authentication", "urgent tasks"]
+        examples = ["\"project alpha\"", "authentication", "urgent tasks"],
+        tags = ["read", "search"],
+        read_only = true,
     )]
     async fn search(&self, query: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1138,7 +1174,9 @@ impl ObsidianMcpServer {
             "find notes tagged 'important'",
             "query with frontmatter_filters:[{key:'type', value:'task'}, {key:'status', value:'active'}]",
             "search 'meeting' exclude_paths:['archive/'] limit:20"
-        ]
+        ],
+        tags = ["read", "search"],
+        read_only = true,
     )]
     async fn advanced_search(
         &self,
@@ -1187,7 +1225,9 @@ impl ObsidianMcpServer {
         usage = "Use for structured queries like finding all notes with type:'task' or status:'active'. For multiple filters combined with AND logic, use advanced_search with frontmatter_filters instead",
         performance = "Moderate - scans indexed content then filters by frontmatter, <200ms on 10k notes",
         related = ["advanced_search", "query_metadata", "get_metadata_value"],
-        examples = ["key:'type' value:'task'", "key:'status' value:'active'", "key:'project' value:'alpha'"]
+        examples = ["key:'type' value:'task'", "key:'status' value:'active'", "key:'project' value:'alpha'"],
+        tags = ["read", "search"],
+        read_only = true,
     )]
     async fn search_by_frontmatter(
         &self,
@@ -1218,7 +1258,9 @@ impl ObsidianMcpServer {
         usage = "Ideal for discovering non-obvious connections and suggesting reading paths. More sophisticated than get_related_notes which uses only graph structure",
         performance = "Slow - uses TF-IDF + graph features requiring content analysis and ML computations, may take seconds on large vaults",
         related = ["get_related_notes", "suggest_links", "search"],
-        examples = ["recommend notes related to 'Machine Learning'", "find similar notes", "what should I read next?"]
+        examples = ["recommend notes related to 'Machine Learning'", "find similar notes", "what should I read next?"],
+        tags = ["read", "search"],
+        read_only = true,
     )]
     async fn recommend_related(&self, path: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1247,7 +1289,9 @@ impl ObsidianMcpServer {
         usage = "Always call this first before query_frontmatter_sql so you know what columns exist. Returns the full schema of the 'files' table",
         performance = "Moderate - scans all vault files to collect schema metadata",
         related = ["query_frontmatter_sql", "query_metadata", "advanced_search"],
-        examples = ["inspect schema to see available columns"]
+        examples = ["inspect schema to see available columns"],
+        tags = ["read", "frontmatter"],
+        read_only = true,
     )]
     async fn inspect_frontmatter(&self) -> McpResult<serde_json::Value> {
         #[cfg(feature = "sql")]
@@ -1280,7 +1324,9 @@ impl ObsidianMcpServer {
             "SELECT path, status, type FROM files WHERE status = 'active' AND type = 'task'",
             "SELECT status, COUNT(*) as cnt FROM files GROUP BY status ORDER BY cnt DESC",
             "SELECT path FROM files WHERE tags IS NOT NULL ORDER BY path LIMIT 20"
-        ]
+        ],
+        tags = ["read", "frontmatter", "sql"],
+        read_only = true,
     )]
     async fn query_frontmatter_sql(&self, sql: String) -> McpResult<serde_json::Value> {
         #[cfg(feature = "sql")]
@@ -1312,7 +1358,9 @@ impl ObsidianMcpServer {
         usage = "Use to discover available templates before creating notes from templates",
         performance = "Instant (<5ms) - reads from in-memory template registry",
         related = ["get_template", "create_from_template", "find_notes_from_template"],
-        examples = ["List all templates to find daily note template", "Check template fields before creation"]
+        examples = ["List all templates to find daily note template", "Check template fields before creation"],
+        tags = ["read", "template"],
+        read_only = true,
     )]
     async fn list_templates(&self) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1333,7 +1381,9 @@ impl ObsidianMcpServer {
         usage = "Use to understand template structure and required fields before creating notes",
         performance = "Instant (<5ms) - template lookup from in-memory registry",
         related = ["list_templates", "create_from_template", "find_notes_from_template"],
-        examples = ["Get daily-note template to see required fields", "Preview meeting-notes template structure"]
+        examples = ["Get daily-note template to see required fields", "Preview meeting-notes template structure"],
+        tags = ["read", "template"],
+        read_only = true,
     )]
     async fn get_template(&self, template_id: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1358,7 +1408,9 @@ impl ObsidianMcpServer {
         usage = "Use for consistent note creation workflows with predefined structure and metadata",
         performance = "Fast (10-50ms) - template rendering + file write with directory creation",
         related = ["get_template", "list_templates", "write_note", "find_notes_from_template"],
-        examples = ["Create daily note with date=2024-01-15", "Create meeting note with title and attendees", "Generate project note from template"]
+        examples = ["Create daily note with date=2024-01-15", "Create meeting note with title and attendees", "Generate project note from template"],
+        tags = ["write", "template"],
+        destructive = true,
     )]
     async fn create_from_template(
         &self,
@@ -1397,7 +1449,9 @@ impl ObsidianMcpServer {
         usage = "Use to audit template usage, bulk update template-based notes, or analyze note patterns",
         performance = "Moderate (50-200ms) - scans vault frontmatter for template_id metadata",
         related = ["query_metadata", "get_template", "advanced_search", "create_from_template"],
-        examples = ["Find all daily notes from template", "List meeting notes to bulk update", "Audit project note usage"]
+        examples = ["Find all daily notes from template", "List meeting notes to bulk update", "Audit project note usage"],
+        tags = ["read", "template"],
+        read_only = true,
     )]
     async fn find_notes_from_template(&self, template_id: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1426,7 +1480,8 @@ impl ObsidianMcpServer {
         usage = "Use for programmatic vault creation. Must call add_vault afterward to register with server",
         performance = "Fast (<50ms), creates .obsidian directory and config files",
         related = ["add_vault", "set_active_vault"],
-        examples = ["template: basic", "template: zettelkasten", "template: projects"]
+        examples = ["template: basic", "template: zettelkasten", "template: projects"],
+        tags = ["write", "admin"],
     )]
     async fn create_vault(
         &self,
@@ -1457,7 +1512,8 @@ impl ObsidianMcpServer {
         usage = "Use as first step when working with existing vaults. Idempotent and safe to call multiple times",
         performance = "Depends on vault size: 100ms for small vaults, 1-5s for large (1000+ files) due to initialization",
         related = ["list_vaults", "set_active_vault", "get_vault_context"],
-        examples = ["Add personal vault", "Register work vault", "Connect to shared knowledge base"]
+        examples = ["Add personal vault", "Register work vault", "Connect to shared knowledge base"],
+        tags = ["write", "admin"],
     )]
     async fn add_vault(&self, name: String, path: String) -> McpResult<serde_json::Value> {
         let tools = VaultLifecycleTools::new(self.multi_vault_mgr.clone());
@@ -1526,7 +1582,8 @@ impl ObsidianMcpServer {
         usage = "Use when vault is no longer needed in current session. Not idempotent (fails if already removed)",
         performance = "Instant (<1ms), only removes from registry and clears cache",
         related = ["list_vaults", "add_vault"],
-        examples = ["Remove temporary vault", "Cleanup after migration", "Close vault for maintenance"]
+        examples = ["Remove temporary vault", "Cleanup after migration", "Close vault for maintenance"],
+        tags = ["write", "admin"],
     )]
     async fn remove_vault(&self, name: String) -> McpResult<serde_json::Value> {
         let tools = VaultLifecycleTools::new(self.multi_vault_mgr.clone());
@@ -1571,7 +1628,9 @@ impl ObsidianMcpServer {
         usage = "Use to discover available vaults before setting active vault. Empty list means call add_vault first",
         performance = "Instant (<1ms), reads from in-memory registry",
         related = ["get_active_vault", "add_vault", "set_active_vault"],
-        examples = ["Show all vaults", "Check available options", "Verify vault registration"]
+        examples = ["Show all vaults", "Check available options", "Verify vault registration"],
+        tags = ["read", "admin"],
+        read_only = true,
     )]
     async fn list_vaults(&self) -> McpResult<serde_json::Value> {
         let tools = VaultLifecycleTools::new(self.multi_vault_mgr.clone());
@@ -1594,7 +1653,9 @@ impl ObsidianMcpServer {
         usage = "Use to inspect vault settings before operations or validate vault configuration",
         performance = "Instant (<1ms), reads from in-memory config",
         related = ["set_active_vault", "list_vaults"],
-        examples = ["Check vault path", "Verify search settings", "Inspect custom config"]
+        examples = ["Check vault path", "Verify search settings", "Inspect custom config"],
+        tags = ["read", "admin"],
+        read_only = true,
     )]
     async fn get_vault_config(&self, name: String) -> McpResult<serde_json::Value> {
         let tools = VaultLifecycleTools::new(self.multi_vault_mgr.clone());
@@ -1616,7 +1677,8 @@ impl ObsidianMcpServer {
         usage = "Use when working with multiple vaults. All tools operate on the active vault. Idempotent",
         performance = "Instant (<1ms), updates in-memory state only",
         related = ["get_active_vault", "list_vaults", "get_vault_context"],
-        examples = ["Switch to personal vault", "Activate work vault", "Change vault context"]
+        examples = ["Switch to personal vault", "Activate work vault", "Change vault context"],
+        tags = ["write", "admin"],
     )]
     async fn set_active_vault(&self, name: String) -> McpResult<serde_json::Value> {
         let tools = VaultLifecycleTools::new(self.multi_vault_mgr.clone());
@@ -1645,7 +1707,9 @@ impl ObsidianMcpServer {
         usage = "Use to verify vault context before operations. Returns empty string if none active",
         performance = "Instant (<1ms), reads from in-memory state",
         related = ["set_active_vault", "list_vaults", "get_vault_context"],
-        examples = ["Check current vault", "Verify context", "Confirm active vault"]
+        examples = ["Check current vault", "Verify context", "Confirm active vault"],
+        tags = ["read", "admin"],
+        read_only = true,
     )]
     async fn get_active_vault(&self) -> McpResult<serde_json::Value> {
         let tools = VaultLifecycleTools::new(self.multi_vault_mgr.clone());
@@ -1673,7 +1737,9 @@ impl ObsidianMcpServer {
             r#"[{"type":"write","path":"note1.md","content":"..."}]"#,
             r#"[{"type":"delete","path":"old.md"},{"type":"write","path":"new.md","content":"..."}]"#,
             r#"[{"type":"move","from":"a.md","to":"b.md"},{"type":"write","path":"index.md","content":"..."}]"#
-        ]
+        ],
+        tags = ["write", "batch"],
+        destructive = true,
     )]
     async fn batch_execute(&self, operations: Vec<BatchOperation>) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1713,7 +1779,9 @@ impl ObsidianMcpServer {
         usage = "Use for external analysis, reporting, or archiving health metrics over time",
         performance = "Fast, <100ms typical",
         related = ["full_health_analysis", "export_analysis_report", "quick_health_check"],
-        examples = ["format: json", "format: csv"]
+        examples = ["format: json", "format: csv"],
+        tags = ["read", "export"],
+        read_only = true,
     )]
     async fn export_health_report(&self, format: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1739,7 +1807,9 @@ impl ObsidianMcpServer {
         usage = "Use for bulk link fixing workflows or external tooling integration",
         performance = "Fast, <100ms typical",
         related = ["get_broken_links", "export_health_report", "full_health_analysis"],
-        examples = ["format: json", "format: csv"]
+        examples = ["format: json", "format: csv"],
+        tags = ["read", "export"],
+        read_only = true,
     )]
     async fn export_broken_links(&self, format: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1765,7 +1835,9 @@ impl ObsidianMcpServer {
         usage = "Use for analytics dashboards, vault growth tracking, or external reporting",
         performance = "Fast, <100ms typical",
         related = ["quick_health_check", "export_analysis_report", "explain_vault"],
-        examples = ["format: json", "format: csv"]
+        examples = ["format: json", "format: csv"],
+        tags = ["read", "export"],
+        read_only = true,
     )]
     async fn export_vault_stats(&self, format: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1791,7 +1863,9 @@ impl ObsidianMcpServer {
         usage = "Use for full vault audits or migration preparation when complete data export is needed",
         performance = "Slow on large vaults (1-5s for 10k+ notes), combines multiple analyses",
         related = ["full_health_analysis", "export_vault_stats", "export_health_report"],
-        examples = ["format: json", "format: csv"]
+        examples = ["format: json", "format: csv"],
+        tags = ["read", "export"],
+        read_only = true,
     )]
     async fn export_analysis_report(&self, format: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1825,7 +1899,9 @@ impl ObsidianMcpServer {
             "tags contains 'project'",
             "author.name = 'Alice'",
             "created_at > '2024-01-01'"
-        ]
+        ],
+        tags = ["read", "frontmatter"],
+        read_only = true,
     )]
     async fn query_metadata(&self, pattern: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1855,7 +1931,9 @@ impl ObsidianMcpServer {
             "key: author.name",
             "key: metadata.priority",
             "key: custom.nested.field"
-        ]
+        ],
+        tags = ["read", "frontmatter"],
+        read_only = true,
     )]
     async fn get_metadata_value(&self, file: String, key: String) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1884,7 +1962,9 @@ impl ObsidianMcpServer {
         examples = [
             r#"frontmatter: {"status": "published", "priority": 1}, merge: true"#,
             r#"frontmatter: {"tags": ["work", "urgent"]}, merge: false"#
-        ]
+        ],
+        tags = ["write", "frontmatter"],
+        destructive = true,
     )]
     async fn update_frontmatter(
         &self,
@@ -1926,7 +2006,9 @@ impl ObsidianMcpServer {
             "operation: list (returns all tags)",
             r#"operation: add, tags: ["work", "urgent"]"#,
             r#"operation: remove, tags: ["draft"]"#
-        ]
+        ],
+        tags = ["write", "frontmatter"],
+        destructive = true,
     )]
     async fn manage_tags(
         &self,
@@ -1958,7 +2040,9 @@ impl ObsidianMcpServer {
         examples = [
             r#"paths: ["daily/2024-01-15.md", "projects/alpha.md"]"#,
             r#"paths: ["index.md"]"#
-        ]
+        ],
+        tags = ["read"],
+        read_only = true,
     )]
     async fn get_notes_info(&self, paths: Vec<String>) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -1983,7 +2067,9 @@ impl ObsidianMcpServer {
         related = ["move_note", "delete_note"],
         examples = [
             "from: attachments/old.png, to: images/new.png, confirm_from: attachments/old.png, confirm_to: images/new.png"
-        ]
+        ],
+        tags = ["write"],
+        destructive = true,
     )]
     async fn move_file(
         &self,
@@ -2036,7 +2122,9 @@ impl ObsidianMcpServer {
             "file: daily/2024-01-15.md, limit: 5",
             "file: projects/research.md, limit: 10",
             "file: index.md (default limit: 5)"
-        ]
+        ],
+        tags = ["read", "graph"],
+        read_only = true,
     )]
     async fn suggest_links(
         &self,
@@ -2072,7 +2160,9 @@ impl ObsidianMcpServer {
             "source: index.md, target: concepts/foo.md",
             "source: daily/2024-01-15.md, target: projects/research.md",
             "source: MOC.md, target: archive/old-note.md"
-        ]
+        ],
+        tags = ["read", "graph"],
+        read_only = true,
     )]
     async fn get_link_strength(
         &self,
@@ -2106,7 +2196,9 @@ impl ObsidianMcpServer {
             "Returns all notes ranked by betweenness (bridge importance)",
             "Returns all notes ranked by closeness (accessibility)",
             "Returns all notes ranked by eigenvector (influence)"
-        ]
+        ],
+        tags = ["read", "graph"],
+        read_only = true,
     )]
     async fn get_centrality_ranking(&self) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
@@ -2167,7 +2259,9 @@ impl ObsidianMcpServer {
         usage = "Use before writing notes to ensure correct syntax, or as reference for OFM extensions. Prefer resource obsidian://syntax/complete-guide if client supports resources",
         performance = "Instant, returns static documentation",
         related = ["get_ofm_quick_ref", "get_ofm_examples"],
-        examples = []
+        examples = [],
+        tags = ["read"],
+        read_only = true,
     )]
     async fn get_ofm_syntax_guide(&self) -> McpResult<serde_json::Value> {
         let guide = crate::resources::OFM_SYNTAX_GUIDE.to_string();
@@ -2198,7 +2292,9 @@ impl ObsidianMcpServer {
         usage = "Use for quick syntax reminders during note writing. More concise than full guide. Prefer resource obsidian://syntax/quick-ref if client supports resources",
         performance = "Instant, returns static documentation",
         related = ["get_ofm_syntax_guide", "get_ofm_examples"],
-        examples = []
+        examples = [],
+        tags = ["read"],
+        read_only = true,
     )]
     async fn get_ofm_quick_ref(&self) -> McpResult<serde_json::Value> {
         let quick_ref = crate::resources::OFM_QUICK_REFERENCE.to_string();
@@ -2228,7 +2324,9 @@ impl ObsidianMcpServer {
         usage = "Use as reference when creating complex notes or learning OFM syntax by example. Shows daily notes, Zettelkasten, and MOC patterns. Prefer resource obsidian://examples/sample-note if client supports resources",
         performance = "Instant, returns static example note",
         related = ["get_ofm_syntax_guide", "get_ofm_quick_ref"],
-        examples = []
+        examples = [],
+        tags = ["read"],
+        read_only = true,
     )]
     async fn get_ofm_examples(&self) -> McpResult<serde_json::Value> {
         let examples = crate::resources::OFM_EXAMPLE_NOTE.to_string();
@@ -2269,7 +2367,9 @@ impl ObsidianMcpServer {
         usage = "Use to understand differences between two notes, find duplicate content, or review changes. Returns unified diff format with added/removed/changed line counts and word-level inline changes",
         performance = "Fast (<50ms typical). Uses line-level then word-level diff for changed lines",
         related = ["read_note", "find_duplicates", "compare_notes"],
-        examples = ["diff_notes(left='projects/plan-v1.md', right='projects/plan-v2.md')"]
+        examples = ["diff_notes(left='projects/plan-v1.md', right='projects/plan-v2.md')"],
+        tags = ["read"],
+        read_only = true,
     )]
     async fn diff_notes(&self, left: String, right: String) -> McpResult<serde_json::Value> {
         let start = std::time::Instant::now();
@@ -2294,7 +2394,9 @@ impl ObsidianMcpServer {
         usage = "Use to see what changed in a note over time. Specify operation_id from audit_log to identify the version to compare against",
         performance = "Fast (<50ms for diff, plus audit snapshot read time)",
         related = ["audit_log", "rollback_preview", "diff_notes"],
-        examples = ["diff_note_version(path='notes/todo.md', operation_id='abc-123')"]
+        examples = ["diff_note_version(path='notes/todo.md', operation_id='abc-123')"],
+        tags = ["read", "audit"],
+        read_only = true,
     )]
     async fn diff_note_version(
         &self,
@@ -2363,7 +2465,9 @@ impl ObsidianMcpServer {
         usage = "Use to assess individual note quality and get specific improvement recommendations. Examines heading hierarchy, link density, vocabulary diversity, metadata completeness, and modification recency",
         performance = "Fast (<100ms per note). Parses content and checks graph for backlinks",
         related = ["vault_quality_report", "find_stale_notes", "full_health_analysis"],
-        examples = ["evaluate_note_quality(path='projects/research.md')"]
+        examples = ["evaluate_note_quality(path='projects/research.md')"],
+        tags = ["read", "health"],
+        read_only = true,
     )]
     async fn evaluate_note_quality(&self, path: String) -> McpResult<serde_json::Value> {
         let start = std::time::Instant::now();
@@ -2385,7 +2489,9 @@ impl ObsidianMcpServer {
         usage = "Use for vault-wide quality assessment. Identifies notes needing improvement and provides aggregate metrics across readability, structure, completeness, and staleness",
         performance = "Moderate to slow (500ms-5s depending on vault size). Evaluates all notes",
         related = ["evaluate_note_quality", "find_stale_notes", "full_health_analysis", "explain_vault"],
-        examples = ["vault_quality_report()", "vault_quality_report(bottom_n=20)"]
+        examples = ["vault_quality_report()", "vault_quality_report(bottom_n=20)"],
+        tags = ["read", "health"],
+        read_only = true,
     )]
     async fn vault_quality_report(&self, bottom_n: Option<usize>) -> McpResult<serde_json::Value> {
         let start = std::time::Instant::now();
@@ -2411,7 +2517,9 @@ impl ObsidianMcpServer {
         usage = "Use to identify neglected content that may need review, updating, or archiving. Configurable threshold in days and result limit",
         performance = "Moderate (200ms-2s depending on vault size). Checks file modification times",
         related = ["evaluate_note_quality", "vault_quality_report", "query_metadata"],
-        examples = ["find_stale_notes(threshold_days=90)", "find_stale_notes(threshold_days=30, limit=20)"]
+        examples = ["find_stale_notes(threshold_days=90)", "find_stale_notes(threshold_days=30, limit=20)"],
+        tags = ["read", "health"],
+        read_only = true,
     )]
     async fn find_stale_notes(
         &self,
@@ -2444,7 +2552,9 @@ impl ObsidianMcpServer {
         usage = "Use when keyword search returns too few results or you want conceptual similarity. Returns similarity scores (0-1) and shared terms for explainability. More sophisticated than keyword search",
         performance = "Moderate (<500ms for 10k notes). Builds TF-IDF vectors on first call, cached for subsequent queries",
         related = ["search", "find_similar_notes", "recommend_related", "advanced_search"],
-        examples = ["semantic_search(query='distributed systems architecture')", "semantic_search(query='machine learning concepts', limit=20)"]
+        examples = ["semantic_search(query='distributed systems architecture')", "semantic_search(query='machine learning concepts', limit=20)"],
+        tags = ["read", "search", "semantic"],
+        read_only = true,
     )]
     async fn semantic_search(
         &self,
@@ -2472,7 +2582,9 @@ impl ObsidianMcpServer {
         usage = "Use to discover related notes for linking, find candidates for merging, or identify thematic clusters. More content-aware than graph-based get_related_notes",
         performance = "Moderate (<500ms for 10k notes). Uses pre-built TF-IDF vectors",
         related = ["semantic_search", "recommend_related", "get_related_notes", "find_duplicates"],
-        examples = ["find_similar_notes(path='projects/research.md')", "find_similar_notes(path='ideas/concept.md', limit=20)"]
+        examples = ["find_similar_notes(path='projects/research.md')", "find_similar_notes(path='ideas/concept.md', limit=20)"],
+        tags = ["read", "search", "semantic"],
+        read_only = true,
     )]
     async fn find_similar_notes(
         &self,
@@ -2502,7 +2614,9 @@ impl ObsidianMcpServer {
         usage = "Use to identify redundant content, merge candidates, or detect copied notes. Default threshold 0.8 catches close duplicates; lower to 0.6 for looser matching. Two-stage: fast SimHash filtering then precise verification",
         performance = "Moderate (<2s for 10k notes). SimHash O(N^2) candidate filtering then TF-IDF verification",
         related = ["compare_notes", "find_similar_notes", "diff_notes"],
-        examples = ["find_duplicates()", "find_duplicates(threshold=0.6, limit=50)"]
+        examples = ["find_duplicates()", "find_duplicates(threshold=0.6, limit=50)"],
+        tags = ["read", "search", "semantic"],
+        read_only = true,
     )]
     async fn find_duplicates(
         &self,
@@ -2533,7 +2647,9 @@ impl ObsidianMcpServer {
         usage = "Use to assess whether two notes should be merged, linked, or kept separate. Returns similarity score (0-1), shared vocabulary, line-level diff statistics, and a recommendation",
         performance = "Moderate (<500ms). Builds TF-IDF vectors and computes diff",
         related = ["find_duplicates", "diff_notes", "find_similar_notes"],
-        examples = ["compare_notes(left='projects/plan-v1.md', right='projects/plan-v2.md')"]
+        examples = ["compare_notes(left='projects/plan-v1.md', right='projects/plan-v2.md')"],
+        tags = ["read", "semantic"],
+        read_only = true,
     )]
     async fn compare_notes(&self, left: String, right: String) -> McpResult<serde_json::Value> {
         let start = std::time::Instant::now();
@@ -2560,7 +2676,9 @@ impl ObsidianMcpServer {
         usage = "Use to review what changed in the vault, when, and get operation IDs for rollback. Returns chronological entries (newest first) with operation IDs, timestamps, paths, and content hashes",
         performance = "Fast (<100ms typical). Reads from append-only JSONL log file",
         related = ["rollback_note", "rollback_preview", "audit_stats", "diff_note_version"],
-        examples = ["audit_log()", "audit_log(path='projects/', limit=20)", "audit_log(operation='DELETE')"]
+        examples = ["audit_log()", "audit_log(path='projects/', limit=20)", "audit_log(operation='DELETE')"],
+        tags = ["read", "audit"],
+        read_only = true,
     )]
     async fn audit_log(
         &self,
@@ -2611,7 +2729,9 @@ impl ObsidianMcpServer {
         usage = "Always use before rollback_note to verify the change. Returns whether the rollback would create, delete, or modify the file, plus a diff preview",
         performance = "Fast (<50ms). Read-only operation",
         related = ["rollback_note", "audit_log", "diff_note_version"],
-        examples = ["rollback_preview(operation_id='abc-123-def-456')"]
+        examples = ["rollback_preview(operation_id='abc-123-def-456')"],
+        tags = ["read", "audit"],
+        read_only = true,
     )]
     async fn rollback_preview(&self, operation_id: String) -> McpResult<serde_json::Value> {
         let start = std::time::Instant::now();
@@ -2640,7 +2760,9 @@ impl ObsidianMcpServer {
         usage = "Use to undo unwanted changes. The rollback itself is recorded in the audit trail. Use rollback_preview first to verify. Cannot roll back MOVE or ROLLBACK operations",
         performance = "Moderate (<100ms). Reads snapshot, writes file atomically, records new audit entry",
         related = ["rollback_preview", "audit_log", "diff_note_version"],
-        examples = ["rollback_note(operation_id='abc-123-def-456')"]
+        examples = ["rollback_note(operation_id='abc-123-def-456')"],
+        tags = ["write", "audit"],
+        destructive = true,
     )]
     async fn rollback_note(&self, operation_id: String) -> McpResult<serde_json::Value> {
         let start = std::time::Instant::now();
@@ -2684,7 +2806,9 @@ impl ObsidianMcpServer {
         usage = "Use for vault auditing overview. Shows operation breakdown (CREATE/UPDATE/DELETE/MOVE) and total snapshot disk usage",
         performance = "Fast (<50ms). Aggregates from log file",
         related = ["audit_log", "explain_vault", "vault_quality_report"],
-        examples = ["audit_stats()"]
+        examples = ["audit_stats()"],
+        tags = ["read", "audit"],
+        read_only = true,
     )]
     async fn audit_stats(&self) -> McpResult<serde_json::Value> {
         let start = std::time::Instant::now();

--- a/crates/turbovault/src/tools.rs
+++ b/crates/turbovault/src/tools.rs
@@ -37,6 +37,199 @@ fn to_mcp_error(e: Error) -> McpError {
     McpError::internal(e.to_string())
 }
 
+/// Parse a human-readable priority string to `TaskPriority`.
+fn parse_task_priority(s: &str) -> Option<turbovault_core::TaskPriority> {
+    use turbovault_core::TaskPriority;
+    match s.to_lowercase().as_str() {
+        "lowest" => Some(TaskPriority::Lowest),
+        "low" => Some(TaskPriority::Low),
+        "normal" | "none" | "" => Some(TaskPriority::Normal),
+        "medium" => Some(TaskPriority::Medium),
+        "high" => Some(TaskPriority::High),
+        "highest" => Some(TaskPriority::Highest),
+        _ => None,
+    }
+}
+
+/// Apply an optional date string update to a `NaiveDate` field.
+/// `None` → leave unchanged; `Some("")` → clear; `Some("YYYY-MM-DD")` → set.
+fn apply_date_field(
+    field: &mut Option<chrono::NaiveDate>,
+    update: Option<&str>,
+    name: &str,
+) -> McpResult<()> {
+    if let Some(s) = update {
+        if s.is_empty() || s.eq_ignore_ascii_case("clear") || s.eq_ignore_ascii_case("none") {
+            *field = None;
+        } else {
+            *field = Some(
+                chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").map_err(|_| {
+                    McpError::internal(format!("invalid date for {name}: {s:?} — use YYYY-MM-DD"))
+                })?,
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Load raw file content and locate the typed `TaskItem` at `position` for in-place editing.
+///
+/// Validates the hash if provided, splits lines preserving the original line-ending style,
+/// bounds-checks `position`, confirms the line is a task checkbox, extracts leading indentation,
+/// and parses the file to return the typed task. Shared by `update_task` and `complete_task`.
+///
+/// Returns `(line_sep, raw_lines, indent, task)`.
+async fn read_task_for_update(
+    manager: &std::sync::Arc<VaultManager>,
+    file_path: &Path,
+    position: usize,
+    expected_hash: Option<&str>,
+) -> McpResult<(String, Vec<String>, String, turbovault_core::TaskItem)> {
+    let content = manager.read_file(file_path).await.map_err(to_mcp_error)?;
+
+    if let Some(expected) = expected_hash {
+        let actual = turbovault_vault::compute_hash(&content);
+        if actual != expected {
+            return Err(McpError::internal(
+                "File modified since last read (hash mismatch). Re-read with read_note and retry."
+                    .to_string(),
+            ));
+        }
+    }
+
+    let line_sep = if content.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    let raw_lines: Vec<String> = content.split(line_sep).map(|s| s.to_string()).collect();
+
+    let line_idx = position
+        .checked_sub(1)
+        .ok_or_else(|| McpError::internal("position must be >= 1".to_string()))?;
+
+    if line_idx >= raw_lines.len() {
+        return Err(McpError::internal(format!(
+            "position {} is beyond end of file ({} lines)",
+            position,
+            raw_lines.len()
+        )));
+    }
+
+    let trimmed = raw_lines[line_idx].trim();
+    if !trimmed.starts_with("- [ ]")
+        && !trimmed.starts_with("- [x]")
+        && !trimmed.starts_with("- [X]")
+    {
+        return Err(McpError::internal(format!(
+            "line {} is not a task checkbox: {:?}",
+            position, raw_lines[line_idx]
+        )));
+    }
+
+    let indent = {
+        let original = &raw_lines[line_idx];
+        let trimmed_len = original.trim_start().len();
+        original[..original.len() - trimmed_len].to_string()
+    };
+
+    let vault_file = manager.parse_file(file_path).await.map_err(to_mcp_error)?;
+    let task = vault_file
+        .tasks
+        .into_iter()
+        .find(|t| t.position.line == position)
+        .ok_or_else(|| McpError::internal(format!("no parsed task found at line {}", position)))?;
+
+    Ok((line_sep.to_string(), raw_lines, indent, task))
+}
+
+/// Compute next-occurrence dates for a recurring task using the Obsidian Tasks plugin convention.
+///
+/// Returns `(due_date, scheduled_date, start_date)` for the next instance, offset by the same
+/// interval as `due_date`. Returns `None` when the recurrence rule is not recognized.
+///
+/// Supported units: `day(s)`, `week(s)`, `month(s)`, `year(s)`, `weekday(s)`, `weekend(s)`.
+/// An optional leading count (e.g. `"every 2 weeks"`) is supported.
+fn compute_next_occurrence(
+    recurrence: &str,
+    due_date: Option<chrono::NaiveDate>,
+    scheduled_date: Option<chrono::NaiveDate>,
+    start_date: Option<chrono::NaiveDate>,
+    done_date: chrono::NaiveDate,
+) -> Option<(
+    Option<chrono::NaiveDate>,
+    Option<chrono::NaiveDate>,
+    Option<chrono::NaiveDate>,
+)> {
+    use chrono::Datelike;
+
+    let lower = recurrence.trim().to_lowercase();
+    let rest = lower.strip_prefix("every ").unwrap_or(&lower).trim();
+    // "!" prefix signals "when done" scheduling in Tasks plugin; treat identically for our purposes
+    let rest = rest.trim_start_matches('!').trim();
+
+    let (n, unit_str): (i64, &str) = match rest.find(' ') {
+        Some(pos) => match rest[..pos].parse::<i64>() {
+            Ok(n) => (n, rest[pos + 1..].trim()),
+            Err(_) => (1, rest),
+        },
+        None => (1, rest),
+    };
+
+    // Use due_date as the reference if set; otherwise fall back to done_date
+    let reference = due_date.unwrap_or(done_date);
+
+    let next_due: chrono::NaiveDate = match unit_str {
+        "day" | "days" => reference + chrono::Duration::days(n),
+        "week" | "weeks" => reference + chrono::Duration::days(n * 7),
+        "month" | "months" => advance_by_months(reference, n as u32)?,
+        "year" | "years" => advance_by_months(reference, (n * 12) as u32)?,
+        "weekday" | "weekdays" => {
+            let mut d = reference + chrono::Duration::days(1);
+            while matches!(d.weekday(), chrono::Weekday::Sat | chrono::Weekday::Sun) {
+                d += chrono::Duration::days(1);
+            }
+            d
+        }
+        "weekend" | "weekends" => {
+            let mut d = reference + chrono::Duration::days(1);
+            while !matches!(d.weekday(), chrono::Weekday::Sat | chrono::Weekday::Sun) {
+                d += chrono::Duration::days(1);
+            }
+            d
+        }
+        _ => return None,
+    };
+
+    let offset = next_due.signed_duration_since(reference);
+    let next_scheduled = scheduled_date.map(|d| d + offset);
+    let next_start = start_date.map(|d| d + offset);
+
+    Some((Some(next_due), next_scheduled, next_start))
+}
+
+/// Advance a date by `months` calendar months, clamping the day to the last valid day if needed.
+fn advance_by_months(date: chrono::NaiveDate, months: u32) -> Option<chrono::NaiveDate> {
+    use chrono::Datelike;
+    let total = date.month0() + months;
+    let new_year = date.year() + (total / 12) as i32;
+    let new_month = total % 12 + 1;
+    let last_day = days_in_month(new_year, new_month);
+    chrono::NaiveDate::from_ymd_opt(new_year, new_month, date.day().min(last_day))
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    let (ny, nm) = if month == 12 {
+        (year + 1, 1)
+    } else {
+        (year, month + 1)
+    };
+    chrono::NaiveDate::from_ymd_opt(ny, nm, 1)
+        .and_then(|d| d.pred_opt())
+        .map(|d| chrono::Datelike::day(&d))
+        .unwrap_or(28)
+}
+
 /// Extract count from serde_json::Value array (eliminates DRY violation)
 #[inline]
 fn extract_count(value: &serde_json::Value) -> usize {
@@ -2217,6 +2410,574 @@ impl ObsidianMcpServer {
             );
 
         response.to_json()
+    }
+
+    // ==================== Tasks ====================
+
+    /// List all tasks in the active vault
+    #[tool(
+        description = "List all task items from markdown files in the vault with their status, priority, dates, and metadata",
+        usage = "Use to get a complete overview of all tasks across all notes in the vault. Filter by status using status_filter: 'completed' or 'done' for finished tasks; 'pending', 'incomplete', 'open', or 'todo' for unfinished tasks; omit or pass 'all' to return everything. Filter by one or more tags using tag_filters (# prefix optional, AND logic — all tags must match).",
+        performance = "Moderate - parses all markdown files in vault",
+        related = ["read_note"],
+        examples = [
+            "status_filter: 'pending'",
+            "status_filter: 'completed'",
+            "status_filter: 'incomplete'",
+            "tag_filters: ['work', 'urgent']",
+            "status_filter: 'pending', tag_filters: ['#errands']"
+        ],
+        tags = ["read", "task"]
+    )]
+    async fn list_tasks(
+        &self,
+        status_filter: Option<String>,
+        tag_filters: Option<Vec<String>>,
+    ) -> McpResult<serde_json::Value> {
+        let (vault_name, manager) = self.get_vault_pair().await?;
+        let files = manager.scan_vault().await.map_err(to_mcp_error)?;
+
+        let status = status_filter.unwrap_or_else(|| "all".to_string());
+        let status_lowercase = status.to_lowercase();
+
+        let normalize_tag = |tf: String| -> Option<String> {
+            let mut tag = if tf.starts_with('#') {
+                tf
+            } else {
+                format!("#{}", tf)
+            };
+            tag = tag.to_lowercase();
+            tag.retain(|c| !c.is_whitespace());
+
+            if tag.len() <= 1 || tag[1..].chars().all(|c| c.is_ascii_digit()) {
+                None
+            } else {
+                Some(tag)
+            }
+        };
+
+        let tag_filters: Vec<String> = tag_filters
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(normalize_tag)
+            .collect();
+
+        let mut all_tasks: Vec<serde_json::Value> = Vec::new();
+
+        for file_path in files {
+            if !file_path.to_string_lossy().ends_with(".md") {
+                continue;
+            }
+
+            let vault_file = match manager.parse_file(&file_path).await {
+                Ok(vf) => vf,
+                Err(_) => continue,
+            };
+
+            for task in vault_file.tasks {
+                let is_completed = task.is_completed;
+
+                let passes_status = match status_lowercase.as_str() {
+                    "completed" | "done" => is_completed,
+                    "pending" | "open" | "todo" | "incomplete" => !is_completed,
+                    _ => true,
+                };
+
+                if !passes_status {
+                    continue;
+                }
+
+                let passes_tags = tag_filters.is_empty()
+                    || tag_filters.iter().all(|required| {
+                        let bare = required.trim_start_matches('#');
+                        task.tags.iter().any(|t| t.eq_ignore_ascii_case(bare))
+                    });
+
+                if passes_tags {
+                    all_tasks.push(serde_json::json!({
+                        "content": task.content,
+                        "is_completed": is_completed,
+                        "path": file_path.to_string_lossy().to_string(),
+                        "position": task.position,
+                        "priority": task.priority,
+                        "due_date": task.due_date.map(|d| d.to_string()),
+                        "scheduled_date": task.scheduled_date.map(|d| d.to_string()),
+                        "start_date": task.start_date.map(|d| d.to_string()),
+                        "done_date": task.done_date.map(|d| d.to_string()),
+                        "recurrence": task.recurrence,
+                        "tags": task.tags,
+                        "depends_on": task.depends_on,
+                    }));
+                }
+            }
+        }
+
+        let count = all_tasks.len();
+        let response = StandardResponse::new(
+            vault_name,
+            "list_tasks",
+            serde_json::json!({
+                "tasks": all_tasks,
+                "status_filter": status,
+                "tag_filters": tag_filters,
+            }),
+        )
+        .with_count(count)
+        .with_next_step("read_note");
+
+        response.to_json()
+    }
+    /// Update fields of a specific task in the vault
+    #[tool(
+        description = "Update one or more fields of a task identified by its file path and line position",
+        usage = "Use to modify a task in-place. Identify the task using path and position from list_tasks. Only fields you provide are changed — omitted fields are left as-is. Pass expected_hash (from read_note) for concurrency safety. To clear a date or recurrence, pass an empty string \"\". Completing a task (is_completed: true) auto-stamps done_date with today; marking incomplete clears it. Pass description to reword the task text (inline #tags in the description are re-indexed automatically).",
+        performance = "Fast - reads and writes a single file",
+        related = ["list_tasks", "read_note"],
+        examples = [
+            "is_completed: true",
+            "priority: 'high'",
+            "due_date: '2026-05-10'",
+            "due_date: '' (clears the date)",
+            "add_tags: ['urgent'], remove_tags: ['someday']",
+            "recurrence: 'every week'",
+            "description: 'Buy oat milk and eggs'"
+        ],
+        tags = ["write", "task"]
+    )]
+    #[allow(clippy::too_many_arguments)]
+    async fn update_task(
+        &self,
+        path: String,
+        position: usize,
+        expected_hash: Option<String>,
+        description: Option<String>,
+        is_completed: Option<bool>,
+        priority: Option<String>,
+        due_date: Option<String>,
+        scheduled_date: Option<String>,
+        start_date: Option<String>,
+        recurrence: Option<String>,
+        add_tags: Option<Vec<String>>,
+        remove_tags: Option<Vec<String>>,
+    ) -> McpResult<serde_json::Value> {
+        let (vault_name, manager) = self.get_vault_pair().await?;
+        let file_path = std::path::Path::new(&path);
+
+        let (line_sep, mut raw_lines, indent, mut task) =
+            read_task_for_update(&manager, file_path, position, expected_hash.as_deref()).await?;
+        let line_idx = position - 1;
+
+        let mut warnings: Vec<String> = Vec::new();
+
+        // --- Apply mutations ---
+
+        if let Some(desc) = description {
+            task.content = desc;
+            // Re-index inline tags from the new content
+            task.tags = task
+                .content
+                .split_whitespace()
+                .filter_map(|w| {
+                    let bare = w.trim_start_matches('#');
+                    if bare.len() < w.len() && !bare.is_empty() {
+                        Some(bare.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+        }
+
+        if let Some(completed) = is_completed {
+            task.is_completed = completed;
+            if completed && task.done_date.is_none() {
+                task.done_date = Some(chrono::Local::now().date_naive());
+            } else if !completed {
+                task.done_date = None;
+            }
+        }
+
+        if let Some(ref p) = priority {
+            task.priority = parse_task_priority(p).ok_or_else(|| {
+                McpError::internal(format!(
+                    "unknown priority {:?} — use: lowest, low, normal, medium, high, highest",
+                    p
+                ))
+            })?;
+        }
+
+        apply_date_field(&mut task.due_date, due_date.as_deref(), "due_date")?;
+        apply_date_field(
+            &mut task.scheduled_date,
+            scheduled_date.as_deref(),
+            "scheduled_date",
+        )?;
+        apply_date_field(&mut task.start_date, start_date.as_deref(), "start_date")?;
+
+        if let Some(ref rec) = recurrence {
+            task.recurrence = if rec.is_empty() {
+                None
+            } else {
+                Some(rec.clone())
+            };
+        }
+
+        if let Some(tags) = add_tags {
+            for tag in tags {
+                let bare = tag.trim_start_matches('#').to_string();
+                if !task.tags.iter().any(|t| t.eq_ignore_ascii_case(&bare)) {
+                    task.content.push(' ');
+                    task.content.push('#');
+                    task.content.push_str(&bare);
+                    task.tags.push(bare);
+                }
+            }
+        }
+
+        if let Some(tags) = remove_tags {
+            for tag in tags {
+                let bare = tag.trim_start_matches('#').to_lowercase();
+                let pattern = format!("#{}", bare);
+                let lower = task.content.to_lowercase();
+                if let Some(pos) = lower.find(&pattern) {
+                    let end = pos + pattern.len();
+                    // Check word boundary — don't remove #work from #work-hard
+                    let is_boundary = lower[end..]
+                        .chars()
+                        .next()
+                        .map(|c| !c.is_alphanumeric() && c != '-' && c != '_')
+                        .unwrap_or(true);
+                    if is_boundary {
+                        let start =
+                            if pos > 0 && task.content.as_bytes().get(pos - 1) == Some(&b' ') {
+                                pos - 1
+                            } else {
+                                pos
+                            };
+                        task.content.drain(start..end);
+                        task.content = task.content.trim_end().to_string();
+                        task.tags.retain(|t| !t.eq_ignore_ascii_case(&bare));
+                        continue;
+                    }
+                }
+                warnings.push(format!("tag {:?} not found on task", tag));
+            }
+        }
+
+        let new_line = format!("{}{}", indent, task.to_markdown_line());
+        raw_lines[line_idx] = new_line.clone();
+        let new_content = raw_lines.join(&line_sep);
+
+        // Write back — pass original expected_hash so write_file re-validates atomically
+        manager
+            .write_file(file_path, &new_content, expected_hash.as_deref())
+            .await
+            .map_err(to_mcp_error)?;
+
+        let mut response = StandardResponse::new(
+            vault_name,
+            "update_task",
+            serde_json::json!({
+                "path": path,
+                "position": position,
+                "new_line": new_line,
+                "task": {
+                    "content": task.content,
+                    "is_completed": task.is_completed,
+                    "priority": task.priority,
+                    "due_date": task.due_date.map(|d| d.to_string()),
+                    "scheduled_date": task.scheduled_date.map(|d| d.to_string()),
+                    "start_date": task.start_date.map(|d| d.to_string()),
+                    "done_date": task.done_date.map(|d| d.to_string()),
+                    "recurrence": task.recurrence,
+                    "tags": task.tags,
+                },
+            }),
+        );
+        for w in warnings {
+            response = response.with_warning(w);
+        }
+        response.with_next_step("list_tasks").to_json()
+    }
+
+    /// Mark a task as done and spawn the next recurrence if applicable
+    #[tool(
+        description = "Mark a task as completed, stamp today's done date, and spawn the next pending occurrence for recurring tasks",
+        usage = "Preferred shorthand over update_task when completing a task. Automatically stamps done_date with today. For recurring tasks, inserts a new pending occurrence immediately after the completed line (Tasks plugin convention) so the chain stays intact. Pass done_date to override today's date.",
+        performance = "Fast - reads and writes a single file",
+        related = ["list_tasks", "update_task", "get_overdue_tasks"],
+        examples = [
+            "path: 'daily/2026-05-01.md', position: 5",
+            "path: 'tasks.md', position: 3, done_date: '2026-05-01'"
+        ],
+        tags = ["write", "task"]
+    )]
+    async fn complete_task(
+        &self,
+        path: String,
+        position: usize,
+        expected_hash: Option<String>,
+        done_date: Option<String>,
+    ) -> McpResult<serde_json::Value> {
+        let (vault_name, manager) = self.get_vault_pair().await?;
+        let file_path = std::path::Path::new(&path);
+
+        let (line_sep, mut raw_lines, indent, mut task) =
+            read_task_for_update(&manager, file_path, position, expected_hash.as_deref()).await?;
+        let line_idx = position - 1;
+
+        let stamp = if let Some(ref s) = done_date {
+            if s.is_empty() {
+                chrono::Local::now().date_naive()
+            } else {
+                chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").map_err(|_| {
+                    McpError::internal(format!("invalid done_date: {s:?} — use YYYY-MM-DD"))
+                })?
+            }
+        } else {
+            chrono::Local::now().date_naive()
+        };
+
+        task.is_completed = true;
+        task.done_date = Some(stamp);
+
+        let completed_line = format!("{}{}", indent, task.to_markdown_line());
+        raw_lines[line_idx] = completed_line.clone();
+
+        let mut spawned = false;
+        let mut next_occurrence_line: Option<String> = None;
+        let mut next_occurrence_position: Option<usize> = None;
+
+        if let Some(ref rec) = task.recurrence.clone()
+            && let Some((next_due, next_sched, next_start)) = compute_next_occurrence(
+                rec,
+                task.due_date,
+                task.scheduled_date,
+                task.start_date,
+                stamp,
+            )
+        {
+            let mut next_task = task.clone();
+            next_task.is_completed = false;
+            next_task.done_date = None;
+            next_task.cancelled_date = None;
+            next_task.due_date = next_due;
+            next_task.scheduled_date = next_sched;
+            next_task.start_date = next_start;
+
+            let next_line = format!("{}{}", indent, next_task.to_markdown_line());
+            raw_lines.insert(line_idx + 1, next_line.clone());
+            next_occurrence_line = Some(next_line);
+            next_occurrence_position = Some(position + 1);
+            spawned = true;
+        }
+
+        let new_content = raw_lines.join(&line_sep);
+        manager
+            .write_file(file_path, &new_content, expected_hash.as_deref())
+            .await
+            .map_err(to_mcp_error)?;
+
+        let mut data = serde_json::json!({
+            "path": path,
+            "position": position,
+            "completed_line": completed_line,
+            "done_date": stamp.to_string(),
+            "spawned_next_occurrence": spawned,
+            "task": {
+                "content": task.content,
+                "is_completed": task.is_completed,
+                "priority": task.priority,
+                "due_date": task.due_date.map(|d| d.to_string()),
+                "scheduled_date": task.scheduled_date.map(|d| d.to_string()),
+                "start_date": task.start_date.map(|d| d.to_string()),
+                "done_date": task.done_date.map(|d| d.to_string()),
+                "recurrence": task.recurrence,
+                "tags": task.tags,
+            },
+        });
+        if let Some(ref line) = next_occurrence_line {
+            data["next_occurrence_line"] = serde_json::Value::String(line.clone());
+        }
+        if let Some(pos) = next_occurrence_position {
+            data["next_occurrence_position"] = serde_json::json!(pos);
+        }
+
+        StandardResponse::new(vault_name, "complete_task", data)
+            .with_next_step("list_tasks")
+            .to_json()
+    }
+
+    /// List pending tasks whose due date is in the past
+    #[tool(
+        description = "List all pending tasks whose due date is before today (or a specified date), sorted oldest-first",
+        usage = "Use to surface tasks that need immediate attention. Returns only pending (not completed) tasks with a due_date set. Each result includes a days_overdue field. Optionally pass as_of_date (YYYY-MM-DD) to check overdue status relative to a specific date instead of today — useful for weekly reviews.",
+        performance = "Moderate - parses all markdown files in vault",
+        related = ["list_tasks", "complete_task", "update_task"],
+        examples = [
+            "No arguments — returns all tasks overdue as of today",
+            "as_of_date: '2026-05-07' — returns tasks overdue on that date"
+        ],
+        tags = ["read", "task"]
+    )]
+    async fn get_overdue_tasks(&self, as_of_date: Option<String>) -> McpResult<serde_json::Value> {
+        let (vault_name, manager) = self.get_vault_pair().await?;
+
+        let today = if let Some(ref s) = as_of_date {
+            chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").map_err(|_| {
+                McpError::internal(format!("invalid as_of_date: {s:?} — use YYYY-MM-DD"))
+            })?
+        } else {
+            chrono::Local::now().date_naive()
+        };
+
+        let files = manager.scan_vault().await.map_err(to_mcp_error)?;
+        let mut overdue: Vec<serde_json::Value> = Vec::new();
+
+        for file_path in files {
+            if !file_path.to_string_lossy().ends_with(".md") {
+                continue;
+            }
+            let vault_file = match manager.parse_file(&file_path).await {
+                Ok(vf) => vf,
+                Err(_) => continue,
+            };
+            for task in vault_file.tasks {
+                if task.is_completed {
+                    continue;
+                }
+                if let Some(due) = task.due_date
+                    && due < today
+                {
+                    let days_overdue = (today - due).num_days();
+                    overdue.push(serde_json::json!({
+                        "content": task.content,
+                        "is_completed": false,
+                        "path": file_path.to_string_lossy(),
+                        "position": task.position,
+                        "priority": task.priority,
+                        "due_date": due.to_string(),
+                        "days_overdue": days_overdue,
+                        "scheduled_date": task.scheduled_date.map(|d| d.to_string()),
+                        "start_date": task.start_date.map(|d| d.to_string()),
+                        "recurrence": task.recurrence,
+                        "tags": task.tags,
+                    }));
+                }
+            }
+        }
+
+        // Oldest overdue first
+        overdue.sort_by(|a, b| {
+            a["due_date"]
+                .as_str()
+                .unwrap_or("")
+                .cmp(b["due_date"].as_str().unwrap_or(""))
+        });
+
+        let count = overdue.len();
+        StandardResponse::new(
+            vault_name,
+            "get_overdue_tasks",
+            serde_json::json!({
+                "tasks": overdue,
+                "as_of": today.to_string(),
+            }),
+        )
+        .with_count(count)
+        .with_next_step("complete_task")
+        .with_next_step("update_task")
+        .to_json()
+    }
+
+    /// List all unique task tags across the vault
+    #[tool(
+        description = "Return a deduplicated, sorted list of all inline #tags used on task items across the vault",
+        usage = "Use before calling list_tasks with tag_filters to discover which tags are actually present. Returns tag strings without the # prefix, ready to pass directly into list_tasks tag_filters.",
+        performance = "Moderate - parses all markdown files in vault",
+        related = ["list_tasks"],
+        examples = [
+            "No arguments — returns all tags found on any task"
+        ],
+        tags = ["read", "task"]
+    )]
+    async fn list_task_tags(&self) -> McpResult<serde_json::Value> {
+        let (vault_name, manager) = self.get_vault_pair().await?;
+        let files = manager.scan_vault().await.map_err(to_mcp_error)?;
+
+        let mut tag_set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+        for file_path in files {
+            if !file_path.to_string_lossy().ends_with(".md") {
+                continue;
+            }
+            let vault_file = match manager.parse_file(&file_path).await {
+                Ok(vf) => vf,
+                Err(_) => continue,
+            };
+            for task in vault_file.tasks {
+                for tag in task.tags {
+                    tag_set.insert(tag.to_lowercase());
+                }
+            }
+        }
+
+        let tags: Vec<&str> = tag_set.iter().map(String::as_str).collect();
+        let count = tags.len();
+        StandardResponse::new(
+            vault_name,
+            "list_task_tags",
+            serde_json::json!({ "tags": tags }),
+        )
+        .with_count(count)
+        .with_next_step("list_tasks")
+        .to_json()
+    }
+
+    /// Permanently remove a task line from the vault
+    #[tool(
+        description = "Permanently delete a task by removing its line from the markdown file. This is a destructive operation — it removes the line entirely, not just marks the task complete. Use complete_task instead if you want to record completion.",
+        usage = "Use when a task should be erased from the file, not completed. Identify the task by path and position from list_tasks. Pass expected_hash (from read_note) for concurrency safety. The line is removed and the file is written back immediately.",
+        performance = "Fast - reads and writes a single file",
+        related = ["list_tasks", "complete_task", "update_task"],
+        examples = [
+            "path: 'tasks.md', position: 4",
+            "path: 'daily/2026-05-22.md', position: 7, expected_hash: '<hash from read_note>'"
+        ],
+        tags = ["write", "task", "delete"]
+    )]
+    async fn delete_task(
+        &self,
+        path: String,
+        position: usize,
+        expected_hash: Option<String>,
+    ) -> McpResult<serde_json::Value> {
+        let (vault_name, manager) = self.get_vault_pair().await?;
+        let file_path = std::path::Path::new(&path);
+
+        let (line_sep, mut raw_lines, _, task) =
+            read_task_for_update(&manager, file_path, position, expected_hash.as_deref()).await?;
+
+        let deleted_content = task.content.clone();
+        raw_lines.remove(position - 1);
+        let new_content = raw_lines.join(&line_sep);
+
+        manager
+            .write_file(file_path, &new_content, expected_hash.as_deref())
+            .await
+            .map_err(to_mcp_error)?;
+
+        StandardResponse::new(
+            vault_name,
+            "delete_task",
+            serde_json::json!({
+                "path": path,
+                "position": position,
+                "deleted_content": deleted_content,
+            }),
+        )
+        .with_next_step("list_tasks")
+        .to_json()
     }
 
     // ==================== Resources (OFM Knowledge Injection) ====================

--- a/crates/turbovault/tests/integration_test.rs
+++ b/crates/turbovault/tests/integration_test.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use tempfile::TempDir;
     use tokio::fs;
     use turbovault::ObsidianMcpServer;
@@ -330,7 +330,7 @@ mod tests {
     /// Mirrors the logic in the update_task MCP tool.
     async fn apply_task_update(
         manager: &VaultManager,
-        file_path: &PathBuf,
+        file_path: &Path,
         task: &turbovault_core::TaskItem,
     ) {
         let content = manager.read_file(file_path).await.expect("read file");
@@ -583,7 +583,7 @@ mod tests {
     /// Returns the next-occurrence line if recurrence was detected and handled.
     async fn apply_task_complete(
         manager: &VaultManager,
-        file_path: &PathBuf,
+        file_path: &Path,
         task_content: &str,
         done: chrono::NaiveDate,
     ) -> Option<String> {
@@ -773,10 +773,10 @@ mod tests {
                 if task.is_completed {
                     continue;
                 }
-                if let Some(due) = task.due_date {
-                    if due < as_of {
-                        overdue.push((task.content, due));
-                    }
+                if let Some(due) = task.due_date
+                    && due < as_of
+                {
+                    overdue.push((task.content, due));
                 }
             }
         }
@@ -805,41 +805,61 @@ mod tests {
             "expected 5 overdue tasks as of {as_of}, got: {contents:?}"
         );
         assert!(
-            contents.iter().any(|c| *c == "Take out the trash"),
+            contents.contains(&"Take out the trash"),
             "missing 'Take out the trash'"
         );
+        assert!(contents.contains(&"Feed the cat"), "missing 'Feed the cat'");
         assert!(
-            contents.iter().any(|c| *c == "Feed the cat"),
-            "missing 'Feed the cat'"
-        );
-        assert!(
-            contents
-                .iter()
-                .any(|c| *c == "Clean the kitchen #task_type_1"),
+            contents.contains(&"Clean the kitchen #task_type_1"),
             "missing 'Clean the kitchen #task_type_1'"
         );
         assert!(
-            contents
-                .iter()
-                .any(|c| *c == "Clean the baseboards #task_type_2"),
+            contents.contains(&"Clean the baseboards #task_type_2"),
             "missing 'Clean the baseboards #task_type_2'"
         );
         assert!(
-            contents.iter().any(|c| *c == "Buy groceries #errands"),
+            contents.contains(&"Buy groceries #errands"),
             "missing 'Buy groceries #errands'"
         );
 
         // Completed or future-due tasks must NOT appear
         assert!(
-            !contents.iter().any(|c| *c == "Submit expense report"),
+            !contents.contains(&"Submit expense report"),
             "completed task should not be overdue"
         );
         assert!(
-            !contents.iter().any(|c| *c == "Write weekly report"),
+            !contents.contains(&"Write weekly report"),
             "future task (due 2026-05-10) should not be overdue as of {as_of}"
         );
         assert!(
-            !contents.iter().any(|c| *c == "Plan sprint"),
+            !contents.contains(&"Plan sprint"),
+            "future task (due 2026-05-07) should not be overdue as of {as_of}"
+        );
+        assert!(contents.contains(&"Feed the cat"), "missing 'Feed the cat'");
+        assert!(
+            contents.contains(&"Clean the kitchen #task_type_1"),
+            "missing 'Clean the kitchen #task_type_1'"
+        );
+        assert!(
+            contents.contains(&"Clean the baseboards #task_type_2"),
+            "missing 'Clean the baseboards #task_type_2'"
+        );
+        assert!(
+            contents.contains(&"Buy groceries #errands"),
+            "missing 'Buy groceries #errands'"
+        );
+
+        // Completed or future-due tasks must NOT appear
+        assert!(
+            !contents.contains(&"Submit expense report"),
+            "completed task should not be overdue"
+        );
+        assert!(
+            !contents.contains(&"Write weekly report"),
+            "future task (due 2026-05-10) should not be overdue as of {as_of}"
+        );
+        assert!(
+            !contents.contains(&"Plan sprint"),
             "future task (due 2026-05-07) should not be overdue as of {as_of}"
         );
     }
@@ -906,7 +926,7 @@ mod tests {
             all_tasks
                 .iter()
                 .find(|t| t["content"] == content)
-                .expect(&format!("task not found: {content}"))
+                .unwrap_or_else(|| panic!("task not found: {content}"))
         };
 
         let pending_task = find_task("Take out the trash");

--- a/crates/turbovault/tests/integration_test.rs
+++ b/crates/turbovault/tests/integration_test.rs
@@ -324,6 +324,259 @@ mod tests {
         assert_eq!(t.id.as_deref(), Some("sprint-42"));
     }
 
+    // ==================== update_task Tests ====================
+
+    /// Helper: replace a specific 1-indexed line in file content and write it back.
+    /// Mirrors the logic in the update_task MCP tool.
+    async fn apply_task_update(
+        manager: &VaultManager,
+        file_path: &PathBuf,
+        task: &turbovault_core::TaskItem,
+    ) {
+        let content = manager.read_file(file_path).await.expect("read file");
+        let hash = turbovault_vault::compute_hash(&content);
+
+        let line_sep = if content.contains("\r\n") {
+            "\r\n"
+        } else {
+            "\n"
+        };
+        let mut lines: Vec<String> = if line_sep == "\r\n" {
+            content.split("\r\n").map(|s| s.to_string()).collect()
+        } else {
+            content.split('\n').map(|s| s.to_string()).collect()
+        };
+
+        let line_idx = task.position.line - 1; // 1-indexed → 0-indexed
+        let original = &lines[line_idx];
+        let indent_len = original.len() - original.trim_start().len();
+        let indent = original[..indent_len].to_string();
+        lines[line_idx] = format!("{}{}", indent, task.to_markdown_line());
+
+        let new_content = lines.join(line_sep);
+        manager
+            .write_file(file_path, &new_content, Some(&hash))
+            .await
+            .expect("write file");
+    }
+
+    #[tokio::test]
+    async fn test_update_task_mark_complete() {
+        use chrono::NaiveDate;
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        // Find the task we want to update
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Take out the trash")
+            .expect("find task")
+            .clone();
+
+        assert!(!task.is_completed);
+        assert!(task.done_date.is_none());
+
+        // Mutate
+        task.is_completed = true;
+        task.done_date = NaiveDate::from_ymd_opt(2026, 5, 2);
+
+        apply_task_update(&manager, &file_path, &task).await;
+
+        // Re-parse and verify
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        let updated = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Take out the trash")
+            .expect("find updated task");
+
+        assert!(updated.is_completed);
+        assert_eq!(
+            updated.done_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-02")
+        );
+        // Dates from the original task should be preserved
+        assert_eq!(
+            updated.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_task_change_priority() {
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Feed the cat")
+            .expect("find task")
+            .clone();
+
+        assert_eq!(task.priority, TaskPriority::High);
+
+        task.priority = TaskPriority::Lowest;
+        apply_task_update(&manager, &file_path, &task).await;
+
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        let updated = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Feed the cat")
+            .expect("find updated task");
+
+        assert_eq!(updated.priority, TaskPriority::Lowest);
+        // Other fields should be unchanged
+        assert_eq!(updated.recurrence.as_deref(), Some("every day"));
+        assert!(!updated.is_completed);
+    }
+
+    #[tokio::test]
+    async fn test_update_task_add_and_remove_tags() {
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Clean the kitchen #task_type_1")
+            .expect("find task")
+            .clone();
+
+        assert!(task.tags.iter().any(|t| t == "task_type_1"));
+
+        // Add a new tag and remove the existing one
+        let bare = "urgent";
+        task.content.push(' ');
+        task.content.push('#');
+        task.content.push_str(bare);
+        task.tags.push(bare.to_string());
+
+        // Remove task_type_1
+        let remove = "task_type_1";
+        let pattern = format!("#{}", remove);
+        let lower = task.content.to_lowercase();
+        if let Some(pos) = lower.find(&pattern) {
+            let end = pos + pattern.len();
+            let start = if pos > 0 && task.content.as_bytes().get(pos - 1) == Some(&b' ') {
+                pos - 1
+            } else {
+                pos
+            };
+            task.content.drain(start..end);
+            task.content = task.content.trim_end().to_string();
+            task.tags.retain(|t| t != remove);
+        }
+
+        apply_task_update(&manager, &file_path, &task).await;
+
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        let updated = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.tags.iter().any(|tag| tag == "urgent"))
+            .expect("find updated task");
+
+        assert!(updated.tags.iter().any(|t| t == "urgent"));
+        assert!(!updated.tags.iter().any(|t| t == "task_type_1"));
+    }
+
+    #[tokio::test]
+    async fn test_update_task_dataview_format_preserved() {
+        use chrono::NaiveDate;
+        use turbovault_core::TaskMetadataFormat;
+
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Buy groceries #errands")
+            .expect("find task")
+            .clone();
+
+        // Confirm parser detected dataview format
+        assert_eq!(task.metadata_format, TaskMetadataFormat::Dataview);
+
+        // Update the due date
+        task.due_date = NaiveDate::from_ymd_opt(2026, 6, 1);
+
+        apply_task_update(&manager, &file_path, &task).await;
+
+        // Read raw content to confirm dataview notation was used
+        let new_content = manager.read_file(&file_path).await.expect("read");
+        assert!(
+            new_content.contains("[due:: 2026-06-01]"),
+            "expected dataview [due:: ...] notation in: {new_content}"
+        );
+        assert!(
+            !new_content.contains("📅 2026-06-01"),
+            "unexpected emoji notation in dataview task"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_task_clear_due_date() {
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Take out the trash")
+            .expect("find task")
+            .clone();
+
+        assert!(task.due_date.is_some());
+
+        task.due_date = None;
+        apply_task_update(&manager, &file_path, &task).await;
+
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        let updated = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Take out the trash")
+            .expect("find updated task");
+
+        assert!(
+            updated.due_date.is_none(),
+            "due_date should have been cleared"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_task_hash_guard_rejects_stale_write() {
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        // Read the file and capture hash
+        let content = manager.read_file(&file_path).await.expect("read");
+        let stale_hash = turbovault_vault::compute_hash(&content);
+
+        // Modify the file so the hash becomes stale
+        let modified = format!("{}\n<!-- touched -->", content);
+        manager
+            .write_file(&file_path, &modified, None)
+            .await
+            .expect("first write");
+
+        // Attempt to write with the now-stale hash — should fail
+        let result = manager
+            .write_file(&file_path, &modified, Some(&stale_hash))
+            .await;
+
+        assert!(result.is_err(), "write with stale hash should fail");
+    }
+
     #[tokio::test]
     async fn test_list_tasks_mcp_tool() {
         let (_temp, manager) = create_task_vault().await;

--- a/crates/turbovault/tests/integration_test.rs
+++ b/crates/turbovault/tests/integration_test.rs
@@ -323,4 +323,47 @@ mod tests {
         );
         assert_eq!(t.id.as_deref(), Some("sprint-42"));
     }
+
+    #[tokio::test]
+    async fn test_list_tasks_mcp_tool() {
+        let (_temp, manager) = create_task_vault().await;
+
+        let files = manager.scan_vault().await.expect("scan vault");
+        let mut all_tasks: Vec<serde_json::Value> = Vec::new();
+
+        for file_path in files {
+            if !file_path.to_string_lossy().ends_with(".md") {
+                continue;
+            }
+            let vault_file = manager.parse_file(&file_path).await.expect("parse file");
+            for task in vault_file.tasks {
+                all_tasks.push(serde_json::json!({
+                    "content": task.content,
+                    "is_completed": task.is_completed,
+                    "path": file_path.to_string_lossy().to_string(),
+                    "priority": task.priority,
+                    "tags": task.tags,
+                }));
+            }
+        }
+
+        assert_eq!(all_tasks.len(), 8, "expected 8 tasks");
+
+        let find_task = |content: &str| {
+            all_tasks
+                .iter()
+                .find(|t| t["content"] == content)
+                .expect(&format!("task not found: {content}"))
+        };
+
+        let pending_task = find_task("Take out the trash");
+        assert_eq!(pending_task["is_completed"], false);
+
+        let completed_task = find_task("Submit expense report");
+        assert_eq!(completed_task["is_completed"], true);
+
+        let tag_task = find_task("Clean the kitchen #task_type_1");
+        let tags = tag_task["tags"].as_array().expect("tags array");
+        assert!(tags.iter().any(|t| t == "task_type_1"));
+    }
 }

--- a/crates/turbovault/tests/integration_test.rs
+++ b/crates/turbovault/tests/integration_test.rs
@@ -236,7 +236,7 @@ mod tests {
             Some("2026-04-30")
         );
 
-        let t = find("Clean the kitchen");
+        let t = find("Clean the kitchen #task_type_1");
         assert_eq!(t.priority, TaskPriority::Normal);
         assert_eq!(t.recurrence.as_deref(), Some("every week"));
         assert_eq!(
@@ -254,7 +254,7 @@ mod tests {
         assert_eq!(t.tags, vec!["task_type_1"]);
 
         // task_type_2 task also tests the double-space after 🛫 (🛫  2026-04-30)
-        let t = find("Clean the baseboards");
+        let t = find("Clean the baseboards #task_type_2");
         assert_eq!(t.priority, TaskPriority::Low);
         assert_eq!(t.recurrence.as_deref(), Some("every week"));
         assert_eq!(
@@ -273,7 +273,7 @@ mod tests {
 
         // --- Dataview format ---
 
-        let t = find("Buy groceries");
+        let t = find("Buy groceries #errands");
         assert!(!t.is_completed);
         assert_eq!(t.priority, TaskPriority::Medium);
         assert_eq!(

--- a/crates/turbovault/tests/integration_test.rs
+++ b/crates/turbovault/tests/integration_test.rs
@@ -577,6 +577,306 @@ mod tests {
         assert!(result.is_err(), "write with stale hash should fail");
     }
 
+    // ==================== complete_task Tests ====================
+
+    /// Simulate the complete_task tool: mark done + optionally spawn next occurrence.
+    /// Returns the next-occurrence line if recurrence was detected and handled.
+    async fn apply_task_complete(
+        manager: &VaultManager,
+        file_path: &PathBuf,
+        task_content: &str,
+        done: chrono::NaiveDate,
+    ) -> Option<String> {
+        let vault_file = manager.parse_file(file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == task_content)
+            .unwrap_or_else(|| panic!("task not found: {task_content:?}"))
+            .clone();
+
+        let content = manager.read_file(file_path).await.expect("read");
+        let hash = turbovault_vault::compute_hash(&content);
+        let line_sep = if content.contains("\r\n") {
+            "\r\n"
+        } else {
+            "\n"
+        };
+        let mut lines: Vec<String> = content.split(line_sep).map(|s| s.to_string()).collect();
+
+        let line_idx = task.position.line - 1;
+        let original = &lines[line_idx].clone();
+        let indent_len = original.len() - original.trim_start().len();
+        let indent = original[..indent_len].to_string();
+
+        task.is_completed = true;
+        task.done_date = Some(done);
+        lines[line_idx] = format!("{}{}", indent, task.to_markdown_line());
+
+        // Spawn next occurrence if recurring
+        let mut spawned_line: Option<String> = None;
+        if let Some(ref rec) = task.recurrence.clone() {
+            let reference = task.due_date.unwrap_or(done);
+            let next_due = match rec.as_str() {
+                s if s.contains("every day") => Some(reference + chrono::Duration::days(1)),
+                s if s.contains("every week") => Some(reference + chrono::Duration::days(7)),
+                _ => None,
+            };
+            if let Some(nd) = next_due {
+                let offset = nd.signed_duration_since(reference);
+                let mut next = task.clone();
+                next.is_completed = false;
+                next.done_date = None;
+                next.due_date = Some(nd);
+                next.scheduled_date = task.scheduled_date.map(|d| d + offset);
+                next.start_date = task.start_date.map(|d| d + offset);
+                let line = format!("{}{}", indent, next.to_markdown_line());
+                lines.insert(line_idx + 1, line.clone());
+                spawned_line = Some(line);
+            }
+        }
+
+        let new_content = lines.join(line_sep);
+        manager
+            .write_file(file_path, &new_content, Some(&hash))
+            .await
+            .expect("write");
+
+        spawned_line
+    }
+
+    #[tokio::test]
+    async fn test_complete_task_spawns_next_occurrence() {
+        use chrono::NaiveDate;
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        // Verify initial state
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        assert_eq!(vault_file.tasks.len(), 8);
+        let task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Feed the cat")
+            .expect("find task");
+        assert!(!task.is_completed);
+        assert_eq!(task.recurrence.as_deref(), Some("every day"));
+        assert_eq!(
+            task.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+
+        let done = NaiveDate::from_ymd_opt(2026, 5, 2).unwrap();
+        let next_line = apply_task_complete(&manager, &file_path, "Feed the cat", done).await;
+
+        assert!(
+            next_line.is_some(),
+            "expected next occurrence to be spawned"
+        );
+
+        // Re-parse: should now have 9 tasks (completed + spawned)
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        assert_eq!(
+            vault_file2.tasks.len(),
+            9,
+            "expected 9 tasks after spawning next occurrence"
+        );
+
+        // Completed instance
+        let completed = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Feed the cat" && t.is_completed)
+            .expect("completed task");
+        assert_eq!(
+            completed.done_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-02")
+        );
+
+        // Spawned pending instance — due date advances by 1 day from 2026-04-30
+        let spawned = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Feed the cat" && !t.is_completed)
+            .expect("spawned next occurrence");
+        assert!(!spawned.is_completed);
+        assert_eq!(
+            spawned.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-01")
+        );
+        assert_eq!(spawned.recurrence.as_deref(), Some("every day"));
+        assert_eq!(spawned.priority, TaskPriority::High);
+    }
+
+    #[tokio::test]
+    async fn test_complete_task_no_recurrence_preserves_count() {
+        use chrono::NaiveDate;
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let count_before = vault_file.tasks.len();
+
+        let task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Buy groceries #errands")
+            .expect("find task");
+        assert!(task.recurrence.is_none());
+
+        let done = NaiveDate::from_ymd_opt(2026, 5, 2).unwrap();
+        let next_line =
+            apply_task_complete(&manager, &file_path, "Buy groceries #errands", done).await;
+
+        assert!(
+            next_line.is_none(),
+            "non-recurring task should not spawn next occurrence"
+        );
+
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        assert_eq!(
+            vault_file2.tasks.len(),
+            count_before,
+            "task count should not change for non-recurring tasks"
+        );
+
+        let updated = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Buy groceries #errands")
+            .expect("find updated");
+        assert!(updated.is_completed);
+        assert_eq!(
+            updated.done_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-02")
+        );
+    }
+
+    // ==================== get_overdue_tasks Tests ====================
+
+    /// Collect overdue tasks as of a given date — mirrors get_overdue_tasks logic.
+    async fn collect_overdue(
+        manager: &VaultManager,
+        as_of: chrono::NaiveDate,
+    ) -> Vec<(String, chrono::NaiveDate)> {
+        let files = manager.scan_vault().await.expect("scan");
+        let mut overdue: Vec<(String, chrono::NaiveDate)> = Vec::new();
+        for file_path in &files {
+            if !file_path.to_string_lossy().ends_with(".md") {
+                continue;
+            }
+            let vault_file = match manager.parse_file(file_path).await {
+                Ok(vf) => vf,
+                Err(_) => continue,
+            };
+            for task in vault_file.tasks {
+                if task.is_completed {
+                    continue;
+                }
+                if let Some(due) = task.due_date {
+                    if due < as_of {
+                        overdue.push((task.content, due));
+                    }
+                }
+            }
+        }
+        overdue.sort_by_key(|(_, d)| *d);
+        overdue
+    }
+
+    #[tokio::test]
+    async fn test_get_overdue_tasks_as_of_date() {
+        use chrono::NaiveDate;
+        let (_temp, manager) = create_task_vault().await;
+
+        let as_of = NaiveDate::from_ymd_opt(2026, 5, 2).unwrap();
+        let overdue = collect_overdue(&manager, as_of).await;
+
+        // Pending tasks with due_date < 2026-05-02:
+        //   "Take out the trash"          due 2026-04-30
+        //   "Feed the cat"                due 2026-04-30
+        //   "Clean the kitchen #..."      due 2026-04-30
+        //   "Clean the baseboards #..."   due 2026-04-30
+        //   "Buy groceries #errands"      due 2026-05-01
+        let contents: Vec<&str> = overdue.iter().map(|(c, _)| c.as_str()).collect();
+        assert_eq!(
+            overdue.len(),
+            5,
+            "expected 5 overdue tasks as of {as_of}, got: {contents:?}"
+        );
+        assert!(
+            contents.iter().any(|c| *c == "Take out the trash"),
+            "missing 'Take out the trash'"
+        );
+        assert!(
+            contents.iter().any(|c| *c == "Feed the cat"),
+            "missing 'Feed the cat'"
+        );
+        assert!(
+            contents
+                .iter()
+                .any(|c| *c == "Clean the kitchen #task_type_1"),
+            "missing 'Clean the kitchen #task_type_1'"
+        );
+        assert!(
+            contents
+                .iter()
+                .any(|c| *c == "Clean the baseboards #task_type_2"),
+            "missing 'Clean the baseboards #task_type_2'"
+        );
+        assert!(
+            contents.iter().any(|c| *c == "Buy groceries #errands"),
+            "missing 'Buy groceries #errands'"
+        );
+
+        // Completed or future-due tasks must NOT appear
+        assert!(
+            !contents.iter().any(|c| *c == "Submit expense report"),
+            "completed task should not be overdue"
+        );
+        assert!(
+            !contents.iter().any(|c| *c == "Write weekly report"),
+            "future task (due 2026-05-10) should not be overdue as of {as_of}"
+        );
+        assert!(
+            !contents.iter().any(|c| *c == "Plan sprint"),
+            "future task (due 2026-05-07) should not be overdue as of {as_of}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_overdue_tasks_empty_before_all_due_dates() {
+        use chrono::NaiveDate;
+        let (_temp, manager) = create_task_vault().await;
+
+        // All tasks in TASKS_MD have due dates in April–May 2026; nothing is overdue in January
+        let as_of = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+        let overdue = collect_overdue(&manager, as_of).await;
+
+        assert!(
+            overdue.is_empty(),
+            "expected no overdue tasks as of {as_of}, got: {:?}",
+            overdue
+                .iter()
+                .map(|(c, d)| format!("{c} (due {d})"))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_overdue_tasks_sorted_oldest_first() {
+        use chrono::NaiveDate;
+        let (_temp, manager) = create_task_vault().await;
+
+        let as_of = NaiveDate::from_ymd_opt(2026, 5, 2).unwrap();
+        let overdue = collect_overdue(&manager, as_of).await;
+
+        let dates: Vec<_> = overdue.iter().map(|(_, d)| *d).collect();
+        let mut sorted = dates.clone();
+        sorted.sort();
+        assert_eq!(dates, sorted, "overdue tasks should be sorted oldest-first");
+    }
+
     #[tokio::test]
     async fn test_list_tasks_mcp_tool() {
         let (_temp, manager) = create_task_vault().await;

--- a/crates/turbovault/tests/integration_test.rs
+++ b/crates/turbovault/tests/integration_test.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use tempfile::TempDir;
     use tokio::fs;
     use turbovault::ObsidianMcpServer;
@@ -236,7 +236,7 @@ mod tests {
             Some("2026-04-30")
         );
 
-        let t = find("Clean the kitchen");
+        let t = find("Clean the kitchen #task_type_1");
         assert_eq!(t.priority, TaskPriority::Normal);
         assert_eq!(t.recurrence.as_deref(), Some("every week"));
         assert_eq!(
@@ -254,7 +254,7 @@ mod tests {
         assert_eq!(t.tags, vec!["task_type_1"]);
 
         // task_type_2 task also tests the double-space after 🛫 (🛫  2026-04-30)
-        let t = find("Clean the baseboards");
+        let t = find("Clean the baseboards #task_type_2");
         assert_eq!(t.priority, TaskPriority::Low);
         assert_eq!(t.recurrence.as_deref(), Some("every week"));
         assert_eq!(
@@ -273,7 +273,7 @@ mod tests {
 
         // --- Dataview format ---
 
-        let t = find("Buy groceries");
+        let t = find("Buy groceries #errands");
         assert!(!t.is_completed);
         assert_eq!(t.priority, TaskPriority::Medium);
         assert_eq!(
@@ -322,5 +322,911 @@ mod tests {
             Some("2026-05-07")
         );
         assert_eq!(t.id.as_deref(), Some("sprint-42"));
+    }
+
+    // ==================== update_task Tests ====================
+
+    /// Helper: replace a specific 1-indexed line in file content and write it back.
+    /// Mirrors the logic in the update_task MCP tool.
+    async fn apply_task_update(
+        manager: &VaultManager,
+        file_path: &Path,
+        task: &turbovault_core::TaskItem,
+    ) {
+        let content = manager.read_file(file_path).await.expect("read file");
+        let hash = turbovault_vault::compute_hash(&content);
+
+        let line_sep = if content.contains("\r\n") {
+            "\r\n"
+        } else {
+            "\n"
+        };
+        let mut lines: Vec<String> = if line_sep == "\r\n" {
+            content.split("\r\n").map(|s| s.to_string()).collect()
+        } else {
+            content.split('\n').map(|s| s.to_string()).collect()
+        };
+
+        let line_idx = task.position.line - 1; // 1-indexed → 0-indexed
+        let original = &lines[line_idx];
+        let indent_len = original.len() - original.trim_start().len();
+        let indent = original[..indent_len].to_string();
+        lines[line_idx] = format!("{}{}", indent, task.to_markdown_line());
+
+        let new_content = lines.join(line_sep);
+        manager
+            .write_file(file_path, &new_content, Some(&hash))
+            .await
+            .expect("write file");
+    }
+
+    #[tokio::test]
+    async fn test_update_task_mark_complete() {
+        use chrono::NaiveDate;
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        // Find the task we want to update
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Take out the trash")
+            .expect("find task")
+            .clone();
+
+        assert!(!task.is_completed);
+        assert!(task.done_date.is_none());
+
+        // Mutate
+        task.is_completed = true;
+        task.done_date = NaiveDate::from_ymd_opt(2026, 5, 2);
+
+        apply_task_update(&manager, &file_path, &task).await;
+
+        // Re-parse and verify
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        let updated = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Take out the trash")
+            .expect("find updated task");
+
+        assert!(updated.is_completed);
+        assert_eq!(
+            updated.done_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-02")
+        );
+        // Dates from the original task should be preserved
+        assert_eq!(
+            updated.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_task_change_priority() {
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Feed the cat")
+            .expect("find task")
+            .clone();
+
+        assert_eq!(task.priority, TaskPriority::High);
+
+        task.priority = TaskPriority::Lowest;
+        apply_task_update(&manager, &file_path, &task).await;
+
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        let updated = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Feed the cat")
+            .expect("find updated task");
+
+        assert_eq!(updated.priority, TaskPriority::Lowest);
+        // Other fields should be unchanged
+        assert_eq!(updated.recurrence.as_deref(), Some("every day"));
+        assert!(!updated.is_completed);
+    }
+
+    #[tokio::test]
+    async fn test_update_task_add_and_remove_tags() {
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Clean the kitchen #task_type_1")
+            .expect("find task")
+            .clone();
+
+        assert!(task.tags.iter().any(|t| t == "task_type_1"));
+
+        // Add a new tag and remove the existing one
+        let bare = "urgent";
+        task.content.push(' ');
+        task.content.push('#');
+        task.content.push_str(bare);
+        task.tags.push(bare.to_string());
+
+        // Remove task_type_1
+        let remove = "task_type_1";
+        let pattern = format!("#{}", remove);
+        let lower = task.content.to_lowercase();
+        if let Some(pos) = lower.find(&pattern) {
+            let end = pos + pattern.len();
+            let start = if pos > 0 && task.content.as_bytes().get(pos - 1) == Some(&b' ') {
+                pos - 1
+            } else {
+                pos
+            };
+            task.content.drain(start..end);
+            task.content = task.content.trim_end().to_string();
+            task.tags.retain(|t| t != remove);
+        }
+
+        apply_task_update(&manager, &file_path, &task).await;
+
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        let updated = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.tags.iter().any(|tag| tag == "urgent"))
+            .expect("find updated task");
+
+        assert!(updated.tags.iter().any(|t| t == "urgent"));
+        assert!(!updated.tags.iter().any(|t| t == "task_type_1"));
+    }
+
+    #[tokio::test]
+    async fn test_update_task_dataview_format_preserved() {
+        use chrono::NaiveDate;
+        use turbovault_core::TaskMetadataFormat;
+
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Buy groceries #errands")
+            .expect("find task")
+            .clone();
+
+        // Confirm parser detected dataview format
+        assert_eq!(task.metadata_format, TaskMetadataFormat::Dataview);
+
+        // Update the due date
+        task.due_date = NaiveDate::from_ymd_opt(2026, 6, 1);
+
+        apply_task_update(&manager, &file_path, &task).await;
+
+        // Read raw content to confirm dataview notation was used
+        let new_content = manager.read_file(&file_path).await.expect("read");
+        assert!(
+            new_content.contains("[due:: 2026-06-01]"),
+            "expected dataview [due:: ...] notation in: {new_content}"
+        );
+        assert!(
+            !new_content.contains("📅 2026-06-01"),
+            "unexpected emoji notation in dataview task"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_task_clear_due_date() {
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Take out the trash")
+            .expect("find task")
+            .clone();
+
+        assert!(task.due_date.is_some());
+
+        task.due_date = None;
+        apply_task_update(&manager, &file_path, &task).await;
+
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        let updated = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Take out the trash")
+            .expect("find updated task");
+
+        assert!(
+            updated.due_date.is_none(),
+            "due_date should have been cleared"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_task_description() {
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Buy groceries #errands")
+            .expect("find task")
+            .clone();
+
+        // Change the description — inline tags in new content should be re-indexed
+        task.content = "Buy oat milk and eggs #errands #urgent".to_string();
+        task.tags = vec!["errands".to_string(), "urgent".to_string()];
+        apply_task_update(&manager, &file_path, &task).await;
+
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        let updated = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Buy oat milk and eggs #errands #urgent")
+            .expect("find updated task");
+
+        assert_eq!(updated.content, "Buy oat milk and eggs #errands #urgent");
+        assert!(updated.tags.iter().any(|t| t == "errands"));
+        assert!(updated.tags.iter().any(|t| t == "urgent"));
+        // Metadata from the original task should be preserved
+        assert_eq!(
+            updated.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-01")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_task_hash_guard_rejects_stale_write() {
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        // Read the file and capture hash
+        let content = manager.read_file(&file_path).await.expect("read");
+        let stale_hash = turbovault_vault::compute_hash(&content);
+
+        // Modify the file so the hash becomes stale
+        let modified = format!("{}\n<!-- touched -->", content);
+        manager
+            .write_file(&file_path, &modified, None)
+            .await
+            .expect("first write");
+
+        // Attempt to write with the now-stale hash — should fail
+        let result = manager
+            .write_file(&file_path, &modified, Some(&stale_hash))
+            .await;
+
+        assert!(result.is_err(), "write with stale hash should fail");
+    }
+
+    // ==================== complete_task Tests ====================
+
+    /// Simulate the complete_task tool: mark done + optionally spawn next occurrence.
+    /// Returns the next-occurrence line if recurrence was detected and handled.
+    async fn apply_task_complete(
+        manager: &VaultManager,
+        file_path: &Path,
+        task_content: &str,
+        done: chrono::NaiveDate,
+    ) -> Option<String> {
+        let vault_file = manager.parse_file(file_path).await.expect("parse");
+        let mut task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == task_content)
+            .unwrap_or_else(|| panic!("task not found: {task_content:?}"))
+            .clone();
+
+        let content = manager.read_file(file_path).await.expect("read");
+        let hash = turbovault_vault::compute_hash(&content);
+        let line_sep = if content.contains("\r\n") {
+            "\r\n"
+        } else {
+            "\n"
+        };
+        let mut lines: Vec<String> = content.split(line_sep).map(|s| s.to_string()).collect();
+
+        let line_idx = task.position.line - 1;
+        let original = &lines[line_idx].clone();
+        let indent_len = original.len() - original.trim_start().len();
+        let indent = original[..indent_len].to_string();
+
+        task.is_completed = true;
+        task.done_date = Some(done);
+        lines[line_idx] = format!("{}{}", indent, task.to_markdown_line());
+
+        // Spawn next occurrence if recurring
+        let mut spawned_line: Option<String> = None;
+        if let Some(ref rec) = task.recurrence.clone() {
+            let reference = task.due_date.unwrap_or(done);
+            let next_due = match rec.as_str() {
+                s if s.contains("every day") => Some(reference + chrono::Duration::days(1)),
+                s if s.contains("every week") => Some(reference + chrono::Duration::days(7)),
+                _ => None,
+            };
+            if let Some(nd) = next_due {
+                let offset = nd.signed_duration_since(reference);
+                let mut next = task.clone();
+                next.is_completed = false;
+                next.done_date = None;
+                next.due_date = Some(nd);
+                next.scheduled_date = task.scheduled_date.map(|d| d + offset);
+                next.start_date = task.start_date.map(|d| d + offset);
+                let line = format!("{}{}", indent, next.to_markdown_line());
+                lines.insert(line_idx + 1, line.clone());
+                spawned_line = Some(line);
+            }
+        }
+
+        let new_content = lines.join(line_sep);
+        manager
+            .write_file(file_path, &new_content, Some(&hash))
+            .await
+            .expect("write");
+
+        spawned_line
+    }
+
+    #[tokio::test]
+    async fn test_complete_task_spawns_next_occurrence() {
+        use chrono::NaiveDate;
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        // Verify initial state
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        assert_eq!(vault_file.tasks.len(), 8);
+        let task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Feed the cat")
+            .expect("find task");
+        assert!(!task.is_completed);
+        assert_eq!(task.recurrence.as_deref(), Some("every day"));
+        assert_eq!(
+            task.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-04-30")
+        );
+
+        let done = NaiveDate::from_ymd_opt(2026, 5, 2).unwrap();
+        let next_line = apply_task_complete(&manager, &file_path, "Feed the cat", done).await;
+
+        assert!(
+            next_line.is_some(),
+            "expected next occurrence to be spawned"
+        );
+
+        // Re-parse: should now have 9 tasks (completed + spawned)
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        assert_eq!(
+            vault_file2.tasks.len(),
+            9,
+            "expected 9 tasks after spawning next occurrence"
+        );
+
+        // Completed instance
+        let completed = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Feed the cat" && t.is_completed)
+            .expect("completed task");
+        assert_eq!(
+            completed.done_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-02")
+        );
+
+        // Spawned pending instance — due date advances by 1 day from 2026-04-30
+        let spawned = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Feed the cat" && !t.is_completed)
+            .expect("spawned next occurrence");
+        assert!(!spawned.is_completed);
+        assert_eq!(
+            spawned.due_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-01")
+        );
+        assert_eq!(spawned.recurrence.as_deref(), Some("every day"));
+        assert_eq!(spawned.priority, TaskPriority::High);
+    }
+
+    #[tokio::test]
+    async fn test_complete_task_no_recurrence_preserves_count() {
+        use chrono::NaiveDate;
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let count_before = vault_file.tasks.len();
+
+        let task = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Buy groceries #errands")
+            .expect("find task");
+        assert!(task.recurrence.is_none());
+
+        let done = NaiveDate::from_ymd_opt(2026, 5, 2).unwrap();
+        let next_line =
+            apply_task_complete(&manager, &file_path, "Buy groceries #errands", done).await;
+
+        assert!(
+            next_line.is_none(),
+            "non-recurring task should not spawn next occurrence"
+        );
+
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        assert_eq!(
+            vault_file2.tasks.len(),
+            count_before,
+            "task count should not change for non-recurring tasks"
+        );
+
+        let updated = vault_file2
+            .tasks
+            .iter()
+            .find(|t| t.content == "Buy groceries #errands")
+            .expect("find updated");
+        assert!(updated.is_completed);
+        assert_eq!(
+            updated.done_date.map(|d| d.to_string()).as_deref(),
+            Some("2026-05-02")
+        );
+    }
+
+    // ==================== get_overdue_tasks Tests ====================
+
+    /// Collect overdue tasks as of a given date — mirrors get_overdue_tasks logic.
+    async fn collect_overdue(
+        manager: &VaultManager,
+        as_of: chrono::NaiveDate,
+    ) -> Vec<(String, chrono::NaiveDate)> {
+        let files = manager.scan_vault().await.expect("scan");
+        let mut overdue: Vec<(String, chrono::NaiveDate)> = Vec::new();
+        for file_path in &files {
+            if !file_path.to_string_lossy().ends_with(".md") {
+                continue;
+            }
+            let vault_file = match manager.parse_file(file_path).await {
+                Ok(vf) => vf,
+                Err(_) => continue,
+            };
+            for task in vault_file.tasks {
+                if task.is_completed {
+                    continue;
+                }
+                if let Some(due) = task.due_date
+                    && due < as_of
+                {
+                    overdue.push((task.content, due));
+                }
+            }
+        }
+        overdue.sort_by_key(|(_, d)| *d);
+        overdue
+    }
+
+    #[tokio::test]
+    async fn test_get_overdue_tasks_as_of_date() {
+        use chrono::NaiveDate;
+        let (_temp, manager) = create_task_vault().await;
+
+        let as_of = NaiveDate::from_ymd_opt(2026, 5, 2).unwrap();
+        let overdue = collect_overdue(&manager, as_of).await;
+
+        // Pending tasks with due_date < 2026-05-02:
+        //   "Take out the trash"          due 2026-04-30
+        //   "Feed the cat"                due 2026-04-30
+        //   "Clean the kitchen #..."      due 2026-04-30
+        //   "Clean the baseboards #..."   due 2026-04-30
+        //   "Buy groceries #errands"      due 2026-05-01
+        let contents: Vec<&str> = overdue.iter().map(|(c, _)| c.as_str()).collect();
+        assert_eq!(
+            overdue.len(),
+            5,
+            "expected 5 overdue tasks as of {as_of}, got: {contents:?}"
+        );
+        assert!(
+            contents.contains(&"Take out the trash"),
+            "missing 'Take out the trash'"
+        );
+        assert!(contents.contains(&"Feed the cat"), "missing 'Feed the cat'");
+        assert!(
+            contents.contains(&"Clean the kitchen #task_type_1"),
+            "missing 'Clean the kitchen #task_type_1'"
+        );
+        assert!(
+            contents.contains(&"Clean the baseboards #task_type_2"),
+            "missing 'Clean the baseboards #task_type_2'"
+        );
+        assert!(
+            contents.contains(&"Buy groceries #errands"),
+            "missing 'Buy groceries #errands'"
+        );
+
+        // Completed or future-due tasks must NOT appear
+        assert!(
+            !contents.contains(&"Submit expense report"),
+            "completed task should not be overdue"
+        );
+        assert!(
+            !contents.contains(&"Write weekly report"),
+            "future task (due 2026-05-10) should not be overdue as of {as_of}"
+        );
+        assert!(
+            !contents.contains(&"Plan sprint"),
+            "future task (due 2026-05-07) should not be overdue as of {as_of}"
+        );
+        assert!(contents.contains(&"Feed the cat"), "missing 'Feed the cat'");
+        assert!(
+            contents.contains(&"Clean the kitchen #task_type_1"),
+            "missing 'Clean the kitchen #task_type_1'"
+        );
+        assert!(
+            contents.contains(&"Clean the baseboards #task_type_2"),
+            "missing 'Clean the baseboards #task_type_2'"
+        );
+        assert!(
+            contents.contains(&"Buy groceries #errands"),
+            "missing 'Buy groceries #errands'"
+        );
+
+        // Completed or future-due tasks must NOT appear
+        assert!(
+            !contents.contains(&"Submit expense report"),
+            "completed task should not be overdue"
+        );
+        assert!(
+            !contents.contains(&"Write weekly report"),
+            "future task (due 2026-05-10) should not be overdue as of {as_of}"
+        );
+        assert!(
+            !contents.contains(&"Plan sprint"),
+            "future task (due 2026-05-07) should not be overdue as of {as_of}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_overdue_tasks_empty_before_all_due_dates() {
+        use chrono::NaiveDate;
+        let (_temp, manager) = create_task_vault().await;
+
+        // All tasks in TASKS_MD have due dates in April–May 2026; nothing is overdue in January
+        let as_of = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+        let overdue = collect_overdue(&manager, as_of).await;
+
+        assert!(
+            overdue.is_empty(),
+            "expected no overdue tasks as of {as_of}, got: {:?}",
+            overdue
+                .iter()
+                .map(|(c, d)| format!("{c} (due {d})"))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_overdue_tasks_sorted_oldest_first() {
+        use chrono::NaiveDate;
+        let (_temp, manager) = create_task_vault().await;
+
+        let as_of = NaiveDate::from_ymd_opt(2026, 5, 2).unwrap();
+        let overdue = collect_overdue(&manager, as_of).await;
+
+        let dates: Vec<_> = overdue.iter().map(|(_, d)| *d).collect();
+        let mut sorted = dates.clone();
+        sorted.sort();
+        assert_eq!(dates, sorted, "overdue tasks should be sorted oldest-first");
+    }
+
+    #[tokio::test]
+    async fn test_list_tasks_mcp_tool() {
+        let (_temp, manager) = create_task_vault().await;
+
+        let files = manager.scan_vault().await.expect("scan vault");
+        let mut all_tasks: Vec<serde_json::Value> = Vec::new();
+
+        for file_path in files {
+            if !file_path.to_string_lossy().ends_with(".md") {
+                continue;
+            }
+            let vault_file = manager.parse_file(&file_path).await.expect("parse file");
+            for task in vault_file.tasks {
+                all_tasks.push(serde_json::json!({
+                    "content": task.content,
+                    "is_completed": task.is_completed,
+                    "path": file_path.to_string_lossy().to_string(),
+                    "priority": task.priority,
+                    "tags": task.tags,
+                }));
+            }
+        }
+
+        assert_eq!(all_tasks.len(), 8, "expected 8 tasks");
+
+        let find_task = |content: &str| {
+            all_tasks
+                .iter()
+                .find(|t| t["content"] == content)
+                .unwrap_or_else(|| panic!("task not found: {content}"))
+        };
+
+        let pending_task = find_task("Take out the trash");
+        assert_eq!(pending_task["is_completed"], false);
+
+        let completed_task = find_task("Submit expense report");
+        assert_eq!(completed_task["is_completed"], true);
+
+        let tag_task = find_task("Clean the kitchen #task_type_1");
+        let tags = tag_task["tags"].as_array().expect("tags array");
+        assert!(tags.iter().any(|t| t == "task_type_1"));
+    }
+
+    /// Collect tasks from the vault, applying the same status+tag filter logic as list_tasks.
+    async fn collect_tasks_filtered(
+        manager: &VaultManager,
+        status_filter: Option<&str>,
+        tag_filters: &[&str],
+    ) -> Vec<turbovault_core::TaskItem> {
+        let status = status_filter.unwrap_or("all").to_lowercase();
+        let normalized_tags: Vec<String> = tag_filters
+            .iter()
+            .map(|t| t.trim_start_matches('#').to_lowercase())
+            .collect();
+
+        let files = manager.scan_vault().await.expect("scan vault");
+        let mut results = Vec::new();
+        for file_path in files {
+            if !file_path.to_string_lossy().ends_with(".md") {
+                continue;
+            }
+            let vault_file = match manager.parse_file(&file_path).await {
+                Ok(vf) => vf,
+                Err(_) => continue,
+            };
+            for task in vault_file.tasks {
+                let passes_status = match status.as_str() {
+                    "completed" | "done" => task.is_completed,
+                    "pending" | "open" | "todo" | "incomplete" => !task.is_completed,
+                    _ => true,
+                };
+                if !passes_status {
+                    continue;
+                }
+                let passes_tags = normalized_tags.is_empty()
+                    || normalized_tags
+                        .iter()
+                        .all(|req| task.tags.iter().any(|t| t.eq_ignore_ascii_case(req)));
+                if passes_tags {
+                    results.push(task);
+                }
+            }
+        }
+        results
+    }
+
+    #[tokio::test]
+    async fn test_list_tasks_status_filter_pending() {
+        let (_temp, manager) = create_task_vault().await;
+        let tasks = collect_tasks_filtered(&manager, Some("pending"), &[]).await;
+        assert_eq!(tasks.len(), 7, "expected 7 pending tasks");
+        assert!(
+            tasks.iter().all(|t| !t.is_completed),
+            "all returned tasks should be pending"
+        );
+        // The one completed task must not appear
+        assert!(
+            tasks.iter().all(|t| t.content != "Submit expense report"),
+            "completed task must not appear in pending filter"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_tasks_status_filter_completed() {
+        let (_temp, manager) = create_task_vault().await;
+        let tasks = collect_tasks_filtered(&manager, Some("completed"), &[]).await;
+        assert_eq!(tasks.len(), 1, "expected 1 completed task");
+        assert_eq!(tasks[0].content, "Submit expense report");
+        assert!(tasks[0].is_completed);
+    }
+
+    #[tokio::test]
+    async fn test_list_tasks_status_filter_done_alias() {
+        // "done" is an accepted alias for "completed"
+        let (_temp, manager) = create_task_vault().await;
+        let tasks = collect_tasks_filtered(&manager, Some("done"), &[]).await;
+        assert_eq!(tasks.len(), 1);
+        assert!(tasks[0].is_completed);
+    }
+
+    #[tokio::test]
+    async fn test_list_tasks_tag_filter_single() {
+        let (_temp, manager) = create_task_vault().await;
+        let tasks = collect_tasks_filtered(&manager, None, &["errands"]).await;
+        assert_eq!(tasks.len(), 1, "expected 1 task tagged #errands");
+        assert_eq!(tasks[0].content, "Buy groceries #errands");
+    }
+
+    #[tokio::test]
+    async fn test_list_tasks_tag_filter_hash_prefix_normalized() {
+        // Passing "#errands" should produce the same result as "errands"
+        let (_temp, manager) = create_task_vault().await;
+        let tasks = collect_tasks_filtered(&manager, None, &["#errands"]).await;
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].content, "Buy groceries #errands");
+    }
+
+    #[tokio::test]
+    async fn test_list_tasks_tag_filter_and_logic() {
+        // No single task in the fixture has both errands AND task_type_1 — AND logic means 0 results
+        let (_temp, manager) = create_task_vault().await;
+        let tasks = collect_tasks_filtered(&manager, None, &["errands", "task_type_1"]).await;
+        assert!(
+            tasks.is_empty(),
+            "AND filter across disjoint tags should return no tasks"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_tasks_combined_status_and_tag_filter() {
+        let (_temp, manager) = create_task_vault().await;
+        let tasks = collect_tasks_filtered(&manager, Some("pending"), &["errands"]).await;
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].content, "Buy groceries #errands");
+        assert!(!tasks[0].is_completed);
+    }
+
+    // ==================== list_task_tags Tests ====================
+
+    async fn collect_all_task_tags(manager: &VaultManager) -> Vec<String> {
+        let files = manager.scan_vault().await.expect("scan vault");
+        let mut tag_set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for file_path in files {
+            if !file_path.to_string_lossy().ends_with(".md") {
+                continue;
+            }
+            let vault_file = match manager.parse_file(&file_path).await {
+                Ok(vf) => vf,
+                Err(_) => continue,
+            };
+            for task in vault_file.tasks {
+                for tag in task.tags {
+                    tag_set.insert(tag.to_lowercase());
+                }
+            }
+        }
+        tag_set.into_iter().collect()
+    }
+
+    #[tokio::test]
+    async fn test_list_task_tags_returns_deduplicated_sorted_tags() {
+        let (_temp, manager) = create_task_vault().await;
+        let tags = collect_all_task_tags(&manager).await;
+
+        // TASKS_MD has: #task_type_1, #task_type_2, #errands
+        assert!(tags.contains(&"errands".to_string()));
+        assert!(tags.contains(&"task_type_1".to_string()));
+        assert!(tags.contains(&"task_type_2".to_string()));
+
+        // Each tag should appear exactly once
+        let unique: std::collections::HashSet<_> = tags.iter().collect();
+        assert_eq!(tags.len(), unique.len(), "tags should be deduplicated");
+
+        // Should be sorted
+        let mut sorted = tags.clone();
+        sorted.sort();
+        assert_eq!(tags, sorted, "tags should be sorted");
+    }
+
+    #[tokio::test]
+    async fn test_list_task_tags_excludes_no_tag_tasks() {
+        let (_temp, manager) = create_task_vault().await;
+        let tags = collect_all_task_tags(&manager).await;
+        // "Take out the trash" and "Submit expense report" have no tags — they should not contribute empty strings
+        assert!(tags.iter().all(|t| !t.is_empty()));
+    }
+
+    // ==================== delete_task Tests ====================
+
+    #[tokio::test]
+    async fn test_delete_task_removes_line() {
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let count_before = vault_file.tasks.len();
+        let target = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Buy groceries #errands")
+            .expect("find target task")
+            .clone();
+        let target_line = target.position.line;
+
+        // Delete by removing the line directly (mirrors delete_task logic)
+        let content = manager.read_file(&file_path).await.expect("read");
+        let line_sep = if content.contains("\r\n") {
+            "\r\n"
+        } else {
+            "\n"
+        };
+        let mut lines: Vec<&str> = content.split(line_sep).collect();
+        lines.remove(target_line - 1);
+        let new_content = lines.join(line_sep);
+        manager
+            .write_file(&file_path, &new_content, None)
+            .await
+            .expect("write");
+
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        assert_eq!(
+            vault_file2.tasks.len(),
+            count_before - 1,
+            "task count should decrease by 1"
+        );
+        assert!(
+            vault_file2
+                .tasks
+                .iter()
+                .all(|t| t.content != "Buy groceries #errands"),
+            "deleted task must not appear in re-parsed file"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_task_preserves_other_tasks() {
+        let (_temp, manager) = create_task_vault().await;
+        let file_path = PathBuf::from("TestFolder/Tasks.md");
+
+        let vault_file = manager.parse_file(&file_path).await.expect("parse");
+        let target = vault_file
+            .tasks
+            .iter()
+            .find(|t| t.content == "Plan sprint")
+            .expect("find target task")
+            .clone();
+        let target_line = target.position.line;
+
+        let content = manager.read_file(&file_path).await.expect("read");
+        let line_sep = if content.contains("\r\n") {
+            "\r\n"
+        } else {
+            "\n"
+        };
+        let mut lines: Vec<&str> = content.split(line_sep).collect();
+        lines.remove(target_line - 1);
+        let new_content = lines.join(line_sep);
+        manager
+            .write_file(&file_path, &new_content, None)
+            .await
+            .expect("write");
+
+        let vault_file2 = manager.parse_file(&file_path).await.expect("re-parse");
+        // Other tasks must still be present
+        assert!(
+            vault_file2
+                .tasks
+                .iter()
+                .any(|t| t.content == "Feed the cat")
+        );
+        assert!(
+            vault_file2
+                .tasks
+                .iter()
+                .any(|t| t.content == "Submit expense report")
+        );
     }
 }

--- a/crates/turbovault/tests/test_tool_visibility_integration.rs
+++ b/crates/turbovault/tests/test_tool_visibility_integration.rs
@@ -1,0 +1,154 @@
+//! Integration tests for tool visibility filtering applied to ObsidianMcpServer.
+//!
+//! These tests exercise ToolVisibilitySettings -> VisibilityLayer end-to-end
+//! without starting a network server.
+
+use turbomcp::{McpHandler, RequestContext, VisibilityLayer};
+use turbovault::ObsidianMcpServer;
+use turbovault::tool_visibility::ToolVisibilitySettings;
+
+fn make_server() -> ObsidianMcpServer {
+    ObsidianMcpServer::new().expect("server creation must not fail without a vault")
+}
+
+fn ctx() -> RequestContext {
+    RequestContext::new()
+}
+
+fn tool_names(layer: &impl McpHandler) -> Vec<String> {
+    layer.list_tools().into_iter().map(|t| t.name).collect()
+}
+
+#[tokio::test]
+async fn visibility_layer_empty_settings_exposes_all_tools() {
+    let layer =
+        ToolVisibilitySettings::default().apply_to_layer(VisibilityLayer::new(make_server()));
+    let names = tool_names(&layer);
+    // A minimal set of expected tools — confirm nothing was accidentally hidden.
+    for expected in &[
+        "read_note",
+        "write_note",
+        "delete_note",
+        "search",
+        "audit_log",
+    ] {
+        assert!(
+            names.contains(&expected.to_string()),
+            "expected tool {expected:?} to be listed with empty settings"
+        );
+    }
+}
+
+#[tokio::test]
+async fn visibility_layer_disabled_name_blocks_tool() {
+    let settings = ToolVisibilitySettings {
+        disabled: vec!["delete_note".to_string()],
+        ..Default::default()
+    };
+    let layer = settings.apply_to_layer(VisibilityLayer::new(make_server()));
+
+    // Not in list.
+    assert!(!tool_names(&layer).contains(&"delete_note".to_string()));
+
+    // Direct call is rejected with ToolNotFound (-32001).
+    let err = layer
+        .call_tool("delete_note", serde_json::json!({"path": "x.md"}), &ctx())
+        .await
+        .expect_err("disabled tool must not be callable");
+    assert_eq!(
+        err.jsonrpc_code(),
+        -32001,
+        "expected ToolNotFound error code"
+    );
+}
+
+#[tokio::test]
+async fn visibility_layer_hidden_name_omits_from_list_but_allows_call() {
+    let settings = ToolVisibilitySettings {
+        hidden: vec!["full_health_analysis".to_string()],
+        ..Default::default()
+    };
+    let layer = settings.apply_to_layer(VisibilityLayer::new(make_server()));
+
+    // Hidden from listing.
+    assert!(
+        !tool_names(&layer).contains(&"full_health_analysis".to_string()),
+        "hidden tool must not appear in list_tools"
+    );
+
+    // But still callable — it returns a vault-not-found error, not ToolNotFound.
+    let result = layer
+        .call_tool("full_health_analysis", serde_json::json!({}), &ctx())
+        .await;
+    match result {
+        Ok(_) => {}
+        Err(e) => {
+            // Any error except ToolNotFound is acceptable; ToolNotFound (-32001) would
+            // mean the layer is incorrectly blocking a merely-hidden tool.
+            assert_ne!(
+                e.jsonrpc_code(),
+                -32001,
+                "hidden tool must not return ToolNotFound; got: {e}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn visibility_layer_disabled_tags_blocks_all_tagged_tools() {
+    let settings = ToolVisibilitySettings {
+        disabled_tags: vec!["delete".to_string()],
+        ..Default::default()
+    };
+    let layer = settings.apply_to_layer(VisibilityLayer::new(make_server()));
+
+    // delete_note carries the "delete" tag and must be absent.
+    let names = tool_names(&layer);
+    assert!(
+        !names.contains(&"delete_note".to_string()),
+        "delete_note must be absent when tag 'delete' is disabled"
+    );
+    // Non-delete tools must still be present.
+    assert!(
+        names.contains(&"read_note".to_string()),
+        "read_note must remain visible when only 'delete' tag is disabled"
+    );
+
+    // Direct calls must be rejected.
+    let err = layer
+        .call_tool("delete_note", serde_json::json!({"path": "x.md"}), &ctx())
+        .await
+        .expect_err("tag-disabled tool must not be callable");
+    assert_eq!(err.jsonrpc_code(), -32001);
+}
+
+#[tokio::test]
+async fn visibility_layer_require_read_only_hides_write_tools() {
+    let settings = ToolVisibilitySettings {
+        require_read_only: true,
+        ..Default::default()
+    };
+    let layer = settings.apply_to_layer(VisibilityLayer::new(make_server()));
+
+    let names = tool_names(&layer);
+
+    // Read-only tools should still appear.
+    assert!(
+        names.contains(&"read_note".to_string()),
+        "read_only tool read_note must remain visible"
+    );
+    assert!(
+        names.contains(&"search".to_string()),
+        "read_only tool search must remain visible"
+    );
+
+    // Write tools (destructive=true / read_only not set) must be hidden.
+    assert!(
+        !names.contains(&"write_note".to_string()),
+        "write_note must be hidden under require_read_only"
+    );
+    assert!(
+        !names.contains(&"delete_note".to_string()),
+        "delete_note must be hidden under require_read_only"
+    );
+}


### PR DESCRIPTION
## Summary

This PR exposes a complete task management interface over MCP, allowing AI agents to list, query, update, and complete Obsidian tasks without touching note structure. It also lays the groundwork for future task tools with a shared write infrastructure that handles hash-gated atomic writes and round-trip markdown serialization.

### New MCP tools

| Tool | What it does |
|------|-------------|
| `list_tasks` | Scan all notes and return tasks with full metadata; filter by status and/or tags |
| `update_task` | Patch any combination of fields on a single task in-place (priority, dates, recurrence, tags, content) |
| `complete_task` | Mark a task done, stamp `done_date`, and spawn the next occurrence for recurring tasks |
| `get_overdue_tasks` | Return all pending tasks whose `due_date` is before today, sorted oldest-first |
| `delete_task` |delete a task based on task id or file + position. This deletes the actual line from the markdown. |

### Supporting infrastructure

**`TaskMetadataFormat` (new type in `turbovault-core`)** — detected at parse time, stored on `TaskItem`, used to round-trip writes without silently converting between emoji (`📅 2026-05-01`) and Dataview (`[due:: 2026-05-01]`) notation.

**`TaskItem::to_markdown_line()` (new method)** — serializes a `TaskItem` back to a canonical Obsidian Tasks markdown line in whichever format was detected. Field order follows Obsidian Tasks convention: `content priority 🔁 🛫 ⏳ 📅 ✅ ❌`.

**`read_task_for_update()` (shared free function in `tools.rs`)** — consolidates the boilerplate shared by `update_task` and `complete_task`: read file → validate hash → split lines (preserving `\r\n` vs `\n`) → bounds-check position → sanity-check checkbox → extract indentation → parse file → locate task. Keeps each tool's body focused on its actual logic.

**`compute_next_occurrence()` (free function)** — recurrence rule parser for the Obsidian Tasks plugin convention. Supports `every [n] day(s|week(s)|month(s)|year(s)|weekday(s)|weekend(s)`. Uses `due_date` as the reference date (falls back to `done_date`) and offsets all three date fields by the same interval so the full scheduling window advances together.

I totally understand if having helpers in `tools.rs` isn't structurally how you want the code organized. Please feel free to suggest moving the helpers to a new `tool_helpers.rs` module if preferred. 

### Correctness properties

- **Hash-gated writes** — every write tool accepts an optional `expected_hash`. If the file changed since the agent last read it, the write is rejected with an actionable error message. No silent overwrites.
- **Atomic writes** — uses the existing `VaultManager::write_file` infrastructure which writes to a temp file and renames.
- **Format-preserving** — emoji tasks stay emoji; Dataview tasks stay Dataview.
- **Indentation-preserving** — leading whitespace is extracted from the original line and re-applied on write, so nested task lists round-trip correctly.

## Test plan

- [x] All 23 integration tests pass
- [x] All 115 `turbovault-core` unit tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Live-tested end-to-end with OpenClaw agent against a real Obsidian vault. The new tools worked very well :)

**New integration tests added:**
- `test_list_tasks_*` — filtering by status and tag combinations
- `test_update_task_*` — field patching, hash rejection on stale hash, date clearing
- `test_complete_task_spawns_next_occurrence` — recurring task spawns a new pending instance with correct next dates
- `test_complete_task_no_recurrence_preserves_count` — non-recurring completion does not insert extra lines
- `test_get_overdue_tasks_as_of_date` — exact set of overdue tasks for a fixed reference date
- `test_get_overdue_tasks_empty_before_all_due_dates` — returns empty list when no tasks are due yet
- `test_get_overdue_tasks_sorted_oldest_first` — results are in non-decreasing due-date order

All tests use hardcoded `NaiveDate` values and bypass the tool layer so they are fully date-independent.

If the integration tests are too heavy, cluttering, or too much of a maintenance burden, please feel free to let me know and we can consider removing some.

## Gaps

If the calling model doesn't know via system prompt or prompt what tag Obsidian Tasks is filtering for, then if it calls list_tasks without that tag filter, it will return every checkbox item. We could put a "tasks definition" tag to auto filter everything if you want to use an env var or the config yaml file, but I went with the stateless implementation for now. 

Also, the tag filter uses AND logic which makes the most sense to me, but if you did switch it to OR logic, then you'd want the specific Obsidian Tasks single tag "task definition" filter to be ANDed with the OR logic on the other tags.

Anyway, it's stateless now, so we might want to update the docs to tell users to update their system prompts to tell the models to specify that tag filter every time if that's the setting they're using in the Obsidian Tasks plugin. Otherwise it almost looks like a bug even though it's intentional to maintain statelessness.

Actually, idea: since Turbovault obviously has file access, maybe it could automatically retrieve the settings from the Obsidian Tasks settings file in `.obsidian/plugins/obsidian-tasks-plugin/`... that could actually help it automatically align with Obsidian Tasks settings. That might be a good idea for a future PR.

## Proposed Future Tools

### Convenience Tools

- **`get_tasks_due_today`** — tasks due on the current date
- **`get_tasks_due_this_week`** — tasks due within the current week
- **`get_task_stats`** — aggregate counts by status/priority/tag, overdue count, completion rate; useful for a quick summary without listing every task

### Operation Tools

- **`move_task`** — relocate a task from one note to another (e.g. inbox → project note). Common in GTD-style workflows. Requires coordinated delete-from-source + insert-at-destination.
- **`get_task`** — fetch a single task by `[id:: ...]` dataview field. Precise lookup for tasks that have explicit IDs, avoiding a full `list_tasks` scan.

Please let me know what future tools seem most useful / interesting to add. Obviously the models can already do all this stuff by editing / viewing the lines directly. But the tools will save tokens. I think move_task and delete_task might be most useful for my personal workflow, but I could see someone liking the `get_tasks_due_by` tools. Maybe they should just be one tool that takes a date argument. Also, get_task_stats might be useful to help a model respond well to "prioritize my task list" type queries.