### PR TITLE
fix: disable default harness for Criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,12 @@ lto = "thin"
 codegen-units = 16
 debug = false
 
+[profile.bench]
+inherits = "release"
+lto = "thin"
+strip = false
+# debug = true  # uncomment when profiling with cargo flamegraph or perf
+
 [profile.dev]
 opt-level = 0
 debug = true

--- a/crates/turbovault/Cargo.toml
+++ b/crates/turbovault/Cargo.toml
@@ -78,6 +78,10 @@ tokio = { workspace = true, features = ["full"] }
 tempfile = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio", "html_reports"] }
 
+[[bench]]
+name = "tool_benchmarks"
+harness = false
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
## Issue

Criterion needs the default harness disabled to work properly. Running `cargo bench` runs Cargo's default test harness, which doesn't do anything with the `crates/turbovault/benches/tool_benchmarks.rs`.

## Before

`cargo bench`

(abbreviated, as it runs unit tests as well)

```
...

     Running benches/tool_benchmarks.rs (target/release/deps/tool_benchmarks-2fa3d94d9ec3c936)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
...
```

## After

`cargo bench`

(abbreviated)
```
...
❯ cargo bench | rg -A 1 -B 2 "time:|change:"
    Finished `bench` profile [optimized] target(s) in 0.19s
     Running unittests src/lib.rs (target/release/deps/turbovault-d54a75037b205127)
     Running unittests src/bin/main.rs (target/release/deps/turbovault-11de7df7a0b1a130)
     Running benches/tool_benchmarks.rs (target/release/deps/tool_benchmarks-32c3f3e5fa45fd50)
Gnuplot not found, using plotters backend
Benchmarking file_read_small
Benchmarking file_read_small: Warming up for 3.0000 s
Benchmarking file_read_small: Collecting 100 samples in estimated 5.0181 s (631k iterations)
Benchmarking file_read_small: Analyzing
9-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
10-
11:file_read_small         time:   [7.7224 µs 7.9715 µs 8.2494 µs]
12:                        change: [−8.5421% −3.9829% +0.7355%] (p = 0.11 > 0.05)
13-                        No change in performance detected.
Benchmarking file_write_small
Benchmarking file_write_small: Warming up for 3.0000 s
Benchmarking file_write_small: Collecting 100 samples in estimated 5.1586 s (157k iterations)
Benchmarking file_write_small: Analyzing
--
16-  10 (10.00%) high severe
17-
18:file_write_small        time:   [31.985 µs 32.867 µs 33.869 µs]
19:                        change: [−6.8985% −1.8308% +3.2727%] (p = 0.50 > 0.05)
20-                        No change in performance detected.
Benchmarking backlinks/10
Benchmarking backlinks/10: Warming up for 3.0000 s
Benchmarking backlinks/10: Collecting 100 samples in estimated 5.0005 s (2.6M iterations)
Benchmarking backlinks/10: Analyzing
--
23-  10 (10.00%) high severe
24-
25:backlinks/10            time:   [1.9166 µs 1.9221 µs 1.9283 µs]
26:                        change: [−2.9848% −2.3211% −1.6786%] (p = 0.00 < 0.05)
27-                        Performance has improved.
Benchmarking backlinks/50
Benchmarking backlinks/50: Warming up for 3.0000 s
Benchmarking backlinks/50: Collecting 100 samples in estimated 5.0045 s (2.6M iterations)
Benchmarking backlinks/50: Analyzing
...

```

## Results

Basically the change makes it so that the Criterion bench tests actually run.

---

See the Criterion readme: 

https://github.com/criterion-rs/criterion.rs

And cargo docs:

https://doc.rust-lang.org/cargo/commands/cargo-bench.html

...for more info on the bench harness behavior