### PR TITLE
Add missing ENVs + improve transport configuration

### DIFF
--- a/crates/turbovault/src/bin/main.rs
+++ b/crates/turbovault/src/bin/main.rs
@@ -46,7 +46,7 @@ struct Args {
 
     /// Output format for non-STDIO transports (json, human, text)
     /// Note: STDIO transport always uses JSON per MCP protocol specification
-    #[arg(long, default_value = "json")]
+    #[arg(long, default_value = "json", env = "TURBOVAULT_OUTPUT_FORMAT")]
     output_format: String,
 
     /// Initialize vault on startup (scan and build graph)

--- a/crates/turbovault/src/bin/main.rs
+++ b/crates/turbovault/src/bin/main.rs
@@ -28,8 +28,8 @@ struct Args {
     #[arg(short, long, default_value = "stdio")]
     transport: String,
 
-    /// HTTP server port (for http transport)
-    #[arg(long, default_value = "3000")]
+    /// Port to bind for network transports (http, websocket, tcp)
+    #[arg(long, default_value = "3000", env = "TURBOVAULT_PORT")]
     port: u16,
 
     /// Output format for non-STDIO transports (json, human, text)

--- a/crates/turbovault/src/bin/main.rs
+++ b/crates/turbovault/src/bin/main.rs
@@ -21,7 +21,7 @@ struct Args {
     vault: Option<PathBuf>,
 
     /// Configuration profile to use (development, production, etc.)
-    #[arg(short, long, default_value = "development")]
+    #[arg(short, long, default_value = "development", env = "TURBOVAULT_PROFILE")]
     profile: String,
 
     /// Transport mode (stdio, http, websocket, tcp, unix)

--- a/crates/turbovault/src/bin/main.rs
+++ b/crates/turbovault/src/bin/main.rs
@@ -24,8 +24,8 @@ struct Args {
     #[arg(short, long, default_value = "development")]
     profile: String,
 
-    /// Transport mode (stdio, http, websocket)
-    #[arg(short, long, default_value = "stdio")]
+    /// Transport mode (stdio, http, websocket, tcp, unix)
+    #[arg(short, long, default_value = "stdio", env = "TURBOVAULT_TRANSPORT")]
     transport: String,
 
     /// Port to bind for network transports (http, websocket, tcp)

--- a/crates/turbovault/src/bin/main.rs
+++ b/crates/turbovault/src/bin/main.rs
@@ -388,7 +388,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             server
                 .builder()
                 .with_protocol(ProtocolConfig::multi_version())
-                .transport(turbomcp::Transport::unix(args.socket_path))
+                .transport(turbomcp::Transport::unix(&args.socket_path))
                 .serve()
                 .await?;
         }

--- a/crates/turbovault/src/bin/main.rs
+++ b/crates/turbovault/src/bin/main.rs
@@ -28,6 +28,10 @@ struct Args {
     #[arg(short, long, default_value = "stdio", env = "TURBOVAULT_TRANSPORT")]
     transport: String,
 
+    /// Host/interface to bind for network transports (http, websocket, tcp)
+    #[arg(long, default_value = "127.0.0.1", env = "TURBOVAULT_HOST")]
+    host: String,
+
     /// Port to bind for network transports (http, websocket, tcp)
     #[arg(long, default_value = "3000", env = "TURBOVAULT_PORT")]
     port: u16,
@@ -343,7 +347,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         #[cfg(feature = "http")]
         "http" => {
-            let addr = format!("127.0.0.1:{}", args.port);
+            let addr = format!("{}:{}", args.host, args.port);
             log::info!("Running HTTP server on {}", addr);
             log::info!("Output format: {:?}", output_format);
             server
@@ -355,7 +359,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         #[cfg(feature = "websocket")]
         "websocket" => {
-            let addr = format!("127.0.0.1:{}", args.port);
+            let addr = format!("{}:{}", args.host, args.port);
             log::info!("Running WebSocket server on {}", addr);
             log::info!("Output format: {:?}", output_format);
             server
@@ -367,7 +371,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         #[cfg(feature = "tcp")]
         "tcp" => {
-            let addr = format!("127.0.0.1:{}", args.port);
+            let addr = format!("{}:{}", args.host, args.port);
             log::info!("Running TCP server on {}", addr);
             log::info!("Output format: {:?}", output_format);
             server

--- a/crates/turbovault/src/bin/main.rs
+++ b/crates/turbovault/src/bin/main.rs
@@ -32,6 +32,14 @@ struct Args {
     #[arg(long, default_value = "3000", env = "TURBOVAULT_PORT")]
     port: u16,
 
+    /// Socket path for the unix transport
+    #[arg(
+        long,
+        default_value = "/tmp/turbovault.sock",
+        env = "TURBOVAULT_SOCKET_PATH"
+    )]
+    socket_path: String,
+
     /// Output format for non-STDIO transports (json, human, text)
     /// Note: STDIO transport always uses JSON per MCP protocol specification
     #[arg(long, default_value = "json")]
@@ -371,13 +379,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         #[cfg(feature = "unix")]
         "unix" => {
-            let socket_path = "/tmp/turbovault.sock".to_string();
-            log::info!("Running Unix socket server on {}", socket_path);
+            log::info!("Running Unix socket server on {}", args.socket_path);
             log::info!("Output format: {:?}", output_format);
             server
                 .builder()
                 .with_protocol(ProtocolConfig::multi_version())
-                .transport(turbomcp::Transport::unix(&socket_path))
+                .transport(turbomcp::Transport::unix(args.socket_path))
                 .serve()
                 .await?;
         }


### PR DESCRIPTION
This PR adds configuration options for the various transports that had hard coded options:

- `host`, `websocket`, `tcp` now support `--host` or `TURBOVAULT_HOST` with `127.0.0.1` as the default
- `unix` now supports `--socket-path` or `TURBOVAULT_SOCKET_PATH` with `/tmp/turbovault.sock` as the default
- adds `TURBOVAULT_PORT`, `TURBOVAULT_TRANSPORT`, `TURBOVAULT_PROFILE`, `TURBOVAULT_OUTPUT_FORMAT` env options

Note I did these as small, individual commits in case you wanted to cherry pick anything. I can squash them if you'd prefer.