### PR TITLE
fix: Concurrency hardening. Hash check prior to file edit added to VaultManager::edit_file

### DIFF
--- a/crates/turbovault-batch/src/lib.rs
+++ b/crates/turbovault-batch/src/lib.rs
@@ -92,10 +92,12 @@
 //! let write = BatchOperation::WriteNote {
 //!     path: "file.md".to_string(),
 //!     content: "content".to_string(),
+//!     expected_hash: None,
 //! };
 //!
 //! let delete = BatchOperation::DeleteNote {
 //!     path: "file.md".to_string(),
+//!     expected_hash: None,
 //! };
 //!
 //! assert!(write.conflicts_with(&delete));
@@ -145,15 +147,35 @@ pub enum BatchOperation {
 
     /// Write/overwrite a note
     #[serde(rename = "WriteNote", alias = "WriteFile")]
-    WriteNote { path: String, content: String },
+    WriteNote {
+        path: String,
+        content: String,
+        /// Optional optimistic-concurrency precondition: SHA-256 hash the file
+        /// is expected to have before the write. Checked before the operation
+        /// is applied; a mismatch fails the batch with a ConcurrencyError.
+        #[serde(default)]
+        expected_hash: Option<String>,
+    },
 
     /// Delete a note
     #[serde(rename = "DeleteNote", alias = "DeleteFile")]
-    DeleteNote { path: String },
+    DeleteNote {
+        path: String,
+        /// Optional optimistic-concurrency precondition (see `WriteNote`).
+        #[serde(default)]
+        expected_hash: Option<String>,
+    },
 
     /// Move/rename a note
     #[serde(rename = "MoveNote", alias = "MoveFile")]
-    MoveNote { from: String, to: String },
+    MoveNote {
+        from: String,
+        to: String,
+        /// Optional optimistic-concurrency precondition on the source file
+        /// (see `WriteNote`).
+        #[serde(default)]
+        expected_hash: Option<String>,
+    },
 
     /// Update links in a note (find and replace link target)
     #[serde(rename = "UpdateLinks")]
@@ -170,8 +192,8 @@ impl BatchOperation {
         match self {
             Self::CreateNote { path, .. } => vec![path.clone()],
             Self::WriteNote { path, .. } => vec![path.clone()],
-            Self::DeleteNote { path } => vec![path.clone()],
-            Self::MoveNote { from, to } => vec![from.clone(), to.clone()],
+            Self::DeleteNote { path, .. } => vec![path.clone()],
+            Self::MoveNote { from, to, .. } => vec![from.clone(), to.clone()],
             Self::UpdateLinks {
                 file,
                 old_target,
@@ -179,6 +201,31 @@ impl BatchOperation {
             } => {
                 vec![file.clone(), old_target.clone(), new_target.clone()]
             }
+        }
+    }
+
+    /// Optimistic-concurrency precondition for this operation, if any.
+    ///
+    /// Returns `(path, expected_hash)` where `path` is the file whose current
+    /// content hash must equal `expected_hash` for the operation to proceed.
+    /// `CreateNote` and `UpdateLinks` never carry a precondition.
+    pub fn precondition(&self) -> Option<(&str, &str)> {
+        match self {
+            Self::WriteNote {
+                path,
+                expected_hash: Some(h),
+                ..
+            } => Some((path, h)),
+            Self::DeleteNote {
+                path,
+                expected_hash: Some(h),
+            } => Some((path, h)),
+            Self::MoveNote {
+                from,
+                expected_hash: Some(h),
+                ..
+            } => Some((from, h)),
+            _ => None,
         }
     }
 
@@ -275,12 +322,52 @@ impl BatchExecutor {
         Ok(())
     }
 
+    /// Pre-flight check of every operation's optimistic-concurrency
+    /// precondition before any operation is applied.
+    ///
+    /// This narrows (though, like all optimistic schemes, does not eliminate)
+    /// the partial-application window: if any `expected_hash` is already stale
+    /// when the batch starts, the whole batch fails before mutating anything,
+    /// rather than applying the first few operations and then aborting.
+    async fn precheck_preconditions(&self, ops: &[BatchOperation]) -> Result<()> {
+        for op in ops {
+            if let Some((path, expected)) = op.precondition() {
+                let path_buf = PathBuf::from(path);
+                match self.manager.read_file(&path_buf).await {
+                    Ok(content) => {
+                        let actual = turbovault_vault::compute_hash(&content);
+                        if actual != expected {
+                            return Err(Error::concurrency_error(format!(
+                                "Precondition failed for {}: expected hash {}, actual {}. Re-read the file and retry.",
+                                path, expected, actual
+                            )));
+                        }
+                    }
+                    // File missing but a hash was expected — treat as a conflict
+                    // (it was likely deleted since the caller read it).
+                    Err(_) => {
+                        return Err(Error::concurrency_error(format!(
+                            "Precondition failed for {}: file does not exist but expected_hash {} was provided. It may have been deleted.",
+                            path, expected
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Execute batch operations atomically
     pub async fn execute(&self, ops: Vec<BatchOperation>) -> Result<BatchResult> {
         let transaction = TransactionBuilder::new();
 
-        // 1. Validate
-        if let Err(e) = self.validate(&ops).await {
+        // 1. Validate (intra-batch conflicts) + pre-flight precondition check
+        //    (external, since-read conflicts via expected_hash).
+        if let Err(e) = self
+            .validate(&ops)
+            .await
+            .and(self.precheck_preconditions(&ops).await)
+        {
             return Ok(BatchResult {
                 success: false,
                 executed: 0,
@@ -364,22 +451,39 @@ impl BatchExecutor {
                 Ok(format!("Created: {}", path))
             }
 
-            BatchOperation::WriteNote { path, content } => {
+            BatchOperation::WriteNote {
+                path,
+                content,
+                expected_hash,
+            } => {
                 let path_buf = PathBuf::from(path);
-                self.manager.write_file(&path_buf, content, None).await?;
+                self.manager
+                    .write_file(&path_buf, content, expected_hash.as_deref())
+                    .await?;
                 Ok(format!("Updated: {}", path))
             }
 
-            BatchOperation::DeleteNote { path } => {
+            BatchOperation::DeleteNote {
+                path,
+                expected_hash,
+            } => {
                 let path_buf = PathBuf::from(path);
-                self.manager.delete_file(&path_buf, None).await?;
+                self.manager
+                    .delete_file(&path_buf, expected_hash.as_deref())
+                    .await?;
                 Ok(format!("Deleted: {}", path))
             }
 
-            BatchOperation::MoveNote { from, to } => {
+            BatchOperation::MoveNote {
+                from,
+                to,
+                expected_hash,
+            } => {
                 let from_buf = PathBuf::from(from);
                 let to_buf = PathBuf::from(to);
-                self.manager.move_file(&from_buf, &to_buf, None).await?;
+                self.manager
+                    .move_file(&from_buf, &to_buf, expected_hash.as_deref())
+                    .await?;
                 Ok(format!("Moved: {} → {}", from, to))
             }
 
@@ -424,6 +528,7 @@ mod tests {
         let op = BatchOperation::MoveNote {
             from: "a.md".to_string(),
             to: "b.md".to_string(),
+            expected_hash: None,
         };
         let affected = op.affected_files();
         assert_eq!(affected.len(), 2);
@@ -436,9 +541,11 @@ mod tests {
         let op1 = BatchOperation::WriteNote {
             path: "file.md".to_string(),
             content: "content".to_string(),
+            expected_hash: None,
         };
         let op2 = BatchOperation::DeleteNote {
             path: "file.md".to_string(),
+            expected_hash: None,
         };
 
         assert!(op1.conflicts_with(&op2));
@@ -450,10 +557,12 @@ mod tests {
         let op1 = BatchOperation::WriteNote {
             path: "file1.md".to_string(),
             content: "content".to_string(),
+            expected_hash: None,
         };
         let op2 = BatchOperation::WriteNote {
             path: "file2.md".to_string(),
             content: "content".to_string(),
+            expected_hash: None,
         };
 
         assert!(!op1.conflicts_with(&op2));
@@ -510,6 +619,7 @@ mod tests {
             .execute(vec![BatchOperation::WriteNote {
                 path: "existing.md".to_string(),
                 content: "new content".to_string(),
+                expected_hash: None,
             }])
             .await
             .unwrap();
@@ -529,6 +639,7 @@ mod tests {
         let result = executor
             .execute(vec![BatchOperation::DeleteNote {
                 path: "to_delete.md".to_string(),
+                expected_hash: None,
             }])
             .await
             .unwrap();
@@ -547,6 +658,7 @@ mod tests {
             .execute(vec![BatchOperation::MoveNote {
                 from: "source.md".to_string(),
                 to: "destination.md".to_string(),
+                expected_hash: None,
             }])
             .await
             .unwrap();
@@ -610,6 +722,7 @@ mod tests {
             },
             BatchOperation::DeleteNote {
                 path: "nonexistent.md".to_string(),
+                expected_hash: None,
             },
         ];
 
@@ -641,5 +754,107 @@ mod tests {
         assert_eq!(result.executed, 0);
         assert_eq!(result.total, 0);
         assert!(!result.errors.is_empty(), "should report why it failed");
+    }
+
+    /// A WriteNote whose `expected_hash` matches the on-disk content proceeds.
+    #[tokio::test]
+    async fn test_batch_expected_hash_match_succeeds() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("note.md"), "v1").unwrap();
+        let hash = turbovault_vault::compute_hash("v1");
+
+        let executor = make_executor(&temp).await;
+        let result = executor
+            .execute(vec![BatchOperation::WriteNote {
+                path: "note.md".to_string(),
+                content: "v2".to_string(),
+                expected_hash: Some(hash),
+            }])
+            .await
+            .unwrap();
+
+        assert!(result.success, "batch should succeed: {:?}", result.errors);
+        let on_disk = std::fs::read_to_string(temp.path().join("note.md")).unwrap();
+        assert_eq!(on_disk, "v2");
+    }
+
+    /// A stale `expected_hash` fails the batch in the pre-flight check, before
+    /// any operation runs — so earlier (hashless) operations are NOT applied.
+    #[tokio::test]
+    async fn test_batch_stale_expected_hash_fails_preflight() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("guarded.md"), "current").unwrap();
+
+        let executor = make_executor(&temp).await;
+        let result = executor
+            .execute(vec![
+                // This op has no precondition and would succeed on its own...
+                BatchOperation::CreateNote {
+                    path: "side_effect.md".to_string(),
+                    content: "should not be written".to_string(),
+                },
+                // ...but this op's precondition is already stale, so the whole
+                // batch must abort before anything is applied.
+                BatchOperation::WriteNote {
+                    path: "guarded.md".to_string(),
+                    content: "new".to_string(),
+                    expected_hash: Some("staleHASH".to_string()),
+                },
+            ])
+            .await
+            .unwrap();
+
+        assert!(!result.success, "batch should fail on stale precondition");
+        assert_eq!(result.executed, 0, "pre-flight must abort before executing");
+        assert!(
+            !temp.path().join("side_effect.md").exists(),
+            "no operation should have been applied"
+        );
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("guarded.md")).unwrap(),
+            "current",
+            "guarded file must be untouched"
+        );
+    }
+
+    /// DeleteNote and MoveNote also honor `expected_hash` preconditions: a
+    /// stale hash on either aborts the batch in the pre-flight pass.
+    #[tokio::test]
+    async fn test_batch_delete_and_move_preconditions() {
+        // Stale DeleteNote precondition.
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("del.md"), "live").unwrap();
+        let executor = make_executor(&temp).await;
+        let result = executor
+            .execute(vec![BatchOperation::DeleteNote {
+                path: "del.md".to_string(),
+                expected_hash: Some("staleHASH".to_string()),
+            }])
+            .await
+            .unwrap();
+        assert!(!result.success, "stale delete precondition must fail");
+        assert_eq!(result.executed, 0);
+        assert!(temp.path().join("del.md").exists(), "file must survive");
+
+        // Matching MoveNote precondition succeeds.
+        let temp2 = TempDir::new().unwrap();
+        std::fs::write(temp2.path().join("src.md"), "data").unwrap();
+        let hash = turbovault_vault::compute_hash("data");
+        let executor2 = make_executor(&temp2).await;
+        let result2 = executor2
+            .execute(vec![BatchOperation::MoveNote {
+                from: "src.md".to_string(),
+                to: "dst.md".to_string(),
+                expected_hash: Some(hash),
+            }])
+            .await
+            .unwrap();
+        assert!(
+            result2.success,
+            "matching move precondition should succeed: {:?}",
+            result2.errors
+        );
+        assert!(!temp2.path().join("src.md").exists());
+        assert!(temp2.path().join("dst.md").exists());
     }
 }

--- a/crates/turbovault-tools/tests/test_async_error_paths.rs
+++ b/crates/turbovault-tools/tests/test_async_error_paths.rs
@@ -199,17 +199,21 @@ async fn test_batch_tools_partial_failure_rollback() {
         BatchOperation::WriteNote {
             path: "file1.md".to_string(),
             content: "Content 1".to_string(),
+            expected_hash: None,
         },
         BatchOperation::WriteNote {
             path: "file2.md".to_string(),
             content: "Content 2".to_string(),
+            expected_hash: None,
         },
         BatchOperation::DeleteNote {
             path: "nonexistent_file_for_failure.md".to_string(),
+            expected_hash: None,
         },
         BatchOperation::WriteNote {
             path: "file3.md".to_string(),
             content: "Content 3".to_string(),
+            expected_hash: None,
         },
     ];
 
@@ -240,6 +244,7 @@ async fn test_batch_tools_concurrent_batch_conflicts() {
         let ops = vec![BatchOperation::WriteNote {
             path: "conflict.md".to_string(),
             content: "Content from batch 1".to_string(),
+            expected_hash: None,
         }];
         tools1.batch_execute(ops).await
     });
@@ -248,6 +253,7 @@ async fn test_batch_tools_concurrent_batch_conflicts() {
         let ops = vec![BatchOperation::WriteNote {
             path: "conflict.md".to_string(),
             content: "Content from batch 2".to_string(),
+            expected_hash: None,
         }];
         tools2.batch_execute(ops).await
     });

--- a/crates/turbovault-tools/tests/test_batch_tools.rs
+++ b/crates/turbovault-tools/tests/test_batch_tools.rs
@@ -35,6 +35,7 @@ async fn test_batch_execute_single_write() {
     let ops = vec![BatchOperation::WriteNote {
         path: "new.md".to_string(),
         content: "# New Note\nContent".to_string(),
+        expected_hash: None,
     }];
 
     let result = tools.batch_execute(ops).await;
@@ -57,14 +58,17 @@ async fn test_batch_execute_multiple_writes() {
         BatchOperation::WriteNote {
             path: "note1.md".to_string(),
             content: "# Note 1".to_string(),
+            expected_hash: None,
         },
         BatchOperation::WriteNote {
             path: "note2.md".to_string(),
             content: "# Note 2".to_string(),
+            expected_hash: None,
         },
         BatchOperation::WriteNote {
             path: "note3.md".to_string(),
             content: "# Note 3".to_string(),
+            expected_hash: None,
         },
     ];
 
@@ -82,6 +86,7 @@ async fn test_batch_execute_delete() {
 
     let ops = vec![BatchOperation::DeleteNote {
         path: "existing.md".to_string(),
+        expected_hash: None,
     }];
 
     let result = tools.batch_execute(ops).await;
@@ -102,6 +107,7 @@ async fn test_batch_execute_move() {
     let ops = vec![BatchOperation::MoveNote {
         from: "existing.md".to_string(),
         to: "moved.md".to_string(),
+        expected_hash: None,
     }];
 
     let result = tools.batch_execute(ops).await;
@@ -124,14 +130,17 @@ async fn test_batch_execute_mixed_operations() {
         BatchOperation::WriteNote {
             path: "new1.md".to_string(),
             content: "# New 1".to_string(),
+            expected_hash: None,
         },
         BatchOperation::WriteNote {
             path: "new2.md".to_string(),
             content: "# New 2".to_string(),
+            expected_hash: None,
         },
         BatchOperation::MoveNote {
             from: "existing.md".to_string(),
             to: "renamed.md".to_string(),
+            expected_hash: None,
         },
     ];
 
@@ -151,13 +160,16 @@ async fn test_batch_execute_rollback_on_error() {
         BatchOperation::WriteNote {
             path: "success1.md".to_string(),
             content: "# Success 1".to_string(),
+            expected_hash: None,
         },
         BatchOperation::DeleteNote {
             path: "nonexistent.md".to_string(), // This will fail
+            expected_hash: None,
         },
         BatchOperation::WriteNote {
             path: "success2.md".to_string(),
             content: "# Success 2".to_string(),
+            expected_hash: None,
         },
     ];
 
@@ -195,6 +207,7 @@ async fn test_batch_execute_creates_directories() {
     let ops = vec![BatchOperation::WriteNote {
         path: "nested/deep/folder/note.md".to_string(),
         content: "# Nested Note".to_string(),
+        expected_hash: None,
     }];
 
     let result = tools.batch_execute(ops).await;
@@ -215,10 +228,12 @@ async fn test_batch_execute_atomic_guarantees() {
         BatchOperation::WriteNote {
             path: "atomic1.md".to_string(),
             content: "# Atomic 1".to_string(),
+            expected_hash: None,
         },
         BatchOperation::WriteNote {
             path: "atomic2.md".to_string(),
             content: "# Atomic 2".to_string(),
+            expected_hash: None,
         },
     ];
 
@@ -230,9 +245,11 @@ async fn test_batch_execute_atomic_guarantees() {
         BatchOperation::WriteNote {
             path: "atomic3.md".to_string(),
             content: "# Atomic 3".to_string(),
+            expected_hash: None,
         },
         BatchOperation::DeleteNote {
             path: "nonexistent_for_atomic_test.md".to_string(),
+            expected_hash: None,
         },
     ];
 
@@ -264,6 +281,7 @@ async fn test_async_error_path_concurrent_batch_operations() {
                 let ops = vec![BatchOperation::WriteNote {
                     path: format!("concurrent_{}.md", i),
                     content: format!("# Concurrent {}", i),
+                    expected_hash: None,
                 }];
                 tools.batch_execute(ops).await
             })

--- a/crates/turbovault-vault/src/manager.rs
+++ b/crates/turbovault-vault/src/manager.rs
@@ -339,17 +339,20 @@ impl VaultManager {
             .await
             .map_err(Error::io)?;
 
+        // Hash of the content we actually read and are editing against. This is
+        // the authoritative pre-image for the write below.
+        let validated_hash = compute_hash(&current_content);
+
         // Validate expected hash if provided
-        if let Some(expected) = expected_hash {
-            let actual = compute_hash(&current_content);
-            if actual != expected {
-                return Err(Error::ConcurrencyError {
-                    reason: format!(
-                        "File modified since read. Expected hash: {}, actual: {}. Re-read the file and try again.",
-                        expected, actual
-                    ),
-                });
-            }
+        if let Some(expected) = expected_hash
+            && validated_hash != expected
+        {
+            return Err(Error::ConcurrencyError {
+                reason: format!(
+                    "File modified since read. Expected hash: {}, actual: {}. Re-read the file and try again.",
+                    expected, validated_hash
+                ),
+            });
         }
 
         // Parse and apply edits
@@ -366,8 +369,14 @@ impl VaultManager {
         // Release cache guard before write (avoid deadlock)
         drop(_cache_guard);
 
-        // Write atomically (hash already validated above, pass None)
-        self.write_file(&vault_path, &new_content, None).await?;
+        // Write atomically, re-checking that the file still holds the exact
+        // content we applied edits to. Passing `validated_hash` (rather than
+        // `None`) closes the TOCTOU window between the read above and the
+        // atomic rename: if another writer changed the file in between, the
+        // write fails with a ConcurrencyError instead of silently
+        // clobbering their change.
+        self.write_file(&vault_path, &new_content, Some(&validated_hash))
+            .await?;
 
         Ok(edit_result)
     }
@@ -1729,5 +1738,163 @@ mod tests {
             0,
             "deleted file must be evicted from cache"
         );
+    }
+
+    /// A stale `expected_hash` on write_file must surface a `ConcurrencyError`
+    /// and leave the existing content in place.
+    #[tokio::test]
+    async fn test_write_file_stale_hash_conflict() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = create_test_config(temp_dir.path());
+        let manager = VaultManager::new(config).unwrap();
+
+        let path = Path::new("note.md");
+        manager.write_file(path, "v1", None).await.unwrap();
+
+        // Caller thinks the file still holds some other content.
+        let err = manager
+            .write_file(path, "v2", Some("deadbeef"))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, Error::ConcurrencyError { .. }),
+            "expected ConcurrencyError, got {err:?}"
+        );
+        // The write must not have happened.
+        assert_eq!(manager.read_file(path).await.unwrap(), "v1");
+    }
+
+    /// When `expected_hash` references a file that no longer exists, the write
+    /// is rejected with a `ConcurrencyError` explaining the file is gone.
+    #[tokio::test]
+    async fn test_write_file_expected_hash_on_missing_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = create_test_config(temp_dir.path());
+        let manager = VaultManager::new(config).unwrap();
+
+        let err = manager
+            .write_file(Path::new("ghost.md"), "x", Some("deadbeef"))
+            .await
+            .unwrap_err();
+
+        match err {
+            Error::ConcurrencyError { reason } => {
+                assert!(
+                    reason.contains("does not exist"),
+                    "reason should explain the file is gone: {reason}"
+                );
+            }
+            other => panic!("expected ConcurrencyError, got {other:?}"),
+        }
+    }
+
+    /// edit_file with a stale `expected_hash` must fail with a `ConcurrencyError`
+    /// and leave the file untouched.
+    #[tokio::test]
+    async fn test_edit_file_stale_hash_conflict() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = create_test_config(temp_dir.path());
+        let manager = VaultManager::new(config).unwrap();
+
+        let path = Path::new("note.md");
+        manager.write_file(path, "hello world", None).await.unwrap();
+
+        let edits = "<<<<<<< SEARCH\nhello world\n=======\ngoodbye world\n>>>>>>> REPLACE";
+        let err = manager
+            .edit_file(path, edits, Some("staleHASH"), false)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, Error::ConcurrencyError { .. }),
+            "expected ConcurrencyError, got {err:?}"
+        );
+        assert_eq!(manager.read_file(path).await.unwrap(), "hello world");
+    }
+
+    /// edit_file closes the TOCTOU window by re-checking the file's content
+    /// hash at write time. If the file is changed out from under the engine
+    /// between its read and the atomic rename, the edit must fail rather than
+    /// clobber the change.
+    ///
+    /// We simulate the interleaving deterministically by hand: read the
+    /// pre-image hash the engine would compute, mutate the file externally,
+    /// then drive `write_file` with that now-stale pre-image hash — which is
+    /// exactly the value edit_file forwards internally.
+    #[tokio::test]
+    async fn test_edit_file_toctou_rechecks_at_write() {
+        use crate::edit::compute_hash;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = create_test_config(temp_dir.path());
+        let manager = VaultManager::new(config).unwrap();
+
+        let path = Path::new("note.md");
+        manager.write_file(path, "original", None).await.unwrap();
+        let preimage_hash = compute_hash("original");
+
+        // Another writer changes the file after the engine read it.
+        manager.write_file(path, "intervening", None).await.unwrap();
+
+        // The write edit_file would perform, carrying the pre-image hash, must
+        // now be rejected instead of overwriting "intervening".
+        let err = manager
+            .write_file(path, "edited", Some(&preimage_hash))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::ConcurrencyError { .. }),
+            "expected ConcurrencyError, got {err:?}"
+        );
+        assert_eq!(manager.read_file(path).await.unwrap(), "intervening");
+    }
+
+    /// delete_file with a stale `expected_hash` must fail with a
+    /// `ConcurrencyError` and leave the file in place.
+    #[tokio::test]
+    async fn test_delete_file_stale_hash_conflict() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = create_test_config(temp_dir.path());
+        let manager = VaultManager::new(config).unwrap();
+
+        let path = Path::new("note.md");
+        manager.write_file(path, "keep me", None).await.unwrap();
+
+        let err = manager
+            .delete_file(path, Some("staleHASH"))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, Error::ConcurrencyError { .. }),
+            "expected ConcurrencyError, got {err:?}"
+        );
+        assert_eq!(manager.read_file(path).await.unwrap(), "keep me");
+    }
+
+    /// move_file with a stale `expected_hash` (on the source) must fail with a
+    /// `ConcurrencyError` and leave the source in place.
+    #[tokio::test]
+    async fn test_move_file_stale_hash_conflict() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = create_test_config(temp_dir.path());
+        let manager = VaultManager::new(config).unwrap();
+
+        let from = Path::new("from.md");
+        let to = Path::new("to.md");
+        manager.write_file(from, "payload", None).await.unwrap();
+
+        let err = manager
+            .move_file(from, to, Some("staleHASH"))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, Error::ConcurrencyError { .. }),
+            "expected ConcurrencyError, got {err:?}"
+        );
+        assert_eq!(manager.read_file(from).await.unwrap(), "payload");
+        assert!(manager.read_file(to).await.is_err(), "dest must not exist");
     }
 }

--- a/crates/turbovault/benches/tool_benchmarks.rs
+++ b/crates/turbovault/benches/tool_benchmarks.rs
@@ -173,6 +173,7 @@ fn bench_batch_operations(c: &mut Criterion) {
                         .map(|i| BatchOperation::WriteNote {
                             path: format!("batch_{}.md", i),
                             content: format!("# Batch {}", i),
+                            expected_hash: None,
                         })
                         .collect();
                     tools.batch_execute(black_box(ops)).await.unwrap()

--- a/crates/turbovault/src/tools.rs
+++ b/crates/turbovault/src/tools.rs
@@ -1729,14 +1729,15 @@ impl ObsidianMcpServer {
 
     /// Execute batch file operations atomically
     #[tool(
-        description = "Execute multiple file operations atomically (all-or-nothing transaction)",
-        usage = "Use for complex multi-file workflows requiring consistency. If any operation fails, all changes are rolled back. Not idempotent.",
+        description = "Execute multiple file operations atomically (all-or-nothing transaction). write/delete/move operations accept an optional expected_hash (from read_note) for optimistic concurrency: all preconditions are checked before any operation runs, so a stale hash fails the whole batch without applying anything.",
+        usage = "Use for complex multi-file workflows requiring consistency. If any operation fails, the batch stops. Pass expected_hash on write/delete/move to guard against concurrent modifications. Not idempotent.",
         performance = "Depends on operation count and types. Transactions add ~10-50ms overhead.",
         related = ["write_note", "delete_note", "move_note"],
         examples = [
             r#"[{"type":"write","path":"note1.md","content":"..."}]"#,
             r#"[{"type":"delete","path":"old.md"},{"type":"write","path":"new.md","content":"..."}]"#,
-            r#"[{"type":"move","from":"a.md","to":"b.md"},{"type":"write","path":"index.md","content":"..."}]"#
+            r#"[{"type":"move","from":"a.md","to":"b.md"},{"type":"write","path":"index.md","content":"..."}]"#,
+            r#"[{"type":"write","path":"note1.md","content":"...","expected_hash":"<hash from read_note>"}]"#
         ],
         tags = ["write", "batch"],
         destructive = true,

--- a/crates/turbovault/tests/test_all_mcp_tools.rs
+++ b/crates/turbovault/tests/test_all_mcp_tools.rs
@@ -275,10 +275,12 @@ async fn integration_test_batch_operations() {
         turbovault_tools::BatchOperation::WriteNote {
             path: "batch1.md".to_string(),
             content: "# Batch 1".to_string(),
+            expected_hash: None,
         },
         turbovault_tools::BatchOperation::WriteNote {
             path: "batch2.md".to_string(),
             content: "# Batch 2".to_string(),
+            expected_hash: None,
         },
     ];
 


### PR DESCRIPTION
# Concurrency improvements: edit_file TOCTOU fix + per-operation optimistic concurrency in batches

## Summary

Two concrete hardening improvements to Turbovault's existing optimistic-concurrency support
(`expected_hash` + atomic rename), plus a clearly-scoped **maintainer decision** on the conflict
error type that is deliberately left out of the shipped diff to avoid a breaking change.

1. **`edit_file` TOCTOU fix** — `edit_file` now re-checks the file's content hash at write time
   instead of writing unconditionally after dropping its cache lock. A concurrent write that lands
   between the read and the atomic rename is now detected and rejected instead of silently
   overwriting the other writer's change.
2. **Per-operation `expected_hash` in `batch_execute`** — `WriteNote`, `DeleteNote`, and `MoveNote`
   batch operations accept an optional `expected_hash`, verified in a pre-flight pass before any
   operation is applied. Wire-compatible (JSON unchanged for existing payloads).

This PR is intentionally **non-breaking at the public-enum level**: it does **not** add or remove any
`Error` variant. A richer structured conflict error is described below as an opt-in the maintainer
can choose to adopt (see [API decision](#api-decision-conflict-error-shape)).

## Motivation

Turbovault already exposes optimistic concurrency end-to-end (`read_note` returns a `hash`;
`write_note`/`edit_note`/`delete_note`/`move_note` accept `expected_hash`, checked before the write).
Two gaps remained for concurrent human + multi-agent use:

- `edit_file` validated the hash under a lock, then **released the lock and wrote with no re-check**,
  leaving a window where a concurrent write could be silently lost.
- Batches had no way to express "apply only if these files are still at the hashes I last read,"
  which coordinated multi-file agent edits need.

## What changed

### 1. `edit_file` TOCTOU fix — [`crates/turbovault-vault/src/manager.rs`]

Previously `edit_file` did: lock → read → validate `expected_hash` → **drop lock** →
`write_file(.., None)`. Because the final write passed `None`, it performed no concurrency check, so
a write landing between the read and the rename was silently clobbered.

Now `edit_file` computes the hash of the content it actually read (`validated_hash`) and forwards it
to the write:

```rust
let validated_hash = compute_hash(&current_content);
// ... validate caller's expected_hash (if any) against validated_hash ...
// ... apply edits ...
self.write_file(&vault_path, &new_content, Some(&validated_hash)).await?;
```

If the file changed since the engine read it, the write now fails with `ConcurrencyError` rather
than overwriting. This is purely internal — **no signature change** — and behaves as a bug fix: the
only newly-observable behavior is a conflict error in a race that previously produced a lost update.

> Scope note: atomic-rename means this narrows the window to the same minimal read→rename window all
> single writes share; it does not (and cannot) mutually exclude **external** editors such as
> Obsidian writing directly. Those are *detected* (hash mismatch → error), not *prevented*, which is
> the correct guarantee for an optimistic scheme.

### 2. Per-operation `expected_hash` in batches — [`crates/turbovault-batch/src/lib.rs`]

`WriteNote`, `DeleteNote`, and `MoveNote` gain an optional `expected_hash`:

```rust
WriteNote { path: String, content: String, #[serde(default)] expected_hash: Option<String> }
DeleteNote { path: String, #[serde(default)] expected_hash: Option<String> }
MoveNote { from: String, to: String, #[serde(default)] expected_hash: Option<String> }
```

A new pre-flight pass (`precheck_preconditions`) verifies **all** preconditions before **any**
operation runs, so a stale hash fails the whole batch without partial application:

```rust
self.validate(&ops).await.and(self.precheck_preconditions(&ops).await)
```

`CreateNote` and `UpdateLinks` carry no precondition. The `batch_execute` MCP tool description and
examples were updated to mention the field; the JSON schema gains an optional field via
`#[serde(default)]`, so **existing batch payloads deserialize unchanged**.

## Tests

All new behavior is covered; full workspace suite green, clippy clean.

- `edit_file` stale hash → conflict; success path; **TOCTOU re-check rejects an intervening write**
- `write_file` stale hash → conflict; `expected_hash` on a missing file → conflict explaining the
  file is gone
- `delete_file` / `move_file` stale hash → conflict, target left untouched
- batch: matching `expected_hash` succeeds; **stale precondition aborts in pre-flight**
  (`executed == 0`, no side effects); `DeleteNote` + `MoveNote` precondition arms covered

(The TOCTOU test simulates the interleave deterministically at the `write_file` layer — driving the
write with the now-stale pre-image hash that `edit_file` forwards internally — since a true in-call
race isn't deterministically injectable without a test hook.)

## API / versioning impact

| Change | Wire (MCP/JSON) | Rust source | Notes |
|---|---|---|---|
| `edit_file` TOCTOU fix | compatible | compatible | internal only; behavioral bug fix |
| batch `expected_hash` fields | compatible (`#[serde(default)]`) | **source-break for direct construction** | see below |
| conflict error shape | compatible | compatible (unchanged) | structured variant offered as opt-in below |

**Batch field caveat:** adding fields to the public `BatchOperation` struct-variants is source-
breaking for any **Rust** code that constructs those variants as literals (Rust struct literals
require all fields). It is **not** wire-breaking. In practice `BatchOperation` is built by
deserializing MCP tool JSON, not constructed by hand in downstream Rust, so real-world impact is
low. There is no way to add a per-operation field in Rust without this; if the maintainer wants
*zero* Rust source-break, the alternative is separate variants
(`WriteNoteChecked { .., expected_hash }`), which is uglier and not recommended.

## <a name="api-decision-conflict-error-shape"></a>API decision: conflict error shape

This is the one place where there's a real "pick one" choice, so it's surfaced rather than decided.

### Option A — keep the string-based `ConcurrencyError` (what this PR ships)

Conflicts continue to return the existing `Error::ConcurrencyError { reason: String }`, with the
hashes interpolated into the message. **No change to the public `Error` enum**, so this option needs
no semver consideration on that axis.

- ✅ Non-breaking to the `Error` enum.
- ➖ Callers (especially agents) that want to recover programmatically must parse the message string
  to recover the expected/actual hashes.

### Option B — add a structured `ConcurrentModification` variant (opt-in)

Replace the string for these four call sites with a typed variant carrying the data needed for
machine recovery:

```rust
/// Concurrent modification detected by an optimistic-concurrency hash check.
/// `actual` is `None` when the file no longer exists.
#[error("Concurrent modification of {path}: expected hash {expected}, found {actual:?}. \
         Re-read the file and retry.")]
ConcurrentModification { path: PathBuf, expected: String, actual: Option<String> },
```

`write_file` / `edit_file` / `delete_file` / `move_file` return this instead of `ConcurrencyError`;
the MCP layer surfaces `expected` / `actual` / `path` as fields so agents don't parse strings.

- ✅ Machine-readable conflict signal — the most useful form for agent-driven retry/merge/escalate.
- ➖ **Public-enum change.** `Error` is not `#[non_exhaustive]`, so adding a variant breaks downstream
  exhaustive `match`es, and switching the returned variant is a behavioral break for anyone matching
  `ConcurrencyError`. Under strict semver this is a breaking change (→ `2.0.0`), though additive
  enum changes are often treated as minor in practice — the maintainer's call.

> If Option B is preferred, I'm happy to push it as a follow-up commit on this branch (the variant +
> the four call sites + structured field assertions in the existing conflict tests are
> straightforward). The implementation already exists in history and can be restored quickly.

## Out of scope

- A higher-level `edit_note_with_retry` helper (easy follow-up; the read→edit→conditional-write loop
  is already expressible).
- Distributed/advisory locking, automatic merge, and provenance — tracked separately.
