### PR TITLE
chore(release): prepare v1.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,27 @@ jobs:
         with:
           key: verify
 
+      - name: Verify release version
+        if: github.ref_type == 'tag'
+        shell: bash
+        run: |
+          VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)"
+          test "v${VERSION}" = "${GITHUB_REF_NAME}"
+          grep -q "^## \[${VERSION}\]" CHANGELOG.md
+
       - name: Verify formatting
         run: cargo fmt --all --check
 
       - name: Lint with clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        run: cargo test --workspace --all-targets --locked
+        run: cargo test --workspace --all-targets --all-features --locked
+
+      - name: Build documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --workspace --no-deps --locked
 
   # ── Publish Crates (manual for now) ──────────────────────────────────
   # publish:
@@ -59,11 +72,14 @@ jobs:
   #           sleep 30
   #         }
   #         publish turbovault-core
+  #         publish turbovault-git
+  #         publish turbovault-audit
   #         publish turbovault-parser
   #         publish turbovault-graph
+  #         publish turbovault-export
   #         publish turbovault-vault
   #         publish turbovault-batch
-  #         publish turbovault-export
+  #         publish turbovault-sql
   #         publish turbovault-tools
   #         publish turbovault
 
@@ -138,9 +154,9 @@ jobs:
       - name: Build
         run: |
           if [ "${{ matrix.use_cross }}" = "true" ]; then
-            cross build --release --target ${{ matrix.target }}
+            cross build --release --locked --target ${{ matrix.target }}
           else
-            cargo build --release --target ${{ matrix.target }}
+            cargo build --release --locked --target ${{ matrix.target }}
           fi
         shell: bash
 
@@ -226,7 +242,11 @@ jobs:
 
           # Create tar to preserve permissions and prevent corruption
           tar -czf "artifacts/$BINARY.tar.gz" "$BINARY"
-          sha256sum "$BINARY" > "artifacts/$BINARY.sha256"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$BINARY" > "artifacts/$BINARY.sha256"
+          else
+            shasum -a 256 "$BINARY" > "artifacts/$BINARY.sha256"
+          fi
           ls -lh "$BINARY"
           cat "artifacts/$BINARY.sha256"
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to TurboVault will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-07-17
+
+### Added
+
+- **Atomic Git-backed writes** ([#32](https://github.com/Epistates/turbovault/issues/32), [#37](https://github.com/Epistates/turbovault/pull/37)): New `turbovault-git` crate and opt-in `write_backend: git` mode. Each mutation builds an isolated Git tree and advances the branch with compare-and-swap; a multi-operation batch is one commit, so stale preconditions or later failures apply none of it.
+- **Cross-process write coordination**: An advisory repository lock spans commit creation, ref advancement, and working-tree materialization. TurboVault refuses to overwrite dirty or untracked touched paths and refuses writes while the Git index contains staged changes.
+- **Git worktree fanout tools**: `begin_fanout`, `commit_fanout`, `abandon_fanout`, and `list_orphan_fanouts` provide isolated workspaces for parallel agents, with fast-forward or merge-back support.
+- **Commit-driven derived-state reindexing**: Git-backed writes enqueue changed commit ranges and reconcile the graph/search state before dependent reads. External ref advances such as `git pull` are detected and indexed.
+- **Open Knowledge Format support**: Detect OKF bundles, validate OKF v0.1 conformance, resolve OKF cross-links, generate bundle indexes, surface grounding context, maintain change logs, and render an HTML vault viewer.
+- **Configurable tool visibility** ([#25](https://github.com/Epistates/turbovault/pull/25)): Allow, hide, or disable tools by name or tag through YAML, environment variables, and CLI options.
+- **Transport environment configuration** ([#26](https://github.com/Epistates/turbovault/pull/26)): Added the documented environment-variable surface for vault, config, tool visibility, and logging behavior.
+
+### Changed
+
+- **74 MCP tools**: The public tool surface grew from 70 to 74 with Git fanout, and is now implemented as focused providers composed through TurboMCP while preserving the existing flat tool names.
+- **Git-aware mutation routing**: Note writes, edits, deletes, moves, templates, frontmatter/tag updates, binary moves, and batches use the selected write backend. Git-backed note moves update inbound wikilinks atomically by default.
+- **Safer overwrite contract**: Existing-note overwrites require the hash returned by `read_note` unless `force=true` is explicitly supplied. Edit and batch preconditions are revalidated at the final write boundary.
+- **Batch execution contract**: Git-backed batches are all-or-nothing with per-path CAS. The compatibility backend remains sequential/fail-fast and now reports that execution mode and warns when completed operations were not rolled back.
+- **Performance**: Vault-wide metadata queries use validated cache-first scans, and Git repository handles and derived-state updates are reused or incrementally reconciled.
+- **Dependencies**: Updated TurboMCP to 3.1.5 and Git bindings to `git2` 0.21 / libgit2 1.9.4, alongside current compatible transitive security updates.
+
+### Fixed
+
+- **Attachment graph pollution**: Non-Markdown attachment links are excluded consistently from note graph ingestion and broken-link analysis.
+- **Edit TOCTOU race**: `edit_note` carries the validated pre-image hash into the final write instead of silently overwriting an intervening change.
+- **Batch stale-write window**: Supplied write/delete/move hashes are checked before legacy execution, while Git-backed batches recheck them against the atomic commit base.
+- **Provider contract drift**: Checked-in tool catalog, dispatch, schema, tag, visibility, and shared-state tests protect the decomposed server surface.
+
+### Security
+
+- **Working-tree protection**: Git-backed writes reject symlinks/non-regular touched paths, untracked collisions, dirty touched files, and staged-index state before materialization.
+- **Dependency audit refresh**: Removed Git-specific RustSec warnings by upgrading `git2`; only two allowed transitive warnings remain in the audit output.
+
+### Upgrade notes
+
+- Existing installations keep the compatibility write backend. To enable atomic multi-file transactions, point TurboVault at an existing Git repository and set `write_backend: git` in that vault's YAML configuration.
+- Git commits are the atomic source of truth. Working-tree paths are replaced atomically one file at a time; interrupted materialization is recoverable by idempotently resynchronizing from `HEAD`.
+- Audit/rollback MCP tools continue to serve the compatibility backend. For Git-backed vaults, use Git history and restore operations; TurboVault returns an explicit backend-specific message instead of an unrelated legacy audit.
+
 ## [1.5.0] - 2026-05-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-audit"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "log",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-batch"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "schemars",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-core"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "log",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-export"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "serde",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-git"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "criterion",
  "fs4",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-graph"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-parser"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "log",
  "pulldown-cmark",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-sql"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "gluesql",
  "log",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-tools"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-vault"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.0"
+version = "1.6.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Epistates, Inc <nick@epistates.com>"]
@@ -108,17 +108,17 @@ fs4 = "0.13"              # cross-process advisory lock for commit + materialize
 # sonic-rs = "0.3"         # Fastest JSON parser, deferred optimization
 
 # Workspace crates
-turbovault-core = { version = "1.5.0", path = "crates/turbovault-core" }
-turbovault-parser = { version = "1.5.0", path = "crates/turbovault-parser" }
-turbovault-graph = { version = "1.5.0", path = "crates/turbovault-graph" }
-turbovault-vault = { version = "1.5.0", path = "crates/turbovault-vault" }
-turbovault-batch = { version = "1.5.0", path = "crates/turbovault-batch" }
-turbovault-export = { version = "1.5.0", path = "crates/turbovault-export" }
-turbovault-audit = { version = "1.5.0", path = "crates/turbovault-audit" }
-turbovault-git = { version = "1.5.0", path = "crates/turbovault-git" }
-turbovault-sql = { version = "1.5.0", path = "crates/turbovault-sql" }
-turbovault-tools = { version = "1.5.0", path = "crates/turbovault-tools" }
-turbovault = { version = "1.5.0", path = "crates/turbovault" }
+turbovault-core = { version = "1.6.0", path = "crates/turbovault-core" }
+turbovault-parser = { version = "1.6.0", path = "crates/turbovault-parser" }
+turbovault-graph = { version = "1.6.0", path = "crates/turbovault-graph" }
+turbovault-vault = { version = "1.6.0", path = "crates/turbovault-vault" }
+turbovault-batch = { version = "1.6.0", path = "crates/turbovault-batch" }
+turbovault-export = { version = "1.6.0", path = "crates/turbovault-export" }
+turbovault-audit = { version = "1.6.0", path = "crates/turbovault-audit" }
+turbovault-git = { version = "1.6.0", path = "crates/turbovault-git" }
+turbovault-sql = { version = "1.6.0", path = "crates/turbovault-sql" }
+turbovault-tools = { version = "1.6.0", path = "crates/turbovault-tools" }
+turbovault = { version = "1.6.0", path = "crates/turbovault" }
 
 [profile.release]
 opt-level = 3

--- a/crates/turbovault-core/src/models.rs
+++ b/crates/turbovault-core/src/models.rs
@@ -460,7 +460,7 @@ pub enum ContentBlock {
     },
     /// A horizontal rule (---, ***, ___)
     HorizontalRule,
-    /// HTML <details><summary> block
+    /// HTML `<details><summary>` block
     Details {
         summary: String,
         content: String,
@@ -553,7 +553,7 @@ pub enum InlineElement {
     Emphasis { value: String },
     /// Inline code (`code`)
     Code { value: String },
-    /// A link [text](url)
+    /// A link such as `[text](url)`
     Link {
         text: String,
         url: String,

--- a/crates/turbovault-git/src/fanout.rs
+++ b/crates/turbovault-git/src/fanout.rs
@@ -297,7 +297,7 @@ impl VaultRepo {
     /// Scan this repo's registered worktrees for `wip-*` entries — fanout
     /// artifacts left over from a previous session. Pure read; never mutates.
     /// Caller decides whether to clean each one up (via
-    /// [`abandon_fanout_by_info`] if they can rebuild the [`FanoutInfo`], or
+    /// [`Self::abandon_fanout_by_info`] if they can rebuild the [`FanoutInfo`], or
     /// manually via `git worktree remove` + `git branch -D`).
     pub fn list_orphan_fanouts(&self) -> Result<Vec<OrphanFanout>> {
         let repo = self.git();

--- a/crates/turbovault-parser/src/blocks.rs
+++ b/crates/turbovault-parser/src/blocks.rs
@@ -802,7 +802,7 @@ fn collect_inline_elements(blocks: &[ContentBlock], output: &mut Vec<InlineEleme
 /// Parse markdown content into structured blocks.
 ///
 /// This is the main entry point for block-level parsing. It handles:
-/// - Wikilink preprocessing (converts [[x]] to markdown links)
+/// - Wikilink preprocessing (converts `[[x]]` to markdown links)
 /// - HTML details block extraction
 /// - Full pulldown-cmark parsing with GFM extensions
 ///

--- a/crates/turbovault-parser/src/standalone.rs
+++ b/crates/turbovault-parser/src/standalone.rs
@@ -42,11 +42,11 @@ pub struct ParseOptions {
     pub parse_frontmatter: bool,
     /// Parse wikilinks and embeds
     pub parse_wikilinks: bool,
-    /// Parse markdown links [text](url)
+    /// Parse markdown links such as `[text](url)`
     pub parse_markdown_links: bool,
     /// Parse headings (H1-H6)
     pub parse_headings: bool,
-    /// Parse task items (- [ ] / - [x])
+    /// Parse task items (`- [ ]` / `- [x]`)
     pub parse_tasks: bool,
     /// Parse callout blocks (> [!NOTE])
     pub parse_callouts: bool,
@@ -142,15 +142,15 @@ pub struct ParsedContent {
     pub frontmatter: Option<Frontmatter>,
     /// Document headings (H1-H6)
     pub headings: Vec<Heading>,
-    /// Wikilinks: [[Note]], [[Note|alias]], [[Note#heading]]
+    /// Wikilinks: `[[Note]]`, `[[Note|alias]]`, `[[Note#heading]]`
     pub wikilinks: Vec<Link>,
-    /// Embeds: ![[image.png]], ![[Note]]
+    /// Embeds: `![[image.png]]`, `![[Note]]`
     pub embeds: Vec<Link>,
-    /// Standard markdown links: [text](url)
+    /// Standard markdown links: `[text](url)`
     pub markdown_links: Vec<Link>,
     /// Inline tags: #tag, #nested/tag
     pub tags: Vec<Tag>,
-    /// Task items: - [ ], - [x]
+    /// Task items: `- [ ]`, `- [x]`
     pub tasks: Vec<TaskItem>,
     /// Callout blocks: > [!NOTE]
     pub callouts: Vec<Callout>,

--- a/crates/turbovault-tools/src/git_file_tools.rs
+++ b/crates/turbovault-tools/src/git_file_tools.rs
@@ -36,7 +36,7 @@ pub struct MoveWithLinksResult {
 }
 
 /// Callback invoked **before** returning a `ConcurrencyError` from
-/// [`GitFileTools::apply_txn`] (GWS.14b). The MCP server installs one that
+/// the internal `GitFileTools::apply_txn` path (GWS.14b). The MCP server installs one that
 /// drains the per-vault reindex queue — so the agent's re-read (which the
 /// error tells it to do) sees a coherent graph + search state, not the
 /// pre-conflict snapshot.
@@ -655,7 +655,7 @@ impl GitFileTools {
 
     /// Translate every [`BatchOperation`] to a single [`Changeset`] and
     /// commit as **one atomic commit** — either every op lands or none do.
-    /// This is the spec-promised behavior the legacy [`BatchTools`] never
+    /// This is the spec-promised behavior the legacy [`crate::BatchTools`] never
     /// actually delivered (the legacy path stopped at `failed_at` and left
     /// partial state on disk).
     pub async fn batch_execute(&self, operations: Vec<BatchOperation>) -> Result<BatchResult> {

--- a/crates/turbovault-tools/src/grounding.rs
+++ b/crates/turbovault-tools/src/grounding.rs
@@ -44,7 +44,7 @@ pub struct GroundingAnalysis {
     pub has_schema_section: bool,
     /// Whether an `# Examples` section is present.
     pub has_examples_section: bool,
-    /// Whether claims were truncated to [`MAX_CLAIMS`].
+    /// Whether claims were truncated to the internal maximum claim count.
     pub claims_truncated: bool,
     /// Extracted candidate claims (declarative prose sentences).
     pub claims: Vec<String>,

--- a/crates/turbovault/src/tools/providers/analysis.rs
+++ b/crates/turbovault/src/tools/providers/analysis.rs
@@ -21,7 +21,7 @@ impl Deref for AnalysisProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl AnalysisProvider {
     // ─── DIFF TOOLS ──────────────────────────────────────────────────
 

--- a/crates/turbovault/src/tools/providers/audit.rs
+++ b/crates/turbovault/src/tools/providers/audit.rs
@@ -21,7 +21,7 @@ impl Deref for AuditProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl AuditProvider {
     // ─── AUDIT TOOLS ─────────────────────────────────────────────────
 

--- a/crates/turbovault/src/tools/providers/batch.rs
+++ b/crates/turbovault/src/tools/providers/batch.rs
@@ -21,7 +21,7 @@ impl Deref for BatchProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl BatchProvider {
     // ==================== Batch Operations ====================
 

--- a/crates/turbovault/src/tools/providers/content.rs
+++ b/crates/turbovault/src/tools/providers/content.rs
@@ -21,7 +21,7 @@ impl Deref for ContentProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl ContentProvider {
     // ==================== Resources (OFM Knowledge Injection) ====================
 

--- a/crates/turbovault/src/tools/providers/context.rs
+++ b/crates/turbovault/src/tools/providers/context.rs
@@ -21,7 +21,7 @@ impl Deref for ContextProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl ContextProvider {
     // ==================== Vault Context (LLM Discovery) ====================
 

--- a/crates/turbovault/src/tools/providers/discovery.rs
+++ b/crates/turbovault/src/tools/providers/discovery.rs
@@ -21,7 +21,7 @@ impl Deref for DiscoveryProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl DiscoveryProvider {
     // ==================== Search (LLM Discovery) ====================
 

--- a/crates/turbovault/src/tools/providers/export.rs
+++ b/crates/turbovault/src/tools/providers/export.rs
@@ -21,7 +21,7 @@ impl Deref for ExportProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl ExportProvider {
     // ==================== Export Operations ====================
 

--- a/crates/turbovault/src/tools/providers/fanout.rs
+++ b/crates/turbovault/src/tools/providers/fanout.rs
@@ -54,7 +54,7 @@ impl Deref for FanoutProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl FanoutProvider {
     #[tool(
         description = "Open an isolated Git worktree for parallel agent writes. Fanout provides isolation, while batch_execute provides all-or-nothing multi-file atomicity.",

--- a/crates/turbovault/src/tools/providers/files.rs
+++ b/crates/turbovault/src/tools/providers/files.rs
@@ -21,7 +21,7 @@ impl Deref for FileProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl FileProvider {
     // ==================== File Operations ====================
 

--- a/crates/turbovault/src/tools/providers/graph.rs
+++ b/crates/turbovault/src/tools/providers/graph.rs
@@ -21,7 +21,7 @@ impl Deref for GraphProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl GraphProvider {
     // ==================== Search & Links ====================
 

--- a/crates/turbovault/src/tools/providers/metadata.rs
+++ b/crates/turbovault/src/tools/providers/metadata.rs
@@ -21,7 +21,7 @@ impl Deref for MetadataProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl MetadataProvider {
     // ==================== Metadata Operations ====================
 

--- a/crates/turbovault/src/tools/providers/relationship.rs
+++ b/crates/turbovault/src/tools/providers/relationship.rs
@@ -21,7 +21,7 @@ impl Deref for RelationshipProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl RelationshipProvider {
     // ==================== Relationship Operations ====================
 

--- a/crates/turbovault/src/tools/providers/templates.rs
+++ b/crates/turbovault/src/tools/providers/templates.rs
@@ -21,7 +21,7 @@ impl Deref for TemplateProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl TemplateProvider {
     // ==================== Templates (LLM Note Creation) ====================
 

--- a/crates/turbovault/src/tools/providers/vault.rs
+++ b/crates/turbovault/src/tools/providers/vault.rs
@@ -21,7 +21,7 @@ impl Deref for VaultProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.5.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl VaultProvider {
     // ==================== Vault Lifecycle (Multi-Vault Management) ====================
 


### PR DESCRIPTION
## Release scope

Prepares TurboVault 1.6.0 around the production-ready work since 1.5.0:

- atomic Git-backed writes and all-or-nothing multi-file CAS from #37
- cross-process commit/materialization locking and working-tree safety
- Git worktree fanout plus commit-driven graph/search reindexing
- Open Knowledge Format detection, validation, indexing, grounding, logs, and viewer
- provider decomposition with checked-in tool contract coverage
- configurable tool visibility, transport environment configuration, cache-first query improvements, attachment graph fixes, and concurrency hardening

## Release preparation

- bumps all workspace crates and MCP provider metadata to 1.6.0
- adds complete upgrade notes and compatibility guarantees to CHANGELOG.md
- verifies tag/version/changelog consistency in the release workflow
- runs release lint/tests with all features and locked dependencies
- makes rustdoc warnings release-blocking and fixes all existing warnings
- restores the complete future crate publish order, including turbovault-git, turbovault-audit, and turbovault-sql
- uses locked cross-platform builds and portable macOS/Linux checksum generation

## Local validation

- all 11 workspace crates package successfully as 1.6.0
- `cargo test --workspace --all-targets --all-features --locked --no-fail-fast`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- `cargo fmt --all -- --check`
- `cargo audit` passes with two allowed transitive warnings and no Git-specific findings
- `cargo build --release --locked`
- optimized binary reports `turbovault 1.6.0`
