### PR TITLE
feat: establish Phase 2 plugin API boundary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
   #         publish turbovault-batch
   #         publish turbovault-sql
   #         publish turbovault-tools
+  #         publish turbovault-plugin-api
   #         publish turbovault
 
   # ── Build Prebuilt Binaries ───────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to TurboVault will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Compiled-in plugin boundary** ([#34](https://github.com/Epistates/turbovault/issues/34)): Added the default-off `plugin-api` feature and the publishable `turbovault-plugin-api` crate. Plugins receive a curated CAS-only `VaultApi`, an object-safe tool provider contract, redacted request context, strict MCP namespaces, and a bounded hook bus with explicit lag/resync and close semantics.
+- **Best-effort hook provenance** ([#33](https://github.com/Epistates/turbovault/issues/33)): Plugin writes can carry source and correlation metadata into advisory event envelopes. Attribution is explicitly not an authentication boundary, and uncorrelated events fail open as external-or-unknown.
+
 ## [1.6.0] - 2026-07-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5181,6 +5181,7 @@ name = "turbovault"
 version = "1.6.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "config",
  "criterion",
@@ -5205,6 +5206,7 @@ dependencies = [
  "turbomcp-types",
  "turbovault-audit",
  "turbovault-core",
+ "turbovault-plugin-api",
  "turbovault-tools",
  "turbovault-vault",
  "uuid",
@@ -5314,6 +5316,18 @@ dependencies = [
  "tokio",
  "turbovault-core",
  "yaml_serde",
+]
+
+[[package]]
+name = "turbovault-plugin-api"
+version = "1.6.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "turbomcp-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/turbovault-git",
     "crates/turbovault-sql",
     "crates/turbovault-tools",
+    "crates/turbovault-plugin-api",
     "crates/turbovault",
 ]
 resolver = "2"
@@ -118,6 +119,7 @@ turbovault-audit = { version = "1.6.0", path = "crates/turbovault-audit" }
 turbovault-git = { version = "1.6.0", path = "crates/turbovault-git" }
 turbovault-sql = { version = "1.6.0", path = "crates/turbovault-sql" }
 turbovault-tools = { version = "1.6.0", path = "crates/turbovault-tools" }
+turbovault-plugin-api = { version = "1.6.0", path = "crates/turbovault-plugin-api" }
 turbovault = { version = "1.6.0", path = "crates/turbovault" }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ TurboVault is a modular system composed of specialized crates. You can depend on
 | **[turbovault-graph](crates/turbovault-graph)** | Link graph analysis & relationship discovery | [![Docs.rs](https://docs.rs/turbovault-graph/badge.svg)](https://docs.rs/turbovault-graph) |
 | **[turbovault-vault](crates/turbovault-vault)** | Vault management, file I/O & atomic writes | [![Docs.rs](https://docs.rs/turbovault-vault/badge.svg)](https://docs.rs/turbovault-vault) |
 | **[turbovault-tools](crates/turbovault-tools)** | 74 MCP tool implementations | [![Docs.rs](https://docs.rs/turbovault-tools/badge.svg)](https://docs.rs/turbovault-tools) |
+| **[turbovault-plugin-api](crates/turbovault-plugin-api)** | Stable facade, provider contract & bounded hooks for compiled-in plugins | [![Docs.rs](https://docs.rs/turbovault-plugin-api/badge.svg)](https://docs.rs/turbovault-plugin-api) |
 | **[turbovault-sql](crates/turbovault-sql)** | SQL frontmatter queries (GlueSQL) | [![Docs.rs](https://docs.rs/turbovault-sql/badge.svg)](https://docs.rs/turbovault-sql) |
 | **[turbovault-batch](crates/turbovault-batch)** | Validated fail-fast operation batches | [![Docs.rs](https://docs.rs/turbovault-batch/badge.svg)](https://docs.rs/turbovault-batch) |
 | **[turbovault-export](crates/turbovault-export)** | Export & reporting (JSON/CSV/MD) | [![Docs.rs](https://docs.rs/turbovault-export/badge.svg)](https://docs.rs/turbovault-export) |
@@ -496,6 +497,7 @@ turbovault-batch       — Validated sequential batch operations
 turbovault-export      — JSON/CSV/Markdown export
 turbovault-sql         — SQL frontmatter queries (GlueSQL, feature-gated)
 turbovault-tools       — 74 MCP tool implementations
+turbovault-plugin-api  — Curated plugin facade, provider contract, event hooks
 turbovault (binary)    — CLI and MCP server entry point
 ```
 

--- a/crates/turbovault-plugin-api/Cargo.toml
+++ b/crates/turbovault-plugin-api/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "turbovault-plugin-api"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish = true
+description = "Stable plugin contract and curated vault facade for TurboVault"
+documentation = "https://docs.rs/turbovault-plugin-api"
+readme = "README.md"
+keywords = ["mcp", "obsidian", "vault", "plugin", "turbovault"]
+categories = ["development-tools", "text-processing"]
+
+[dependencies]
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+turbomcp-types = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/turbovault-plugin-api/README.md
+++ b/crates/turbovault-plugin-api/README.md
@@ -1,0 +1,12 @@
+# TurboVault Plugin API
+
+`turbovault-plugin-api` is the stable boundary between TurboVault and its
+compiled-in, feature-gated plugins.
+
+It deliberately exposes a small `VaultApi` facade instead of TurboVault's
+internal managers or MCP server. Plugins can read and safely write notes,
+advertise namespaced MCP tools, and consume a bounded best-effort vault event
+stream.
+
+The v1 plugin model is curated and compiled in. It does not load dynamic code,
+provide FFI, or sandbox plugins.

--- a/crates/turbovault-plugin-api/src/error.rs
+++ b/crates/turbovault-plugin-api/src/error.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+
+/// Stable, machine-readable categories returned across the plugin boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginErrorCode {
+    /// A request was malformed or violated a contract precondition.
+    InvalidInput,
+    /// The requested vault, note, or tool does not exist.
+    NotFound,
+    /// An optimistic-concurrency precondition failed.
+    Conflict,
+    /// A required host capability is temporarily unavailable.
+    Unavailable,
+    /// The host or plugin failed unexpectedly.
+    Internal,
+}
+
+/// Error type shared by the host and plugins.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[error("{code:?}: {message}")]
+pub struct PluginError {
+    /// Stable error category.
+    pub code: PluginErrorCode,
+    /// Human-readable detail safe to return to a plugin caller.
+    pub message: String,
+}
+
+impl PluginError {
+    /// Construct an error with a stable code.
+    pub fn new(code: PluginErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    /// Construct an invalid-input error.
+    pub fn invalid_input(message: impl Into<String>) -> Self {
+        Self::new(PluginErrorCode::InvalidInput, message)
+    }
+
+    /// Construct a not-found error.
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::new(PluginErrorCode::NotFound, message)
+    }
+
+    /// Construct a concurrency-conflict error.
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self::new(PluginErrorCode::Conflict, message)
+    }
+
+    /// Construct an unavailable error.
+    pub fn unavailable(message: impl Into<String>) -> Self {
+        Self::new(PluginErrorCode::Unavailable, message)
+    }
+
+    /// Construct an internal error.
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::new(PluginErrorCode::Internal, message)
+    }
+}
+
+/// Result type used by plugin contracts.
+pub type PluginResult<T> = Result<T, PluginError>;

--- a/crates/turbovault-plugin-api/src/hooks.rs
+++ b/crates/turbovault-plugin-api/src/hooks.rs
@@ -1,0 +1,326 @@
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+/// Provenance supplied by a writer for best-effort event correlation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WriteProvenance {
+    /// Stable caller-selected source, such as `daily-review-agent`.
+    pub source: String,
+    /// Optional identifier connecting related operations.
+    pub correlation_id: Option<String>,
+    /// Optional human-readable reason.
+    pub note: Option<String>,
+}
+
+/// Best-effort event attribution.
+///
+/// This is advisory loop-prevention metadata, never an authorization or
+/// security boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "provenance")]
+pub enum EventAttribution {
+    /// The host correlated the observed content with a known write.
+    Attributed(WriteProvenance),
+    /// No trusted correlation was available; the change may be external.
+    ExternalOrUnknown,
+}
+
+/// A vault mutation observed by a hook producer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum HookEvent {
+    /// A note was created.
+    FileCreated {
+        /// Vault-relative path.
+        path: String,
+    },
+    /// A note was modified.
+    FileModified {
+        /// Vault-relative path.
+        path: String,
+    },
+    /// A note was deleted.
+    FileDeleted {
+        /// Vault-relative path.
+        path: String,
+    },
+    /// A note moved between two paths.
+    FileRenamed {
+        /// Original vault-relative path.
+        from: String,
+        /// New vault-relative path.
+        to: String,
+    },
+    /// The authoritative state must be re-read after a producer reset.
+    ResyncRequired {
+        /// Human-readable reason for the reset.
+        reason: String,
+    },
+}
+
+/// Sequenced event delivered to hook subscribers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VaultEventEnvelope {
+    /// Process-local monotonic sequence number.
+    pub sequence: u64,
+    /// Observation time as Unix epoch milliseconds.
+    pub observed_at_ms: u64,
+    /// Vault name.
+    pub vault: String,
+    /// Observed mutation.
+    pub event: HookEvent,
+    /// Content identity when it was available at observation time.
+    pub content_hash: Option<String>,
+    /// Best-effort writer attribution.
+    pub attribution: EventAttribution,
+}
+
+/// Current event-bus lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookLifecycle {
+    /// New events may be published.
+    Running,
+    /// No further events will be accepted.
+    Closed,
+}
+
+/// Publish failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum PublishError {
+    /// The bus was explicitly closed.
+    #[error("hook bus is closed")]
+    Closed,
+}
+
+/// Receive failure with explicit overflow semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum HookRecvError {
+    /// No event is currently available to a non-blocking receiver.
+    #[error("no hook event is currently available")]
+    Empty,
+    /// This subscriber fell behind the bounded ring buffer.
+    ///
+    /// The consumer must re-read authoritative vault state before continuing.
+    #[error("hook subscriber lagged by {skipped} event(s); resync required")]
+    Lagged {
+        /// Number of discarded envelopes.
+        skipped: u64,
+    },
+    /// The bus closed and all buffered events were drained.
+    #[error("hook bus is closed")]
+    Closed,
+}
+
+struct HookBusInner {
+    sender: Mutex<Option<broadcast::Sender<VaultEventEnvelope>>>,
+    sequence: AtomicU64,
+    closed: AtomicBool,
+    capacity: usize,
+}
+
+/// Cloneable bounded event bus shared by a host and its plugins.
+///
+/// Delivery is best-effort. A slow subscriber receives
+/// [`HookRecvError::Lagged`] and must resynchronize from [`crate::VaultApi`].
+#[derive(Clone)]
+pub struct HookBus {
+    inner: Arc<HookBusInner>,
+}
+
+impl std::fmt::Debug for HookBus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HookBus")
+            .field("capacity", &self.capacity())
+            .field("lifecycle", &self.lifecycle())
+            .finish()
+    }
+}
+
+impl HookBus {
+    fn sender(&self) -> std::sync::MutexGuard<'_, Option<broadcast::Sender<VaultEventEnvelope>>> {
+        self.inner
+            .sender
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Create a bus with a fixed per-subscriber ring-buffer capacity.
+    ///
+    /// A zero capacity is promoted to one.
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        let (sender, _) = broadcast::channel(capacity);
+        Self {
+            inner: Arc::new(HookBusInner {
+                sender: Mutex::new(Some(sender)),
+                sequence: AtomicU64::new(0),
+                closed: AtomicBool::new(false),
+                capacity,
+            }),
+        }
+    }
+
+    /// Return the fixed ring-buffer capacity.
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity
+    }
+
+    /// Return whether new events are accepted.
+    pub fn lifecycle(&self) -> HookLifecycle {
+        if self.inner.closed.load(Ordering::Acquire) {
+            HookLifecycle::Closed
+        } else {
+            HookLifecycle::Running
+        }
+    }
+
+    /// Subscribe to future events.
+    pub fn subscribe(&self) -> Result<HookSubscription, PublishError> {
+        let guard = self.sender();
+        let sender = guard.as_ref().ok_or(PublishError::Closed)?;
+        Ok(HookSubscription {
+            receiver: sender.subscribe(),
+        })
+    }
+
+    /// Sequence and publish an advisory event.
+    ///
+    /// Success does not imply that a subscriber exists.
+    pub fn publish(
+        &self,
+        vault: impl Into<String>,
+        event: HookEvent,
+        content_hash: Option<String>,
+        attribution: EventAttribution,
+    ) -> Result<VaultEventEnvelope, PublishError> {
+        let guard = self.sender();
+        let sender = guard.as_ref().ok_or(PublishError::Closed)?;
+        let envelope = VaultEventEnvelope {
+            sequence: self.inner.sequence.fetch_add(1, Ordering::Relaxed) + 1,
+            observed_at_ms: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX),
+            vault: vault.into(),
+            event,
+            content_hash,
+            attribution,
+        };
+        let _subscriber_count = sender.send(envelope.clone());
+        Ok(envelope)
+    }
+
+    /// Stop accepting events and close subscribers after buffered delivery.
+    ///
+    /// Returns `true` only for the call that changed the lifecycle.
+    pub fn close(&self) -> bool {
+        let mut guard = self.sender();
+        let changed = guard.take().is_some();
+        self.inner.closed.store(true, Ordering::Release);
+        changed
+    }
+}
+
+/// A single bounded subscription to [`HookBus`].
+pub struct HookSubscription {
+    receiver: broadcast::Receiver<VaultEventEnvelope>,
+}
+
+impl std::fmt::Debug for HookSubscription {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HookSubscription")
+            .finish_non_exhaustive()
+    }
+}
+
+impl HookSubscription {
+    /// Wait for the next event or an explicit lag/close condition.
+    pub async fn recv(&mut self) -> Result<VaultEventEnvelope, HookRecvError> {
+        self.receiver.recv().await.map_err(|error| match error {
+            broadcast::error::RecvError::Closed => HookRecvError::Closed,
+            broadcast::error::RecvError::Lagged(skipped) => HookRecvError::Lagged { skipped },
+        })
+    }
+
+    /// Receive immediately without waiting.
+    pub fn try_recv(&mut self) -> Result<VaultEventEnvelope, HookRecvError> {
+        self.receiver.try_recv().map_err(|error| match error {
+            broadcast::error::TryRecvError::Closed => HookRecvError::Closed,
+            broadcast::error::TryRecvError::Lagged(skipped) => HookRecvError::Lagged { skipped },
+            broadcast::error::TryRecvError::Empty => HookRecvError::Empty,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn publish(bus: &HookBus, path: &str) -> VaultEventEnvelope {
+        bus.publish(
+            "test",
+            HookEvent::FileModified {
+                path: path.to_string(),
+            },
+            None,
+            EventAttribution::ExternalOrUnknown,
+        )
+        .expect("publish")
+    }
+
+    #[tokio::test]
+    async fn sequences_events_and_closes_after_buffered_delivery() {
+        let bus = HookBus::new(2);
+        let mut subscription = bus.subscribe().expect("subscribe");
+        assert_eq!(publish(&bus, "a.md").sequence, 1);
+        assert_eq!(publish(&bus, "b.md").sequence, 2);
+        assert!(bus.close());
+        assert!(!bus.close());
+
+        assert_eq!(subscription.recv().await.expect("first").sequence, 1);
+        assert_eq!(subscription.recv().await.expect("second").sequence, 2);
+        assert_eq!(subscription.recv().await, Err(HookRecvError::Closed));
+        assert_eq!(bus.lifecycle(), HookLifecycle::Closed);
+    }
+
+    #[tokio::test]
+    async fn reports_lag_and_requires_resync() {
+        let bus = HookBus::new(1);
+        let mut subscription = bus.subscribe().expect("subscribe");
+        publish(&bus, "a.md");
+        publish(&bus, "b.md");
+
+        assert_eq!(
+            subscription.recv().await,
+            Err(HookRecvError::Lagged { skipped: 1 })
+        );
+        assert_eq!(subscription.recv().await.expect("retained").sequence, 2);
+    }
+
+    #[test]
+    fn rejects_new_work_after_close() {
+        let bus = HookBus::new(0);
+        assert_eq!(bus.capacity(), 1);
+        assert!(bus.close());
+        assert!(matches!(bus.subscribe(), Err(PublishError::Closed)));
+        assert_eq!(
+            bus.publish(
+                "test",
+                HookEvent::ResyncRequired {
+                    reason: "closed".to_string()
+                },
+                None,
+                EventAttribution::ExternalOrUnknown
+            ),
+            Err(PublishError::Closed)
+        );
+    }
+}

--- a/crates/turbovault-plugin-api/src/lib.rs
+++ b/crates/turbovault-plugin-api/src/lib.rs
@@ -1,0 +1,29 @@
+//! Stable contracts for compiled-in TurboVault plugins.
+//!
+//! This crate is intentionally smaller than TurboVault's internal API. A
+//! plugin receives a curated [`VaultApi`] facade and an advisory [`HookBus`],
+//! never a raw vault manager or MCP server.
+//!
+//! Plugins are compiled into the host behind default-off Cargo features. The
+//! host mounts each plugin under [`PluginDescriptor::id`], so a local tool
+//! called `list` in the `tasks` plugin is advertised as `tasks_list`.
+
+mod error;
+mod hooks;
+mod provider;
+mod vault;
+
+pub use error::{PluginError, PluginErrorCode, PluginResult};
+pub use hooks::{
+    EventAttribution, HookBus, HookEvent, HookLifecycle, HookRecvError, HookSubscription,
+    PublishError, VaultEventEnvelope, WriteProvenance,
+};
+pub use provider::{
+    Plugin, PluginContext, PluginDescriptor, PluginProvider, PluginRequestContext,
+    validate_plugin_id,
+};
+pub use turbomcp_types::{Tool, ToolResult};
+pub use vault::{
+    NoteSnapshot, VaultApi, VaultDescriptor, VaultHost, WriteNoteRequest, WritePrecondition,
+    WriteReceipt,
+};

--- a/crates/turbovault-plugin-api/src/provider.rs
+++ b/crates/turbovault-plugin-api/src/provider.rs
@@ -1,0 +1,140 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{HookBus, PluginError, PluginResult, Tool, ToolResult, VaultApi};
+
+/// Stable identity and compatibility metadata for a compiled-in plugin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PluginDescriptor {
+    /// Namespace used for every MCP capability, for example `tasks`.
+    pub id: String,
+    /// Human-readable plugin name.
+    pub name: String,
+    /// Plugin version.
+    pub version: String,
+    /// Short human-readable purpose.
+    pub description: String,
+}
+
+impl PluginDescriptor {
+    /// Validate the descriptor before the host mounts any capabilities.
+    pub fn validate(&self) -> PluginResult<()> {
+        validate_plugin_id(&self.id)?;
+        if self.name.trim().is_empty() {
+            return Err(PluginError::invalid_input("plugin name must not be empty"));
+        }
+        if self.version.trim().is_empty() {
+            return Err(PluginError::invalid_input(
+                "plugin version must not be empty",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Validate a plugin namespace.
+///
+/// IDs must start with a lowercase ASCII letter and then contain only
+/// lowercase ASCII letters, digits, or underscores.
+pub fn validate_plugin_id(id: &str) -> PluginResult<()> {
+    let mut chars = id.chars();
+    if !matches!(chars.next(), Some('a'..='z'))
+        || !chars.all(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '_'
+        })
+    {
+        return Err(PluginError::invalid_input(format!(
+            "invalid plugin id {id:?}; expected [a-z][a-z0-9_]*"
+        )));
+    }
+    Ok(())
+}
+
+/// Curated request data passed to plugin tool calls.
+///
+/// Authentication internals and raw transport/session handles intentionally do
+/// not cross the plugin boundary.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PluginRequestContext {
+    /// Host request identifier.
+    pub request_id: String,
+    /// Authenticated user identifier, when available.
+    pub user_id: Option<String>,
+    /// Stateful transport session identifier, when available.
+    pub session_id: Option<String>,
+    /// Client application identifier, when available.
+    pub client_id: Option<String>,
+    /// Serializable request metadata copied by the host.
+    pub metadata: BTreeMap<String, Value>,
+}
+
+/// Capabilities provided to a plugin when it is constructed.
+#[derive(Debug, Clone)]
+pub struct PluginContext {
+    /// Curated vault operations.
+    pub vault: VaultApi,
+    /// Bounded, advisory hook/event bus.
+    pub hooks: HookBus,
+}
+
+/// Object-safe MCP tool provider implemented by a plugin.
+#[async_trait]
+pub trait PluginProvider: Send + Sync {
+    /// Return local, unprefixed tool descriptors.
+    fn tools(&self) -> Vec<Tool>;
+
+    /// Call a local, unprefixed tool.
+    async fn call_tool(
+        &self,
+        name: &str,
+        arguments: Value,
+        context: PluginRequestContext,
+    ) -> PluginResult<ToolResult>;
+}
+
+/// Factory contract for a compiled-in plugin.
+pub trait Plugin: Send + Sync {
+    /// Return plugin identity before construction.
+    fn descriptor(&self) -> PluginDescriptor;
+
+    /// Build the provider using host-curated capabilities.
+    fn build(&self, context: PluginContext) -> PluginResult<Arc<dyn PluginProvider>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_ids_are_stable_mcp_namespaces() {
+        for valid in ["tasks", "vault_events", "vector2"] {
+            validate_plugin_id(valid).expect("valid namespace");
+        }
+        for invalid in ["", "Tasks", "2vector", "vault-events", "vault events"] {
+            let error = validate_plugin_id(invalid).expect_err("invalid namespace");
+            assert_eq!(error.code, crate::PluginErrorCode::InvalidInput);
+        }
+    }
+
+    #[test]
+    fn descriptors_require_user_facing_identity() {
+        let descriptor = PluginDescriptor {
+            id: "tasks".to_string(),
+            name: " ".to_string(),
+            version: "1.0.0".to_string(),
+            description: String::new(),
+        };
+        assert!(descriptor.validate().is_err());
+
+        let descriptor = PluginDescriptor {
+            name: "Tasks".to_string(),
+            version: String::new(),
+            ..descriptor
+        };
+        assert!(descriptor.validate().is_err());
+    }
+}

--- a/crates/turbovault-plugin-api/src/vault.rs
+++ b/crates/turbovault-plugin-api/src/vault.rs
@@ -1,0 +1,126 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::{PluginResult, WriteProvenance};
+
+/// Public identity of the vault selected by the host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VaultDescriptor {
+    /// Host-configured vault name.
+    pub name: String,
+    /// Write substrate selected for this vault.
+    pub write_backend: String,
+}
+
+/// A note plus the backend-native version token used for safe writes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoteSnapshot {
+    /// Vault containing the note.
+    pub vault: String,
+    /// Vault-relative path using `/` separators.
+    pub path: String,
+    /// Complete markdown content.
+    pub content: String,
+    /// Opaque token accepted by [`WritePrecondition::Match`].
+    pub version: String,
+}
+
+/// Required optimistic-concurrency condition for a plugin write.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "version")]
+pub enum WritePrecondition {
+    /// Refuse if the target already exists.
+    CreateOnly,
+    /// Replace only the exact version previously returned by [`VaultApi::read_note`].
+    Match(String),
+}
+
+/// Safe full-note write request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WriteNoteRequest {
+    /// Vault-relative note path.
+    pub path: String,
+    /// Complete replacement content.
+    pub content: String,
+    /// Mandatory create-or-CAS condition; blind overwrites are not exposed.
+    pub precondition: WritePrecondition,
+    /// Optional Git commit subject. Hosts may require it by policy.
+    pub commit_message: Option<String>,
+    /// Optional best-effort writer identity for hook correlation.
+    ///
+    /// This metadata is advisory and is not an authorization boundary.
+    pub provenance: Option<WriteProvenance>,
+}
+
+/// Result of a successful plugin write.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WriteReceipt {
+    /// Vault containing the note.
+    pub vault: String,
+    /// Vault-relative path that was written.
+    pub path: String,
+    /// New backend-native version token.
+    pub version: String,
+    /// Number of content bytes written.
+    pub bytes: usize,
+}
+
+/// Host implementation behind [`VaultApi`].
+///
+/// The trait is public so plugin crates can provide small fakes in their own
+/// tests. Production implementations remain owned by the TurboVault host.
+#[async_trait]
+pub trait VaultHost: Send + Sync {
+    /// Return the active vault identity.
+    async fn active_vault(&self) -> PluginResult<VaultDescriptor>;
+
+    /// List markdown note paths in the active vault.
+    async fn list_notes(&self) -> PluginResult<Vec<String>>;
+
+    /// Read a complete note and its opaque version.
+    async fn read_note(&self, path: &str) -> PluginResult<NoteSnapshot>;
+
+    /// Create or compare-and-swap a complete note.
+    async fn write_note(&self, request: WriteNoteRequest) -> PluginResult<WriteReceipt>;
+}
+
+/// Cloneable, curated facade supplied to every plugin.
+#[derive(Clone)]
+pub struct VaultApi {
+    host: Arc<dyn VaultHost>,
+}
+
+impl std::fmt::Debug for VaultApi {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("VaultApi").finish_non_exhaustive()
+    }
+}
+
+impl VaultApi {
+    /// Wrap a host implementation.
+    pub fn new(host: Arc<dyn VaultHost>) -> Self {
+        Self { host }
+    }
+
+    /// Return the active vault identity.
+    pub async fn active_vault(&self) -> PluginResult<VaultDescriptor> {
+        self.host.active_vault().await
+    }
+
+    /// List markdown note paths in the active vault.
+    pub async fn list_notes(&self) -> PluginResult<Vec<String>> {
+        self.host.list_notes().await
+    }
+
+    /// Read a complete note and its opaque version.
+    pub async fn read_note(&self, path: &str) -> PluginResult<NoteSnapshot> {
+        self.host.read_note(path).await
+    }
+
+    /// Create or compare-and-swap a complete note.
+    pub async fn write_note(&self, request: WriteNoteRequest) -> PluginResult<WriteReceipt> {
+        self.host.write_note(request).await
+    }
+}

--- a/crates/turbovault/Cargo.toml
+++ b/crates/turbovault/Cargo.toml
@@ -40,6 +40,10 @@ unix = ["turbomcp/unix"]                     # Add Unix socket support (~100 KB)
 # SQL frontmatter queries (GlueSQL)
 sql = ["turbovault-tools/sql"]
 
+# Stable compiled-in plugin boundary. Individual plugin features added under
+# crates/plugins/ must include this feature and remain default-off.
+plugin-api = ["dep:async-trait", "dep:turbovault-plugin-api"]
+
 # Convenience bundles
 http-full = ["http", "websocket"]            # HTTP + WebSocket
 # Note: unix is excluded from all-transports on Windows (not supported)
@@ -56,6 +60,7 @@ turbovault-core = { workspace = true }
 turbovault-vault = { workspace = true }
 turbovault-audit = { workspace = true }
 turbovault-tools = { workspace = true }
+turbovault-plugin-api = { workspace = true, optional = true }
 
 # MCP server framework (features passed through from turbovault)
 turbomcp = { workspace = true, features = ["stdio", "telemetry"] }
@@ -73,6 +78,7 @@ yaml_serde = { workspace = true }
 config = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
+async-trait = { workspace = true, optional = true }
 log = { workspace = true }
 simple_logger = "5.2"
 tracing = { workspace = true }

--- a/crates/turbovault/src/tools.rs
+++ b/crates/turbovault/src/tools.rs
@@ -23,6 +23,9 @@ use turbovault_vault::VaultManager;
 mod providers;
 pub use providers::ObsidianMcpServer;
 
+#[cfg(feature = "plugin-api")]
+mod plugin_host;
+
 #[cfg(feature = "sql")]
 use turbovault_tools::FrontmatterSqlEngine;
 

--- a/crates/turbovault/src/tools/plugin_host.rs
+++ b/crates/turbovault/src/tools/plugin_host.rs
@@ -1,0 +1,199 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use turbovault_core::config::WriteBackend;
+use turbovault_core::error::Error;
+use turbovault_plugin_api::{
+    EventAttribution, HookBus, HookEvent, NoteSnapshot, PluginError, PluginResult, VaultDescriptor,
+    VaultHost, WriteNoteRequest, WritePrecondition, WriteReceipt,
+};
+use turbovault_tools::{FileTools, WriteMode};
+
+use super::CoreToolHandler;
+
+pub(super) struct PluginVaultHost {
+    core: CoreToolHandler,
+    hooks: HookBus,
+}
+
+impl PluginVaultHost {
+    pub(super) fn new(core: CoreToolHandler, hooks: HookBus) -> Self {
+        Self { core, hooks }
+    }
+}
+
+fn map_core_error(error: Error) -> PluginError {
+    match error {
+        Error::FileNotFound { .. } | Error::NotFound { .. } => {
+            PluginError::not_found(error.to_string())
+        }
+        Error::Io(ref io_error) if io_error.kind() == std::io::ErrorKind::NotFound => {
+            PluginError::not_found(error.to_string())
+        }
+        Error::InvalidPath { .. }
+        | Error::PathTraversalAttempt { .. }
+        | Error::FileTooLarge { .. }
+        | Error::ParseError { .. }
+        | Error::ValidationError { .. } => PluginError::invalid_input(error.to_string()),
+        Error::ConcurrencyError { .. } => PluginError::conflict(error.to_string()),
+        Error::ConfigError { .. } => PluginError::unavailable(error.to_string()),
+        Error::Io(_) | Error::Other(_) | Error::Wrapped(_) => {
+            PluginError::internal(error.to_string())
+        }
+    }
+}
+
+fn map_host_error(error: impl std::fmt::Display) -> PluginError {
+    PluginError::unavailable(error.to_string())
+}
+
+#[async_trait]
+impl VaultHost for PluginVaultHost {
+    async fn active_vault(&self) -> PluginResult<VaultDescriptor> {
+        let name = self
+            .core
+            .get_active_vault_name()
+            .await
+            .map_err(map_host_error)?;
+        let config = self
+            .core
+            .multi_vault_mgr
+            .get_active_vault_config()
+            .await
+            .map_err(map_core_error)?;
+        let write_backend = match config.write_backend {
+            WriteBackend::Legacy => "legacy",
+            WriteBackend::Git => "git",
+        };
+        Ok(VaultDescriptor {
+            name,
+            write_backend: write_backend.to_string(),
+        })
+    }
+
+    async fn list_notes(&self) -> PluginResult<Vec<String>> {
+        let manager = self
+            .core
+            .get_active_vault_manager()
+            .await
+            .map_err(map_host_error)?;
+        let mut notes = manager
+            .scan_vault()
+            .await
+            .map_err(map_core_error)?
+            .iter()
+            .map(|path| manager.relative_path(path))
+            .collect::<Vec<_>>();
+        notes.sort();
+        Ok(notes)
+    }
+
+    async fn read_note(&self, path: &str) -> PluginResult<NoteSnapshot> {
+        let (vault, manager) = self.core.get_vault_pair().await.map_err(map_host_error)?;
+        let content = FileTools::new(manager)
+            .read_file(path)
+            .await
+            .map_err(map_core_error)?;
+        let version = self
+            .core
+            .hash_for_active_backend(&content)
+            .await
+            .map_err(map_host_error)?;
+        Ok(NoteSnapshot {
+            vault,
+            path: path.to_string(),
+            content,
+            version,
+        })
+    }
+
+    async fn write_note(&self, request: WriteNoteRequest) -> PluginResult<WriteReceipt> {
+        let vault = self
+            .core
+            .get_active_vault_name()
+            .await
+            .map_err(map_host_error)?;
+        let manager = self
+            .core
+            .get_active_vault_manager()
+            .await
+            .map_err(map_host_error)?;
+        let tools = self
+            .core
+            .get_active_write_tools()
+            .await
+            .map_err(map_host_error)?;
+        let resolved_path = manager
+            .resolve_path(Path::new(&request.path))
+            .map_err(map_core_error)?;
+        let message = self
+            .core
+            .resolve_commit_message(request.commit_message.clone(), || {
+                format!("plugin write {}", request.path)
+            })
+            .await
+            .map_err(map_host_error)?;
+
+        match &request.precondition {
+            WritePrecondition::CreateOnly => {
+                if !tools.is_git() && tokio::fs::try_exists(&resolved_path).await.unwrap_or(false) {
+                    return Err(PluginError::conflict(format!(
+                        "create refused: {:?} already exists",
+                        request.path
+                    )));
+                }
+                tools
+                    .create_file_with_message(&request.path, &request.content, &message)
+                    .await
+                    .map_err(map_core_error)?;
+            }
+            WritePrecondition::Match(version) => {
+                tools
+                    .write_file_with_mode_and_message(
+                        &request.path,
+                        &request.content,
+                        WriteMode::Overwrite,
+                        Some(version),
+                        &message,
+                    )
+                    .await
+                    .map_err(map_core_error)?;
+            }
+        }
+
+        self.core.invalidate_similarity_cache().await;
+        self.core.invalidate_search_cache().await;
+        let version = self
+            .core
+            .hash_for_active_backend(&request.content)
+            .await
+            .map_err(map_host_error)?;
+        let event = match request.precondition {
+            WritePrecondition::CreateOnly => HookEvent::FileCreated {
+                path: request.path.clone(),
+            },
+            WritePrecondition::Match(_) => HookEvent::FileModified {
+                path: request.path.clone(),
+            },
+        };
+        let attribution = request
+            .provenance
+            .map(EventAttribution::Attributed)
+            .unwrap_or(EventAttribution::ExternalOrUnknown);
+        let _ = self
+            .hooks
+            .publish(&vault, event, Some(version.clone()), attribution);
+
+        Ok(WriteReceipt {
+            vault,
+            path: request.path,
+            version,
+            bytes: request.content.len(),
+        })
+    }
+}
+
+pub(super) fn vault_host(core: CoreToolHandler, hooks: HookBus) -> Arc<dyn VaultHost> {
+    Arc::new(PluginVaultHost::new(core, hooks))
+}

--- a/crates/turbovault/src/tools/providers.rs
+++ b/crates/turbovault/src/tools/providers.rs
@@ -30,6 +30,12 @@ use turbomcp_server::CompositeHandler;
 use turbomcp_types::ResourceTemplate;
 use turbovault_core::prelude::MultiVaultManager;
 
+#[cfg(feature = "plugin-api")]
+use turbovault_plugin_api::{
+    HookBus, Plugin, PluginContext, PluginError, PluginErrorCode, PluginProvider,
+    PluginRequestContext, ToolResult as PluginToolResult, VaultApi,
+};
+
 use self::analysis::AnalysisProvider;
 use self::audit::AuditProvider;
 use self::batch::BatchProvider;
@@ -46,6 +52,127 @@ use self::templates::TemplateProvider;
 use self::vault::VaultProvider;
 use super::CoreToolHandler;
 
+#[cfg(feature = "plugin-api")]
+#[derive(Clone)]
+struct PluginProviderAdapter {
+    descriptor: turbovault_plugin_api::PluginDescriptor,
+    provider: Arc<dyn PluginProvider>,
+    tools: Arc<Vec<Tool>>,
+}
+
+#[cfg(feature = "plugin-api")]
+impl PluginProviderAdapter {
+    fn new(
+        descriptor: turbovault_plugin_api::PluginDescriptor,
+        provider: Arc<dyn PluginProvider>,
+    ) -> Result<Self> {
+        let tools = provider.tools();
+        let mut names = std::collections::HashSet::new();
+        for tool in &tools {
+            let valid_name = !tool.name.is_empty()
+                && tool.name.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || character == '_' || character == '-'
+                });
+            if !valid_name {
+                return Err(anyhow!(
+                    "plugin {:?} has invalid local tool name {:?}",
+                    descriptor.id,
+                    tool.name
+                ));
+            }
+            if !names.insert(tool.name.clone()) {
+                return Err(anyhow!(
+                    "plugin {:?} advertises tool {:?} more than once",
+                    descriptor.id,
+                    tool.name
+                ));
+            }
+        }
+        Ok(Self {
+            descriptor,
+            provider,
+            tools: Arc::new(tools),
+        })
+    }
+}
+
+#[cfg(feature = "plugin-api")]
+fn plugin_error(error: PluginError) -> McpError {
+    match error.code {
+        PluginErrorCode::InvalidInput | PluginErrorCode::NotFound | PluginErrorCode::Conflict => {
+            McpError::invalid_request(error.message)
+        }
+        PluginErrorCode::Unavailable | PluginErrorCode::Internal => {
+            McpError::internal(error.message)
+        }
+    }
+}
+
+#[cfg(feature = "plugin-api")]
+#[allow(clippy::manual_async_fn)]
+impl McpHandler for PluginProviderAdapter {
+    fn server_info(&self) -> ServerInfo {
+        ServerInfo::new(&self.descriptor.name, &self.descriptor.version)
+    }
+
+    fn list_tools(&self) -> Vec<Tool> {
+        self.tools.as_ref().clone()
+    }
+
+    fn list_resources(&self) -> Vec<Resource> {
+        Vec::new()
+    }
+
+    fn list_prompts(&self) -> Vec<Prompt> {
+        Vec::new()
+    }
+
+    fn call_tool<'a>(
+        &'a self,
+        name: &'a str,
+        args: serde_json::Value,
+        ctx: &'a RequestContext,
+    ) -> impl std::future::Future<Output = McpResult<PluginToolResult>> + MaybeSend + 'a {
+        async move {
+            if !self.tools.iter().any(|tool| tool.name == name) {
+                return Err(McpError::tool_not_found(name));
+            }
+            let context = PluginRequestContext {
+                request_id: ctx.request_id.clone(),
+                user_id: ctx.user_id.clone(),
+                session_id: ctx.session_id.clone(),
+                client_id: ctx.client_id.clone(),
+                metadata: ctx
+                    .metadata
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect(),
+            };
+            self.provider
+                .call_tool(name, args, context)
+                .await
+                .map_err(plugin_error)
+        }
+    }
+
+    fn read_resource<'a>(
+        &'a self,
+        uri: &'a str,
+        _ctx: &'a RequestContext,
+    ) -> impl std::future::Future<Output = McpResult<ResourceResult>> + MaybeSend + 'a {
+        async move { Err(McpError::resource_not_found(uri)) }
+    }
+
+    fn get_prompt<'a>(
+        &'a self,
+        name: &'a str,
+        _args: Option<serde_json::Value>,
+        _ctx: &'a RequestContext,
+    ) -> impl std::future::Future<Output = McpResult<PromptResult>> + MaybeSend + 'a {
+        async move { Err(McpError::prompt_not_found(name)) }
+    }
+}
+
 /// Obsidian MCP server with stable public names and focused internal providers.
 #[derive(Clone)]
 pub struct ObsidianMcpServer {
@@ -58,6 +185,8 @@ pub struct ObsidianMcpServer {
     tool_routes: Arc<HashMap<String, String>>,
     resource_routes: Arc<HashMap<String, String>>,
     prompt_routes: Arc<HashMap<String, String>>,
+    #[cfg(feature = "plugin-api")]
+    hooks: HookBus,
 }
 
 impl ObsidianMcpServer {
@@ -68,6 +197,30 @@ impl ObsidianMcpServer {
     }
 
     fn from_core(core: CoreToolHandler) -> Result<Self> {
+        #[cfg(feature = "plugin-api")]
+        {
+            Self::assemble(core, Vec::new())
+        }
+        #[cfg(not(feature = "plugin-api"))]
+        {
+            Self::assemble(core)
+        }
+    }
+
+    /// Create a server with compiled-in plugin factories.
+    ///
+    /// Each plugin is mounted under its validated descriptor ID. This API is
+    /// available only with the default-off `plugin-api` Cargo feature.
+    #[cfg(feature = "plugin-api")]
+    pub fn new_with_plugins(plugins: Vec<Arc<dyn Plugin>>) -> Result<Self> {
+        let core = CoreToolHandler::new()?;
+        Self::assemble(core, plugins)
+    }
+
+    fn assemble(
+        core: CoreToolHandler,
+        #[cfg(feature = "plugin-api")] plugins: Vec<Arc<dyn Plugin>>,
+    ) -> Result<Self> {
         let mut composite = CompositeHandler::new("obsidian-vault", env!("CARGO_PKG_VERSION"));
         let mut tools = Vec::new();
         let mut resources = Vec::new();
@@ -141,6 +294,48 @@ impl ObsidianMcpServer {
         mount!(AnalysisProvider::new(core.clone()), "analysis");
         mount!(AuditProvider::new(core.clone()), "audit");
 
+        #[cfg(feature = "plugin-api")]
+        let hooks = {
+            const DEFAULT_HOOK_CAPACITY: usize = 1_024;
+            let hooks = HookBus::new(DEFAULT_HOOK_CAPACITY);
+            let vault = VaultApi::new(super::plugin_host::vault_host(core.clone(), hooks.clone()));
+
+            for plugin in plugins {
+                let descriptor = plugin.descriptor();
+                descriptor
+                    .validate()
+                    .map_err(|error| anyhow!("invalid plugin descriptor: {error}"))?;
+                let prefix = descriptor.id.clone();
+                let provider = plugin
+                    .build(PluginContext {
+                        vault: vault.clone(),
+                        hooks: hooks.clone(),
+                    })
+                    .map_err(|error| anyhow!("plugin {prefix:?} failed to build: {error}"))?;
+                let adapter = PluginProviderAdapter::new(descriptor, provider)?;
+
+                for mut tool in adapter.list_tools() {
+                    let local_name = tool.name.clone();
+                    let public_name = format!("{prefix}_{local_name}");
+                    tool.name = public_name.clone();
+                    if tool_routes
+                        .insert(public_name.clone(), public_name.clone())
+                        .is_some()
+                    {
+                        return Err(anyhow!(
+                            "plugin tool {public_name:?} collides with an existing public tool"
+                        ));
+                    }
+                    tools.push(tool);
+                }
+
+                composite = composite
+                    .try_mount(adapter, &prefix)
+                    .map_err(|error| anyhow!("could not mount plugin {prefix:?}: {error}"))?;
+            }
+            hooks
+        };
+
         Ok(Self {
             core,
             composite,
@@ -151,7 +346,15 @@ impl ObsidianMcpServer {
             tool_routes: Arc::new(tool_routes),
             resource_routes: Arc::new(resource_routes),
             prompt_routes: Arc::new(prompt_routes),
+            #[cfg(feature = "plugin-api")]
+            hooks,
         })
+    }
+
+    /// Return the shared bounded hook bus.
+    #[cfg(feature = "plugin-api")]
+    pub fn hook_bus(&self) -> HookBus {
+        self.hooks.clone()
     }
 
     /// Initialize the persistent cache after server creation.
@@ -358,6 +561,231 @@ mod tests {
         result
             .structured_content
             .expect("tool result should contain structured content")
+    }
+
+    #[cfg(feature = "plugin-api")]
+    struct ContractPlugin;
+
+    #[cfg(feature = "plugin-api")]
+    impl Plugin for ContractPlugin {
+        fn descriptor(&self) -> turbovault_plugin_api::PluginDescriptor {
+            turbovault_plugin_api::PluginDescriptor {
+                id: "contract".to_string(),
+                name: "Contract Test Plugin".to_string(),
+                version: "1.0.0".to_string(),
+                description: "Exercises the stable plugin boundary".to_string(),
+            }
+        }
+
+        fn build(
+            &self,
+            context: PluginContext,
+        ) -> turbovault_plugin_api::PluginResult<Arc<dyn PluginProvider>> {
+            Ok(Arc::new(ContractProvider {
+                vault: context.vault,
+            }))
+        }
+    }
+
+    #[cfg(feature = "plugin-api")]
+    struct ContractProvider {
+        vault: VaultApi,
+    }
+
+    #[cfg(feature = "plugin-api")]
+    #[async_trait::async_trait]
+    impl PluginProvider for ContractProvider {
+        fn tools(&self) -> Vec<Tool> {
+            vec![Tool::new(
+                "round_trip",
+                "Create and read a note through VaultApi",
+            )]
+        }
+
+        async fn call_tool(
+            &self,
+            name: &str,
+            arguments: serde_json::Value,
+            context: PluginRequestContext,
+        ) -> turbovault_plugin_api::PluginResult<ToolResult> {
+            if name != "round_trip" {
+                return Err(PluginError::not_found(format!("unknown tool {name:?}")));
+            }
+            let path = arguments
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| PluginError::invalid_input("path is required"))?;
+            let content = arguments
+                .get("content")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| PluginError::invalid_input("content is required"))?;
+            let precondition = arguments
+                .get("expected_version")
+                .and_then(serde_json::Value::as_str)
+                .map(|version| turbovault_plugin_api::WritePrecondition::Match(version.to_string()))
+                .unwrap_or(turbovault_plugin_api::WritePrecondition::CreateOnly);
+            let vault = self.vault.active_vault().await?;
+            let receipt = self
+                .vault
+                .write_note(turbovault_plugin_api::WriteNoteRequest {
+                    path: path.to_string(),
+                    content: content.to_string(),
+                    precondition,
+                    commit_message: Some(format!("contract plugin creates {path}")),
+                    provenance: Some(turbovault_plugin_api::WriteProvenance {
+                        source: "contract-test".to_string(),
+                        correlation_id: Some(context.request_id),
+                        note: None,
+                    }),
+                })
+                .await?;
+            let snapshot = self.vault.read_note(path).await?;
+            let notes = self.vault.list_notes().await?;
+            ToolResult::json(&serde_json::json!({
+                "vault": vault,
+                "receipt": receipt,
+                "snapshot": snapshot,
+                "notes": notes,
+            }))
+            .map_err(|error| PluginError::internal(error.to_string()))
+        }
+    }
+
+    #[cfg(feature = "plugin-api")]
+    #[tokio::test]
+    async fn plugin_tools_are_namespaced_and_use_the_curated_vault_api() {
+        use turbovault_core::VaultConfig;
+        use turbovault_plugin_api::{EventAttribution, HookEvent};
+
+        let temp = tempfile::TempDir::new().expect("temp vault");
+        let server = ObsidianMcpServer::new_with_plugins(vec![Arc::new(ContractPlugin)])
+            .expect("plugin composition");
+        let config = VaultConfig::builder("plugin-test", temp.path())
+            .build()
+            .expect("vault config");
+        server
+            .multi_vault()
+            .add_vault(config)
+            .await
+            .expect("register vault");
+        server
+            .multi_vault()
+            .set_active_vault("plugin-test")
+            .await
+            .expect("select vault");
+
+        let advertised = server.list_tools();
+        assert_eq!(advertised.len(), 75);
+        assert!(
+            advertised
+                .iter()
+                .any(|tool| tool.name == "contract_round_trip")
+        );
+        assert!(!advertised.iter().any(|tool| tool.name == "round_trip"));
+
+        let mut events = server.hook_bus().subscribe().expect("hook subscription");
+        let ctx = RequestContext::with_id("plugin-request");
+        let result = server
+            .call_tool(
+                "contract_round_trip",
+                serde_json::json!({"path": "plugin.md", "content": "# Plugin"}),
+                &ctx,
+            )
+            .await
+            .expect("namespaced plugin call");
+        let result = structured(result);
+        let initial_version = result["receipt"]["version"]
+            .as_str()
+            .expect("initial version")
+            .to_string();
+        assert_eq!(result["vault"]["name"], "plugin-test");
+        assert_eq!(result["snapshot"]["content"], "# Plugin");
+        assert_eq!(result["receipt"]["version"], result["snapshot"]["version"]);
+        assert_eq!(result["notes"], serde_json::json!(["plugin.md"]));
+
+        let event = events.recv().await.expect("plugin write event");
+        assert_eq!(event.vault, "plugin-test");
+        assert_eq!(
+            event.event,
+            HookEvent::FileCreated {
+                path: "plugin.md".to_string()
+            }
+        );
+        assert!(matches!(
+            event.attribution,
+            EventAttribution::Attributed(turbovault_plugin_api::WriteProvenance {
+                source,
+                correlation_id: Some(id),
+                ..
+            }) if source == "contract-test" && id == "plugin-request"
+        ));
+
+        let error = server
+            .call_tool("round_trip", serde_json::json!({}), &ctx)
+            .await
+            .expect_err("unprefixed plugin tool must not be public");
+        assert_eq!(error.jsonrpc_code(), -32001);
+
+        let conflict = server
+            .call_tool(
+                "contract_round_trip",
+                serde_json::json!({"path": "plugin.md", "content": "# Overwrite"}),
+                &ctx,
+            )
+            .await
+            .expect_err("create-only write must refuse overwrites");
+        assert_eq!(conflict.jsonrpc_code(), -32600);
+
+        let updated = server
+            .call_tool(
+                "contract_round_trip",
+                serde_json::json!({
+                    "path": "plugin.md",
+                    "content": "# Updated",
+                    "expected_version": initial_version.clone(),
+                }),
+                &ctx,
+            )
+            .await
+            .expect("matching CAS write");
+        let updated = structured(updated);
+        assert_eq!(updated["snapshot"]["content"], "# Updated");
+        assert_ne!(updated["receipt"]["version"], result["receipt"]["version"]);
+        let modified = events.recv().await.expect("plugin update event");
+        assert!(matches!(
+            modified.event,
+            HookEvent::FileModified { ref path } if path == "plugin.md"
+        ));
+
+        let stale = server
+            .call_tool(
+                "contract_round_trip",
+                serde_json::json!({
+                    "path": "plugin.md",
+                    "content": "# Stale",
+                    "expected_version": initial_version,
+                }),
+                &ctx,
+            )
+            .await
+            .expect_err("stale CAS write must fail");
+        assert_eq!(stale.jsonrpc_code(), -32600);
+    }
+
+    #[cfg(feature = "plugin-api")]
+    #[test]
+    fn duplicate_plugin_namespaces_are_rejected_before_serving() {
+        let error = ObsidianMcpServer::new_with_plugins(vec![
+            Arc::new(ContractPlugin),
+            Arc::new(ContractPlugin),
+        ])
+        .err()
+        .expect("duplicate namespace must fail");
+        assert!(
+            error.to_string().contains("contract_round_trip")
+                || error.to_string().contains("duplicate prefix"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/docs/crates/README.md
+++ b/docs/crates/README.md
@@ -4,7 +4,7 @@ This section provides detailed documentation for each individual crate in the `T
 
 ## Crate Overview
 
-The `TurboVault` project is organized as a Rust workspace with 8 crates:
+The `TurboVault` project is organized as a modular Rust workspace:
 
 | Crate | Purpose | Lines of Code | Key Features |
 |-------|---------|---------------|--------------|
@@ -15,6 +15,7 @@ The `TurboVault` project is organized as a Rust workspace with 8 crates:
 | **turbovault-batch** | Validated fail-fast operation batches | ~650 LOC | Conflict validation, sequencing, detailed results |
 | **turbovault-export** | JSON/CSV export formats | ~600 LOC | Data export, reporting |
 | **turbovault-tools** | Reusable MCP operations | ~2,500 LOC | Search, graph, metadata, and file operations |
+| **turbovault-plugin-api** | Stable plugin boundary | Small | Curated vault facade, provider contract, bounded hooks |
 | **turbovault-server** | CLI + MCP server | ~600 LOC | Main binary, server orchestration |
 
 **Total**: ~11,000 lines of production Rust code
@@ -166,6 +167,15 @@ This crate implements the Model Context Protocol (MCP) tools that enable AI agen
 - Production-grade search engine built on Tantivy
 - Template system for consistent note creation
 - Comprehensive vault analysis and health monitoring
+
+### [turbovault-plugin-api](../../crates/turbovault-plugin-api/README.md)
+
+**Stable host boundary for compiled-in, feature-gated plugins.**
+
+This crate defines the curated `VaultApi`, plugin factory/provider contracts,
+strict namespacing rules, and bounded best-effort hook delivery. It
+intentionally does not expose raw vault managers or server internals. See the
+[plugin architecture guide](../development/plugins.md).
 
 ### [turbovault-server](../crates/turbovault-server/README.md)
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -14,7 +14,7 @@ Overview of TurboVault's modular architecture.
 │  turbovault-server (MCP Server Binary)  │
 │                                         │
 │  ┌───────────────────────────────────┐ │
-│  │  Flat provider facade (70 tools)  │ │
+│  │  Flat core + plugin providers     │ │
 │  └────────┬───────────────────────────┘ │
 └───────────┼─────────────────────────────┘
             │
@@ -76,18 +76,29 @@ Overview of TurboVault's modular architecture.
 - Data serialization
 
 ### turbovault-tools
-- Reusable implementations behind 70 MCP tools
+- Reusable implementations behind 74 MCP tools
 - Tool implementation
 - Response formatting
 
+### turbovault-plugin-api
+
+- Curated `VaultApi` instead of raw manager/server access
+- Object-safe compiled-in provider and factory contracts
+- Strict plugin tool namespaces
+- Bounded best-effort hooks with explicit lag and close states
+
 ### MCP provider facade
 
-The `turbovault` crate splits the public catalog across 13 focused provider
+The `turbovault` crate splits the public catalog across 14 focused provider
 modules for context, files, graph, discovery, templates, vault lifecycle,
-batch, export, metadata, relationships, content, analysis, and audit. TurboMCP's
-`CompositeHandler` prefixes mounted handlers internally; TurboVault's facade
-maps those routes back to the established flat public names. For example,
-clients still call `read_note`, not `files_read_note`.
+batch, fanout, export, metadata, relationships, content, analysis, and audit.
+TurboMCP's `CompositeHandler` prefixes mounted handlers internally;
+TurboVault's facade maps core routes back to the established flat public
+names. For example, clients still call `read_note`, not `files_read_note`.
+Compiled-in plugins keep their namespace, such as `tasks_list_tasks`.
+
+See [Plugin Architecture](plugins.md) for the host contract, lifecycle, and
+contribution rules.
 
 ## Data Flow
 

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -78,7 +78,8 @@ turbovault/
 │   ├── turbovault-vault/        # File I/O
 │   ├── turbovault-batch/        # Batch ops
 │   ├── turbovault-export/       # Export utils
-│   └── turbovault-tools/        # MCP tools
+│   ├── turbovault-tools/        # MCP tools
+│   └── turbovault-plugin-api/   # Stable compiled-in plugin boundary
 ├── docs/                        # Documentation
 ├── tests/                       # Integration tests
 └── Cargo.toml                   # Workspace

--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -1,0 +1,79 @@
+# Plugin Architecture
+
+TurboVault's v1 plugin model is compiled-in, Cargo-feature-gated Rust. It is a
+curated extension surface: plugins are reviewed and shipped with TurboVault.
+There is no dynamic loader, FFI boundary, sandbox, or runtime installation.
+
+## Boundary
+
+Plugin crates depend on `turbovault-plugin-api`, not on the server's internal
+managers. A plugin factory receives:
+
+- `VaultApi`, a small cloneable facade for active-vault identity, note listing,
+  complete reads, create-only writes, and compare-and-swap writes.
+- `HookBus`, a bounded advisory event stream with explicit lag and closed
+  states.
+
+`VaultApi` requires every write to choose `CreateOnly` or `Match(version)`.
+There is intentionally no blind-overwrite escape hatch. Version tokens are
+opaque and backend-native: SHA-256 on the legacy backend and Git blob IDs on
+the Git backend.
+
+Plugins receive a curated request context containing request, user, session,
+client, and serializable metadata fields. Raw transport sessions,
+authentication principals, vault managers, and the MCP server never cross the
+boundary.
+
+## Registration and names
+
+The main crate's `plugin-api` feature is default-off. A vertical plugin feature
+must include it and its optional plugin dependency:
+
+```toml
+[features]
+plugin-tasks = ["plugin-api", "dep:turbovault-plugin-tasks"]
+```
+
+At startup, compiled-in factories are passed to
+`ObsidianMcpServer::new_with_plugins`. The host validates descriptors, rejects
+duplicate namespaces and tools, and wraps the object-safe provider for
+TurboMCP's clone-based composite handler.
+
+Core tool names stay flat for compatibility. Plugin tools are always
+advertised as `<plugin_id>_<local_tool>`. A `list_tasks` tool owned by the
+`tasks` plugin is therefore `tasks_list_tasks`.
+
+## Hook lifecycle and backpressure
+
+The hook bus is a fixed-size broadcast ring. Delivery is best-effort, not a
+durable log:
+
+- `Lagged { skipped }` means events were discarded for that subscriber. It
+  must re-read authoritative state through `VaultApi`.
+- `Closed` means the producer stopped and all buffered events were drained.
+- Event provenance is best-effort correlation metadata. It is useful for
+  reaction-loop prevention but is never an authentication or authorization
+  boundary. `ExternalOrUnknown` must fail open.
+
+The current host publishes writes made through `VaultApi`. A future
+vault-events plugin can translate filesystem watcher events into the same
+shared envelope; external edits remain attribution-blind unless they can be
+correlated by content identity.
+
+## Plugin-owned Rust APIs
+
+The host contract governs only the capabilities used to mount a plugin into
+TurboVault. A plugin may also expose a broader Rust library API for direct
+non-MCP consumers. That public surface remains owned by the plugin maintainer
+and is reviewed for stability, dependency cost, and maintenance burden like
+any other in-tree public API; it does not need to be forced through `VaultApi`.
+
+## Contribution rules
+
+- Put verticals under `crates/plugins/`.
+- Keep every vertical feature default-off.
+- Depend on `turbovault-plugin-api`; do not reach into server internals.
+- Publish only local tool names and let the host add the namespace.
+- Treat hook delivery and provenance as advisory.
+- Add provider-contract, namespace, lifecycle, lag/resync, and feature-off
+  tests.


### PR DESCRIPTION
## Summary

- add the publishable turbovault-plugin-api contract crate
- add a curated CAS-only VaultApi facade with no raw manager or server access
- adapt object-safe plugin providers into TurboMCP CompositeHandler mounts
- preserve flat core names while enforcing plugin_id_local_tool namespaces
- add a default-off plugin-api feature and future feature-wiring convention
- add a bounded best-effort hook bus with sequence, lag/resync, closure, content identity, and advisory provenance semantics
- document that plugin-owned direct Rust APIs are allowed and reviewed independently of the host boundary

## Safety and compatibility

- plugin writes must choose create-only or match a backend-native version token; blind overwrite is not exposed
- request context excludes raw transport sessions, principals, headers, and server internals
- descriptor, namespace, local tool, duplicate route, and duplicate prefix validation happens before serving
- the existing 74-tool core catalog remains byte-for-byte unchanged when no plugins are registered
- plugin-api is default-off, so current default binaries do not take on the dependency or surface

## Verification

- cargo test --workspace --all-targets --all-features --locked
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features
- cargo package -p turbovault-plugin-api --locked --allow-dirty

The new API crate packages and registry-verifies. Registry verification of the parent turbovault package is expected to wait until the new dependency is published first; the documented release publish order now does that.

Advances Phase 2 of #34. Establishes the compatibility target for #19, #24, and #29, and carries the best-effort attribution contract discussed in #33. This intentionally does not close the umbrella issue.