### PR TITLE
fix: harden plugin API after review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Compiled-in plugin boundary** ([#34](https://github.com/Epistates/turbovault/issues/34)): Added the default-off `plugin-api` feature and the publishable `turbovault-plugin-api` crate. Plugins receive a curated CAS-only `VaultApi`, an object-safe tool provider contract, redacted request context, strict MCP namespaces, and a bounded hook bus with explicit lag/resync and close semantics.
 - **Best-effort hook provenance** ([#33](https://github.com/Epistates/turbovault/issues/33)): Plugin writes can carry source and correlation metadata into advisory event envelopes. Attribution is explicitly not an authentication boundary, and uncorrelated events fail open as external-or-unknown.
 
+### Changed
+
+- **Plugin contract review follow-up**: Plugin-local and fully namespaced tool names are centrally validated against MCP SEP-986, enabled namespaces are described during MCP initialization only when plugins are registered, feature-on tests are required for every vertical, and core/plugin complete-note writes share preparation and cache-finalization orchestration.
+
 ## [1.6.0] - 2026-07-17
 
 ### Added

--- a/crates/turbovault-plugin-api/src/hooks.rs
+++ b/crates/turbovault-plugin-api/src/hooks.rs
@@ -278,7 +278,9 @@ mod tests {
 
     #[tokio::test]
     async fn sequences_events_and_closes_after_buffered_delivery() {
-        let bus = HookBus::new(2);
+        // Capacity two retains both events until this subscriber reads them.
+        const CAPACITY: usize = 2;
+        let bus = HookBus::new(CAPACITY);
         let mut subscription = bus.subscribe().expect("subscribe");
         assert_eq!(publish(&bus, "a.md").sequence, 1);
         assert_eq!(publish(&bus, "b.md").sequence, 2);
@@ -293,7 +295,9 @@ mod tests {
 
     #[tokio::test]
     async fn reports_lag_and_requires_resync() {
-        let bus = HookBus::new(1);
+        // Capacity one intentionally evicts the first of two unread events.
+        const CAPACITY: usize = 1;
+        let bus = HookBus::new(CAPACITY);
         let mut subscription = bus.subscribe().expect("subscribe");
         publish(&bus, "a.md");
         publish(&bus, "b.md");

--- a/crates/turbovault-plugin-api/src/lib.rs
+++ b/crates/turbovault-plugin-api/src/lib.rs
@@ -19,8 +19,8 @@ pub use hooks::{
     PublishError, VaultEventEnvelope, WriteProvenance,
 };
 pub use provider::{
-    Plugin, PluginContext, PluginDescriptor, PluginProvider, PluginRequestContext,
-    validate_plugin_id,
+    MCP_TOOL_NAME_MAX_LEN, Plugin, PluginContext, PluginDescriptor, PluginProvider,
+    PluginRequestContext, namespaced_tool_name, validate_mcp_tool_name, validate_plugin_id,
 };
 pub use turbomcp_types::{Tool, ToolResult};
 pub use vault::{

--- a/crates/turbovault-plugin-api/src/provider.rs
+++ b/crates/turbovault-plugin-api/src/provider.rs
@@ -7,6 +7,9 @@ use serde_json::Value;
 
 use crate::{HookBus, PluginError, PluginResult, Tool, ToolResult, VaultApi};
 
+/// Maximum tool-name length recommended by MCP SEP-986.
+pub const MCP_TOOL_NAME_MAX_LEN: usize = 64;
+
 /// Stable identity and compatibility metadata for a compiled-in plugin.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PluginDescriptor {
@@ -42,16 +45,44 @@ impl PluginDescriptor {
 /// lowercase ASCII letters, digits, or underscores.
 pub fn validate_plugin_id(id: &str) -> PluginResult<()> {
     let mut chars = id.chars();
-    if !matches!(chars.next(), Some('a'..='z'))
+    if id.len() > MCP_TOOL_NAME_MAX_LEN
+        || !matches!(chars.next(), Some('a'..='z'))
         || !chars.all(|character| {
             character.is_ascii_lowercase() || character.is_ascii_digit() || character == '_'
         })
     {
         return Err(PluginError::invalid_input(format!(
-            "invalid plugin id {id:?}; expected [a-z][a-z0-9_]*"
+            "invalid plugin id {id:?}; expected at most {MCP_TOOL_NAME_MAX_LEN} ASCII characters matching [a-z][a-z0-9_]*"
         )));
     }
     Ok(())
+}
+
+/// Validate a complete tool name against MCP SEP-986.
+///
+/// TurboVault enforces the specification recommendation at registration time:
+/// names contain 1–64 ASCII letters, digits, underscores, dashes, dots, or
+/// forward slashes. See <https://modelcontextprotocol.io/seps/986-specify-format-for-tool-names>.
+pub fn validate_mcp_tool_name(name: &str) -> PluginResult<()> {
+    let length_is_valid = (1..=MCP_TOOL_NAME_MAX_LEN).contains(&name.len());
+    let characters_are_valid = name
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b'/'));
+    if !length_is_valid || !characters_are_valid {
+        return Err(PluginError::invalid_input(format!(
+            "invalid MCP tool name {name:?}; expected 1–{MCP_TOOL_NAME_MAX_LEN} ASCII characters from [A-Za-z0-9_./-]"
+        )));
+    }
+    Ok(())
+}
+
+/// Build and validate the public MCP name for a plugin-local tool.
+pub fn namespaced_tool_name(plugin_id: &str, local_name: &str) -> PluginResult<String> {
+    validate_plugin_id(plugin_id)?;
+    validate_mcp_tool_name(local_name)?;
+    let public_name = format!("{plugin_id}_{local_name}");
+    validate_mcp_tool_name(&public_name)?;
+    Ok(public_name)
 }
 
 /// Curated request data passed to plugin tool calls.
@@ -118,6 +149,37 @@ mod tests {
             let error = validate_plugin_id(invalid).expect_err("invalid namespace");
             assert_eq!(error.code, crate::PluginErrorCode::InvalidInput);
         }
+        assert!(validate_plugin_id(&"p".repeat(MCP_TOOL_NAME_MAX_LEN + 1)).is_err());
+    }
+
+    #[test]
+    fn tool_names_enforce_mcp_sep_986() {
+        for valid in [
+            "a",
+            "getUser",
+            "user-profile/update",
+            "DATA_EXPORT_v2",
+            "admin.tools.list",
+        ] {
+            validate_mcp_tool_name(valid).expect("SEP-986 name");
+        }
+        validate_mcp_tool_name(&"a".repeat(MCP_TOOL_NAME_MAX_LEN)).expect("64 characters");
+
+        for invalid in ["", "has space", "has,comma", "has:colon", "unicode_é"] {
+            let error = validate_mcp_tool_name(invalid).expect_err("invalid SEP-986 name");
+            assert_eq!(error.code, crate::PluginErrorCode::InvalidInput);
+        }
+        assert!(validate_mcp_tool_name(&"a".repeat(MCP_TOOL_NAME_MAX_LEN + 1)).is_err());
+    }
+
+    #[test]
+    fn namespaced_tool_names_validate_the_final_public_name() {
+        assert_eq!(
+            namespaced_tool_name("vector_search", "query/v2").expect("namespaced name"),
+            "vector_search_query/v2"
+        );
+        let oversized_plugin_id = "p".repeat(MCP_TOOL_NAME_MAX_LEN);
+        assert!(namespaced_tool_name(&oversized_plugin_id, "x").is_err());
     }
 
     #[test]

--- a/crates/turbovault/src/tools.rs
+++ b/crates/turbovault/src/tools.rs
@@ -333,6 +333,17 @@ struct ActiveFanoutRecord {
     fanout_vault_name: String,
 }
 
+/// Shared preparation for complete-note writes from core and plugin providers.
+///
+/// Keeping active-vault selection, backend dispatch, and commit-message policy
+/// here prevents each provider boundary from reimplementing that orchestration.
+pub(super) struct CompleteNoteWrite {
+    pub(super) vault_name: String,
+    pub(super) manager: Arc<VaultManager>,
+    pub(super) tools: WriteTools,
+    pub(super) message: String,
+}
+
 impl CoreToolHandler {
     /// Create a new server instance (vault-agnostic - no vault required at startup)
     pub fn new() -> Result<Self> {
@@ -840,6 +851,33 @@ impl CoreToolHandler {
             }
             None => Ok(fallback()),
         }
+    }
+
+    /// Resolve the shared state required for a complete-note mutation.
+    async fn prepare_complete_note_write(
+        &self,
+        path: &str,
+        commit_message: Option<String>,
+        fallback_operation: &str,
+    ) -> McpResult<CompleteNoteWrite> {
+        let vault_name = self.get_active_vault_name().await?;
+        let manager = self.get_active_vault_manager().await?;
+        let tools = self.get_active_write_tools().await?;
+        let message = self
+            .resolve_commit_message(commit_message, || format!("{fallback_operation} {path}"))
+            .await?;
+        Ok(CompleteNoteWrite {
+            vault_name,
+            manager,
+            tools,
+            message,
+        })
+    }
+
+    /// Invalidate derived state after a complete-note mutation.
+    async fn finish_complete_note_write(&self) {
+        self.invalidate_similarity_cache().await;
+        self.invalidate_search_cache().await;
     }
 
     /// Helper to get both vault name and manager (eliminates 31 repeated preambles)

--- a/crates/turbovault/src/tools/plugin_host.rs
+++ b/crates/turbovault/src/tools/plugin_host.rs
@@ -109,61 +109,52 @@ impl VaultHost for PluginVaultHost {
     }
 
     async fn write_note(&self, request: WriteNoteRequest) -> PluginResult<WriteReceipt> {
-        let vault = self
+        let prepared = self
             .core
-            .get_active_vault_name()
+            .prepare_complete_note_write(
+                &request.path,
+                request.commit_message.clone(),
+                "plugin write",
+            )
             .await
             .map_err(map_host_error)?;
-        let manager = self
-            .core
-            .get_active_vault_manager()
-            .await
-            .map_err(map_host_error)?;
-        let tools = self
-            .core
-            .get_active_write_tools()
-            .await
-            .map_err(map_host_error)?;
-        let resolved_path = manager
+        let resolved_path = prepared
+            .manager
             .resolve_path(Path::new(&request.path))
             .map_err(map_core_error)?;
-        let message = self
-            .core
-            .resolve_commit_message(request.commit_message.clone(), || {
-                format!("plugin write {}", request.path)
-            })
-            .await
-            .map_err(map_host_error)?;
 
         match &request.precondition {
             WritePrecondition::CreateOnly => {
-                if !tools.is_git() && tokio::fs::try_exists(&resolved_path).await.unwrap_or(false) {
+                if !prepared.tools.is_git()
+                    && tokio::fs::try_exists(&resolved_path).await.unwrap_or(false)
+                {
                     return Err(PluginError::conflict(format!(
                         "create refused: {:?} already exists",
                         request.path
                     )));
                 }
-                tools
-                    .create_file_with_message(&request.path, &request.content, &message)
+                prepared
+                    .tools
+                    .create_file_with_message(&request.path, &request.content, &prepared.message)
                     .await
                     .map_err(map_core_error)?;
             }
             WritePrecondition::Match(version) => {
-                tools
+                prepared
+                    .tools
                     .write_file_with_mode_and_message(
                         &request.path,
                         &request.content,
                         WriteMode::Overwrite,
                         Some(version),
-                        &message,
+                        &prepared.message,
                     )
                     .await
                     .map_err(map_core_error)?;
             }
         }
 
-        self.core.invalidate_similarity_cache().await;
-        self.core.invalidate_search_cache().await;
+        self.core.finish_complete_note_write().await;
         let version = self
             .core
             .hash_for_active_backend(&request.content)
@@ -181,12 +172,15 @@ impl VaultHost for PluginVaultHost {
             .provenance
             .map(EventAttribution::Attributed)
             .unwrap_or(EventAttribution::ExternalOrUnknown);
-        let _ = self
-            .hooks
-            .publish(&vault, event, Some(version.clone()), attribution);
+        let _ = self.hooks.publish(
+            &prepared.vault_name,
+            event,
+            Some(version.clone()),
+            attribution,
+        );
 
         Ok(WriteReceipt {
-            vault,
+            vault: prepared.vault_name,
             path: request.path,
             version,
             bytes: request.content.len(),

--- a/crates/turbovault/src/tools/providers.rs
+++ b/crates/turbovault/src/tools/providers.rs
@@ -33,7 +33,8 @@ use turbovault_core::prelude::MultiVaultManager;
 #[cfg(feature = "plugin-api")]
 use turbovault_plugin_api::{
     HookBus, Plugin, PluginContext, PluginError, PluginErrorCode, PluginProvider,
-    PluginRequestContext, ToolResult as PluginToolResult, VaultApi,
+    PluginRequestContext, ToolResult as PluginToolResult, VaultApi, namespaced_tool_name,
+    validate_mcp_tool_name,
 };
 
 use self::analysis::AnalysisProvider;
@@ -69,17 +70,12 @@ impl PluginProviderAdapter {
         let tools = provider.tools();
         let mut names = std::collections::HashSet::new();
         for tool in &tools {
-            let valid_name = !tool.name.is_empty()
-                && tool.name.chars().all(|character| {
-                    character.is_ascii_alphanumeric() || character == '_' || character == '-'
-                });
-            if !valid_name {
-                return Err(anyhow!(
-                    "plugin {:?} has invalid local tool name {:?}",
-                    descriptor.id,
-                    tool.name
-                ));
-            }
+            validate_mcp_tool_name(&tool.name).map_err(|error| {
+                anyhow!(
+                    "plugin {:?} has an invalid local tool name: {error}",
+                    descriptor.id
+                )
+            })?;
             if !names.insert(tool.name.clone()) {
                 return Err(anyhow!(
                     "plugin {:?} advertises tool {:?} more than once",
@@ -187,6 +183,8 @@ pub struct ObsidianMcpServer {
     prompt_routes: Arc<HashMap<String, String>>,
     #[cfg(feature = "plugin-api")]
     hooks: HookBus,
+    #[cfg(feature = "plugin-api")]
+    plugins: Arc<Vec<turbovault_plugin_api::PluginDescriptor>>,
 }
 
 impl ObsidianMcpServer {
@@ -295,10 +293,11 @@ impl ObsidianMcpServer {
         mount!(AuditProvider::new(core.clone()), "audit");
 
         #[cfg(feature = "plugin-api")]
-        let hooks = {
+        let (hooks, plugin_descriptors) = {
             const DEFAULT_HOOK_CAPACITY: usize = 1_024;
             let hooks = HookBus::new(DEFAULT_HOOK_CAPACITY);
             let vault = VaultApi::new(super::plugin_host::vault_host(core.clone(), hooks.clone()));
+            let mut plugin_descriptors = Vec::new();
 
             for plugin in plugins {
                 let descriptor = plugin.descriptor();
@@ -312,11 +311,16 @@ impl ObsidianMcpServer {
                         hooks: hooks.clone(),
                     })
                     .map_err(|error| anyhow!("plugin {prefix:?} failed to build: {error}"))?;
-                let adapter = PluginProviderAdapter::new(descriptor, provider)?;
+                let adapter = PluginProviderAdapter::new(descriptor.clone(), provider)?;
 
                 for mut tool in adapter.list_tools() {
                     let local_name = tool.name.clone();
-                    let public_name = format!("{prefix}_{local_name}");
+                    let public_name =
+                        namespaced_tool_name(&prefix, &local_name).map_err(|error| {
+                            anyhow!(
+                                "plugin {prefix:?} tool {local_name:?} has an invalid public name: {error}"
+                            )
+                        })?;
                     tool.name = public_name.clone();
                     if tool_routes
                         .insert(public_name.clone(), public_name.clone())
@@ -332,8 +336,9 @@ impl ObsidianMcpServer {
                 composite = composite
                     .try_mount(adapter, &prefix)
                     .map_err(|error| anyhow!("could not mount plugin {prefix:?}: {error}"))?;
+                plugin_descriptors.push(descriptor);
             }
-            hooks
+            (hooks, plugin_descriptors)
         };
 
         Ok(Self {
@@ -348,6 +353,8 @@ impl ObsidianMcpServer {
             prompt_routes: Arc::new(prompt_routes),
             #[cfg(feature = "plugin-api")]
             hooks,
+            #[cfg(feature = "plugin-api")]
+            plugins: Arc::new(plugin_descriptors),
         })
     }
 
@@ -485,7 +492,20 @@ impl Default for ObsidianMcpServer {
 #[allow(clippy::manual_async_fn)]
 impl McpHandler for ObsidianMcpServer {
     fn server_info(&self) -> ServerInfo {
-        ServerInfo::new("obsidian-vault", env!("CARGO_PKG_VERSION"))
+        let info = ServerInfo::new("obsidian-vault", env!("CARGO_PKG_VERSION"));
+        #[cfg(feature = "plugin-api")]
+        if !self.plugins.is_empty() {
+            let namespaces = self
+                .plugins
+                .iter()
+                .map(|plugin| plugin.id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return info.with_description(format!(
+                "TurboVault with optional plugin namespaces: {namespaces}. Plugin tools use <plugin_id>_<local_tool>; use tools/list for the exact enabled catalog."
+            ));
+        }
+        info
     }
 
     fn server_capabilities(&self) -> ServerCapabilities {
@@ -574,6 +594,30 @@ mod tests {
                 name: "Contract Test Plugin".to_string(),
                 version: "1.0.0".to_string(),
                 description: "Exercises the stable plugin boundary".to_string(),
+            }
+        }
+
+        fn build(
+            &self,
+            context: PluginContext,
+        ) -> turbovault_plugin_api::PluginResult<Arc<dyn PluginProvider>> {
+            Ok(Arc::new(ContractProvider {
+                vault: context.vault,
+            }))
+        }
+    }
+
+    #[cfg(feature = "plugin-api")]
+    struct OversizedNamespacePlugin;
+
+    #[cfg(feature = "plugin-api")]
+    impl Plugin for OversizedNamespacePlugin {
+        fn descriptor(&self) -> turbovault_plugin_api::PluginDescriptor {
+            turbovault_plugin_api::PluginDescriptor {
+                id: "p".repeat(turbovault_plugin_api::MCP_TOOL_NAME_MAX_LEN),
+                name: "Oversized Namespace".to_string(),
+                version: "1.0.0".to_string(),
+                description: "Exercises final public-name validation".to_string(),
             }
         }
 
@@ -682,6 +726,12 @@ mod tests {
                 .any(|tool| tool.name == "contract_round_trip")
         );
         assert!(!advertised.iter().any(|tool| tool.name == "round_trip"));
+        let description = server
+            .server_info()
+            .description
+            .expect("enabled plugins should be described during MCP initialization");
+        assert!(description.contains("contract"));
+        assert!(description.contains("<plugin_id>_<local_tool>"));
 
         let mut events = server.hook_bus().subscribe().expect("hook subscription");
         let ctx = RequestContext::with_id("plugin-request");
@@ -788,6 +838,18 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "plugin-api")]
+    #[test]
+    fn final_namespaced_tool_names_must_conform_to_mcp_sep_986() {
+        let error = ObsidianMcpServer::new_with_plugins(vec![Arc::new(OversizedNamespacePlugin)])
+            .err()
+            .expect("oversized public name must fail");
+        assert!(
+            error.to_string().contains("invalid public name"),
+            "unexpected error: {error}"
+        );
+    }
+
     #[test]
     fn tools_list_is_byte_for_byte_equivalent_to_the_pre_split_catalog() {
         let server = ObsidianMcpServer::new().expect("provider composition");
@@ -814,6 +876,14 @@ mod tests {
             );
         }
         assert_eq!(server.tool_routes.len(), 74);
+        assert!(
+            server.server_info().description.is_none(),
+            "default server must not inject plugin guidance"
+        );
+        #[cfg(feature = "plugin-api")]
+        for tool in server.list_tools() {
+            validate_mcp_tool_name(&tool.name).expect("core tool name must conform to MCP SEP-986");
+        }
     }
 
     #[tokio::test]

--- a/crates/turbovault/src/tools/providers/files.rs
+++ b/crates/turbovault/src/tools/providers/files.rs
@@ -71,18 +71,18 @@ impl FileProvider {
         force: Option<bool>,
         commit_message: Option<String>,
     ) -> McpResult<serde_json::Value> {
-        let vault_name = self.get_active_vault_name().await?;
         let write_mode = WriteMode::from_str_opt(mode.as_deref()).map_err(to_mcp_error)?;
-        let tools = self.get_active_write_tools().await?;
-        let message = self
-            .resolve_commit_message(commit_message, || format!("write_note {path}"))
+        let prepared = self
+            .prepare_complete_note_write(&path, commit_message, "write_note")
             .await?;
+        let vault_name = prepared.vault_name;
+        let tools = prepared.tools;
+        let message = prepared.message;
         let force = force.unwrap_or(false);
 
         if tools.is_git() && !force && expected_hash.is_none() && write_mode == WriteMode::Overwrite
         {
-            let manager = self.get_active_vault_manager().await?;
-            if tokio::fs::try_exists(manager.vault_path().join(&path))
+            if tokio::fs::try_exists(prepared.manager.vault_path().join(&path))
                 .await
                 .unwrap_or(false)
             {
@@ -107,8 +107,7 @@ impl FileProvider {
                 .map_err(to_mcp_error)?;
         }
 
-        self.invalidate_similarity_cache().await;
-        self.invalidate_search_cache().await;
+        self.finish_complete_note_write().await;
         let mode_str = mode.as_deref().unwrap_or("overwrite");
         StandardResponse::new(
             vault_name,

--- a/docs/crates/README.md
+++ b/docs/crates/README.md
@@ -6,19 +6,17 @@ This section provides detailed documentation for each individual crate in the `T
 
 The `TurboVault` project is organized as a modular Rust workspace:
 
-| Crate | Purpose | Lines of Code | Key Features |
-|-------|---------|---------------|--------------|
-| **turbovault-core** | Core types, errors, config | ~2,000 LOC | Data models, error handling, configuration |
-| **turbovault-parser** | OFM parsing (wikilinks, frontmatter) | ~1,500 LOC | Markdown parsing, link extraction |
-| **turbovault-graph** | Link graph analysis | ~1,200 LOC | Graph algorithms, health analysis |
-| **turbovault-vault** | File I/O, caching, validation | ~1,800 LOC | Vault management, atomic operations |
-| **turbovault-batch** | Validated fail-fast operation batches | ~650 LOC | Conflict validation, sequencing, detailed results |
-| **turbovault-export** | JSON/CSV export formats | ~600 LOC | Data export, reporting |
-| **turbovault-tools** | Reusable MCP operations | ~2,500 LOC | Search, graph, metadata, and file operations |
-| **turbovault-plugin-api** | Stable plugin boundary | Small | Curated vault facade, provider contract, bounded hooks |
-| **turbovault-server** | CLI + MCP server | ~600 LOC | Main binary, server orchestration |
-
-**Total**: ~11,000 lines of production Rust code
+| Crate | Purpose | Key Features |
+|-------|---------|--------------|
+| **turbovault-core** | Core types, errors, config | Data models, error handling, configuration |
+| **turbovault-parser** | OFM parsing (wikilinks, frontmatter) | Markdown parsing, link extraction |
+| **turbovault-graph** | Link graph analysis | Graph algorithms, health analysis |
+| **turbovault-vault** | File I/O, caching, validation | Vault management, atomic operations |
+| **turbovault-batch** | Validated fail-fast operation batches | Conflict validation, sequencing, detailed results |
+| **turbovault-export** | JSON/CSV export formats | Data export, reporting |
+| **turbovault-tools** | Reusable MCP operations | Search, graph, metadata, and file operations |
+| **turbovault-plugin-api** | Stable plugin boundary | Curated vault facade, provider contract, bounded hooks |
+| **turbovault-server** | CLI + MCP server | Main binary, server orchestration |
 
 ## Individual Crate Documentation
 

--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -1,8 +1,9 @@
 # Plugin Architecture
 
 TurboVault's v1 plugin model is compiled-in, Cargo-feature-gated Rust. It is a
-curated extension surface: plugins are reviewed and shipped with TurboVault.
-There is no dynamic loader, FFI boundary, sandbox, or runtime installation.
+curated extension surface: plugins are reviewed and shipped with TurboVault as
+optional Cargo features. There is no dynamic loader, FFI boundary, sandbox, or
+runtime installation.
 
 ## Boundary
 
@@ -43,6 +44,15 @@ Core tool names stay flat for compatibility. Plugin tools are always
 advertised as `<plugin_id>_<local_tool>`. A `list_tasks` tool owned by the
 `tasks` plugin is therefore `tasks_list_tasks`.
 
+When at least one plugin is registered, MCP `serverInfo.description` lists its
+namespaces and explains that naming convention. The default server omits that
+guidance entirely. The exact enabled catalog remains authoritative through
+`tools/list`.
+
+Plugin-local and fully namespaced names are validated at registration against
+[MCP SEP-986](https://modelcontextprotocol.io/seps/986-specify-format-for-tool-names):
+1–64 ASCII letters, digits, underscores, dashes, dots, or forward slashes.
+
 ## Hook lifecycle and backpressure
 
 The hook bus is a fixed-size broadcast ring. Delivery is best-effort, not a
@@ -75,5 +85,7 @@ any other in-tree public API; it does not need to be forced through `VaultApi`.
 - Depend on `turbovault-plugin-api`; do not reach into server internals.
 - Publish only local tool names and let the host add the namespace.
 - Treat hook delivery and provenance as advisory.
-- Add provider-contract, namespace, lifecycle, lag/resync, and feature-off
-  tests.
+- Add provider-contract, namespace, lifecycle, and lag/resync tests.
+- Test both feature-off compatibility and feature-on behavior. Every plugin
+  must be exercised by the workspace `--all-features` CI suite, plus focused
+  tests in its own crate.


### PR DESCRIPTION
## Summary

Fast-follow to ForrestThump review feedback on #39.

- centralize MCP SEP-986 tool-name validation in turbovault-plugin-api
- validate both plugin-local names and final namespaced public names, including the 64-character limit
- conditionally describe enabled plugin namespaces in MCP serverInfo.description; default servers remain unchanged
- require feature-on and feature-off plugin tests in the contribution contract
- remove stale workspace LOC estimates
- make hook-test capacity and overflow intent explicit
- share complete-note write preparation and post-write cache invalidation between core and plugin providers
- clarify that plugins ship with TurboVault as optional Cargo features

TurboMCP 3.1.5 does not expose InitializeResult.instructions through McpHandler, so conditional serverInfo.description is the supported initialization-time metadata path. tools/list remains authoritative for the exact enabled catalog.

## Verification

- cargo test --workspace --all-targets --all-features --locked
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features
- default and plugin-api feature builds checked independently

Follow-up to #39 and Phase 2 of #34.