### PR TITLE
feat(write-substrate): carry caller metadata from ChangePlan onto audit entries

### DIFF
--- a/crates/turbovault-core/src/change_plan.rs
+++ b/crates/turbovault-core/src/change_plan.rs
@@ -50,6 +50,25 @@ pub struct ChangePlan {
     pub message: String,
     pub changes: Vec<Change>,
     pub preconditions: Vec<(String, Precondition)>,
+    /// Opaque, caller-defined metadata recorded on the audit entries this plan
+    /// produces. **Turbovault does not interpret it.**
+    ///
+    /// It exists because a filesystem change event is provenance-blind: a
+    /// `FileModified` is identical whether Turbovault, Obsidian, or git wrote
+    /// the file. Only the *writer* knows who it was, and before this there was
+    /// nowhere for a writer to say so, so a reactive consumer could not tell
+    /// its own writes apart from a human's — and reacted to notes it had just
+    /// produced itself. Recording the caller's own metadata on the audit entry
+    /// lets a consumer join a change back to the write that caused it and
+    /// break that loop.
+    ///
+    /// Deliberately `serde_json::Value` rather than a typed provenance struct:
+    /// it lands verbatim in [`turbovault_audit::AuditEntry::metadata`], which
+    /// is already this type, so nothing here needs to know or agree on a
+    /// schema. Callers put whatever they read back — provenance, correlation
+    /// ids, trace context. A typed accessor can layer on top later without
+    /// changing this plumbing.
+    pub metadata: Option<serde_json::Value>,
 }
 
 impl ChangePlan {
@@ -84,6 +103,14 @@ impl ChangePlan {
     /// Add an arbitrary [`Change`].
     pub fn with_change(mut self, change: Change) -> Self {
         self.changes.push(change);
+        self
+    }
+
+    /// Attach opaque metadata to be recorded on this plan's audit entries.
+    /// See [`ChangePlan::metadata`]. Applies to every change in the plan: one
+    /// plan is one logical mutation, so its entries share one origin.
+    pub fn with_metadata(mut self, metadata: serde_json::Value) -> Self {
+        self.metadata = Some(metadata);
         self
     }
 

--- a/crates/turbovault-vault/src/substrate.rs
+++ b/crates/turbovault-vault/src/substrate.rs
@@ -177,11 +177,14 @@ impl DirectSubstrate {
             Self::check_precondition(path, precondition, before.as_deref())?;
         }
 
+        // The plan's metadata rides down to every audit entry it produces: one
+        // plan is one logical mutation, so its entries share one origin.
+        let metadata = plan.metadata.as_ref();
         for change in &plan.changes {
             match change {
-                Change::Upsert { path, content } => self.upsert(path, content).await?,
-                Change::Remove { path } => self.remove(path).await?,
-                Change::Rename { from, to } => self.rename(from, to).await?,
+                Change::Upsert { path, content } => self.upsert(path, content, metadata).await?,
+                Change::Remove { path } => self.remove(path, metadata).await?,
+                Change::Rename { from, to } => self.rename(from, to, metadata).await?,
             }
         }
 
@@ -239,7 +242,12 @@ impl DirectSubstrate {
 
     /// Write `content` to `path` via temp+rename — the pre-M3a
     /// `VaultManager::write_file` body.
-    async fn upsert(&self, path: &str, content: &[u8]) -> Result<()> {
+    async fn upsert(
+        &self,
+        path: &str,
+        content: &[u8],
+        metadata: Option<&serde_json::Value>,
+    ) -> Result<()> {
         let full = self.full_path(path);
         let before = tokio::fs::read(&full).await.ok();
 
@@ -258,24 +266,43 @@ impl DirectSubstrate {
         } else {
             OperationType::Create
         };
-        self.record_audit(path, operation, before.as_deref(), Some(content), None)
-            .await;
+        self.record_audit(
+            path,
+            operation,
+            before.as_deref(),
+            Some(content),
+            None,
+            metadata,
+        )
+        .await;
         Ok(())
     }
 
     /// The pre-M3a `VaultManager::delete_file` body.
-    async fn remove(&self, path: &str) -> Result<()> {
+    async fn remove(&self, path: &str, metadata: Option<&serde_json::Value>) -> Result<()> {
         let full = self.full_path(path);
         let before = tokio::fs::read(&full).await.ok();
         tokio::fs::remove_file(&full).await.map_err(Error::io)?;
-        self.record_audit(path, OperationType::Delete, before.as_deref(), None, None)
-            .await;
+        self.record_audit(
+            path,
+            OperationType::Delete,
+            before.as_deref(),
+            None,
+            None,
+            metadata,
+        )
+        .await;
         Ok(())
     }
 
     /// The pre-M3a `VaultManager::move_file` body (rename with cross-device
     /// fallback; raw bytes preserved for non-UTF-8 attachments).
-    async fn rename(&self, from: &str, to: &str) -> Result<()> {
+    async fn rename(
+        &self,
+        from: &str,
+        to: &str,
+        metadata: Option<&serde_json::Value>,
+    ) -> Result<()> {
         let from_full = self.full_path(from);
         let to_full = self.full_path(to);
         let bytes = tokio::fs::read(&from_full).await.map_err(Error::io)?;
@@ -304,6 +331,7 @@ impl DirectSubstrate {
             Some(&bytes),
             Some(&bytes),
             Some(to),
+            metadata,
         )
         .await;
         Ok(())
@@ -321,6 +349,7 @@ impl DirectSubstrate {
         before: Option<&[u8]>,
         after: Option<&[u8]>,
         new_path: Option<&str>,
+        metadata: Option<&serde_json::Value>,
     ) {
         let (Some(audit_log), Some(snapshot_store)) = (&self.audit_log, &self.snapshot_store)
         else {
@@ -330,6 +359,10 @@ impl DirectSubstrate {
         let mut entry = AuditEntry::new(operation, rel_path);
         if let Some(new_path) = new_path {
             entry = entry.with_new_path(new_path);
+        }
+        // Verbatim: the caller's metadata is not interpreted here, only carried.
+        if let Some(metadata) = metadata {
+            entry = entry.with_metadata(metadata.clone());
         }
 
         if let Some(before) = before.and_then(|b| std::str::from_utf8(b).ok()) {
@@ -597,6 +630,134 @@ mod tests {
                 .unwrap(),
             "body"
         );
+    }
+
+    // -------- ChangePlan::metadata -> AuditEntry::metadata --------
+
+    /// A substrate with audit + snapshot recording wired, as `VaultManager::set_audit_log`
+    /// does. The plain `direct()` helper above leaves both `None`, which makes `record_audit`
+    /// a no-op — so these tests need their own.
+    async fn direct_with_audit(tmp: &TempDir) -> (DirectSubstrate, Arc<AuditLog>) {
+        let audit = Arc::new(AuditLog::new(tmp.path()).await.unwrap());
+        let snapshots = Arc::new(SnapshotStore::new(audit.snapshot_dir().to_path_buf()));
+        let mut sub = DirectSubstrate::new(tmp.path().to_path_buf());
+        sub.set_audit_log(Arc::clone(&audit), snapshots);
+        (sub, audit)
+    }
+
+    async fn entries(audit: &AuditLog) -> Vec<turbovault_audit::AuditEntry> {
+        audit
+            .query(&turbovault_audit::AuditFilter::new().with_limit(32))
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn plan_metadata_lands_on_the_audit_entry() {
+        let tmp = TempDir::new().unwrap();
+        let (sub, audit) = direct_with_audit(&tmp).await;
+        let meta = serde_json::json!({ "source": "daily-review-agent", "correlation_id": "r-1" });
+
+        sub.apply(
+            &ChangePlan::new("write")
+                .create("notes/n.md", "body")
+                .with_metadata(meta.clone()),
+        )
+        .await
+        .unwrap();
+
+        let recorded = entries(&audit).await;
+        let entry = recorded
+            .iter()
+            .find(|e| e.path == "notes/n.md")
+            .expect("an audit entry for the written path");
+        assert_eq!(entry.metadata, meta);
+        // The rest of the entry is unchanged — metadata rides alongside, it does not replace.
+        assert_eq!(entry.operation, OperationType::Create);
+        assert_eq!(
+            entry.after_hash.as_deref(),
+            Some(compute_hash("body").as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn a_plan_without_metadata_records_none() {
+        let tmp = TempDir::new().unwrap();
+        let (sub, audit) = direct_with_audit(&tmp).await;
+
+        sub.apply(&ChangePlan::new("write").create("notes/n.md", "body"))
+            .await
+            .unwrap();
+
+        let recorded = entries(&audit).await;
+        let entry = recorded.iter().find(|e| e.path == "notes/n.md").unwrap();
+        assert_eq!(
+            entry.metadata,
+            serde_json::json!({}),
+            "absent plan metadata must leave the entry's default untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_metadata_reaches_remove_and_rename_entries_too() {
+        let tmp = TempDir::new().unwrap();
+        let (sub, audit) = direct_with_audit(&tmp).await;
+        let meta = serde_json::json!({ "source": "organizer" });
+
+        sub.apply(&ChangePlan::new("seed").create("a.md", "body"))
+            .await
+            .unwrap();
+        let hash = compute_hash("body");
+
+        sub.apply(
+            &ChangePlan::new("move")
+                .rename("a.md", "b.md", hash.clone())
+                .with_metadata(meta.clone()),
+        )
+        .await
+        .unwrap();
+        sub.apply(
+            &ChangePlan::new("delete")
+                .delete("b.md", hash)
+                .with_metadata(meta.clone()),
+        )
+        .await
+        .unwrap();
+
+        let recorded = entries(&audit).await;
+        for op in [OperationType::Move, OperationType::Delete] {
+            let entry = recorded
+                .iter()
+                .find(|e| e.operation == op)
+                .unwrap_or_else(|| panic!("an audit entry for {op:?}"));
+            assert_eq!(
+                entry.metadata, meta,
+                "{op:?} entry lost the plan's metadata"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn every_entry_of_a_multi_change_plan_carries_the_metadata() {
+        // One plan is one logical mutation: all of its entries share the origin.
+        let tmp = TempDir::new().unwrap();
+        let (sub, audit) = direct_with_audit(&tmp).await;
+        let meta = serde_json::json!({ "source": "batch-importer" });
+
+        sub.apply(
+            &ChangePlan::new("import")
+                .create("x.md", "one")
+                .create("y.md", "two")
+                .with_metadata(meta.clone()),
+        )
+        .await
+        .unwrap();
+
+        let recorded = entries(&audit).await;
+        for path in ["x.md", "y.md"] {
+            let entry = recorded.iter().find(|e| e.path == path).unwrap();
+            assert_eq!(entry.metadata, meta);
+        }
     }
 
     // -------- DirectSubstrate::apply — every Precondition variant --------


### PR DESCRIPTION
## What

`ChangePlan` gains an optional `metadata: Option<serde_json::Value>`, and `DirectSubstrate`
records it verbatim on every audit entry the plan produces.

```rust
let plan = ChangePlan::new("write")
    .create("notes/n.md", body)
    .with_metadata(json!({ "source": "daily-review-agent", "correlation_id": "r-1" }));

// -> AuditEntry { path: "notes/n.md", metadata: {"source": "...", ...}, .. }
```

Absent metadata is unchanged behaviour: the entry keeps its default `{}`.

## Why

A filesystem change event is provenance-blind. A `FileModified` is identical whether Turbovault,
Obsidian, or `git` wrote the file — only the *writer* ever knows who it was, and there was nowhere
for a writer to say so.

That leaves a consumer of the vault unable to distinguish its own writes from a human's. The
concrete failure: an agent generates a note, files it into the vault, then observes that note
change, cannot attribute it, and reacts to its own output — repeatedly, until a depth limit stops
it.

`AuditEntry.metadata` already exists and is already `serde_json::Value`. Nothing could reach it.
This connects the two ends.

## Why here

Before #44 this had to be threaded tool by tool, and every new write path re-opened the hole.
#44 made `ChangePlan` the single mutation vocabulary and `DirectSubstrate::record_audit` the single
place audit entries are written — so this lands **once** and covers every entry point: the single-op
mutators, batch, and anything built later.

That is the whole reason this is a small diff.

## Design notes

- **Opaque `serde_json::Value`, not a typed provenance struct.** It lands verbatim in a field of the
  same type, so nothing here needs to know or agree on a schema, and `turbovault-core` takes no new
  dependency. Callers put back whatever they read: provenance, correlation ids, trace context. A
  typed accessor (`plugin-api`'s `WriteProvenance` serialises straight into this slot) can layer on
  top later without changing this plumbing.
- **Plan-scoped, not per-change.** One plan is one logical mutation, so its entries share one
  origin. A multi-change plan stamps all of them.
- **Turbovault does not interpret it.** It is carried, never read — advisory correlation data, not
  an authorization boundary.
- **`GitSubstrate` is untouched**, since it records no audit entries today. When it grows them, the
  field is already on the plan it receives.

## Tests

Four new tests in `substrate.rs`, using a substrate with audit + snapshot wired (the existing
`direct()` helper leaves both `None`, which makes `record_audit` a no-op):

- metadata reaches a create/update entry, with the rest of the entry unchanged
- metadata reaches `Move` and `Delete` entries
- every entry of a multi-change plan carries it
- a plan without metadata still records the default `{}`

`cargo fmt` clean; `clippy` adds no new warnings.

**Pre-existing failures, unrelated to this change:** on Windows, 4 tests in
`test_mcp_provider_workflows` fail identically with and without this patch
(`audit_create_delete_and_unsupported_rollbacks_...`, `templates_render_notes_...`,
`graph_navigation_and_topology_...`, `file_lifecycle_and_concurrency_guards_...`). They assert
forward-slash path suffixes and Unix `"No such file"` error strings. Verified by stashing the patch
and re-running against pristine `main`.

## Follow-up (not in this PR)

The MCP tool layer can forward a request's `_meta` into `ChangePlan::with_metadata`, which is what
makes this reachable by an MCP client rather than only an in-process caller. That is deliberately
excluded here: it needs a `turbomcp` that surfaces request `_meta` to handlers, which is not on the
released crate yet. This PR is useful on its own and unblocks that one.

Related: #33 (write provenance in the vault event stream).
