### PR TITLE
fix(batch): report what a direct batch actually did

### DIFF
--- a/crates/turbovault-core/src/change_plan.rs
+++ b/crates/turbovault-core/src/change_plan.rs
@@ -39,6 +39,17 @@ impl Change {
             Change::Rename { from, .. } => from,
         }
     }
+
+    /// Every path this change mutates: `path` for `Upsert`/`Remove`, BOTH
+    /// endpoints for `Rename`. [`ChangePlan::touched_paths`] is the
+    /// plan-wide fold of this; a caller holding only a SUB-RANGE of a plan's
+    /// changes (the batch's per-operation span) folds it itself.
+    pub fn touched_paths(&self) -> Vec<&str> {
+        match self {
+            Change::Upsert { path, .. } | Change::Remove { path } => vec![path],
+            Change::Rename { from, to } => vec![from, to],
+        }
+    }
 }
 
 /// A backend-agnostic description of one mutation: an ordered set of
@@ -187,17 +198,11 @@ impl ChangePlan {
     /// `commit_changeset`) and by the tool layer's intra-batch path-collision
     /// check.
     pub fn touched_paths(&self) -> Vec<String> {
-        let mut out = Vec::with_capacity(self.changes.len());
-        for c in &self.changes {
-            match c {
-                Change::Upsert { path, .. } | Change::Remove { path } => out.push(path.clone()),
-                Change::Rename { from, to } => {
-                    out.push(from.clone());
-                    out.push(to.clone());
-                }
-            }
-        }
-        out
+        self.changes
+            .iter()
+            .flat_map(Change::touched_paths)
+            .map(String::from)
+            .collect()
     }
 }
 

--- a/crates/turbovault-tools/src/batch_tools.rs
+++ b/crates/turbovault-tools/src/batch_tools.rs
@@ -82,7 +82,15 @@ impl BatchTools {
             Err(e) => return Ok(failed_batch(total, e, transaction_id, started)),
         };
         plan.message = message.to_string();
-        if let Err(e) = self.manager.apply_changes(&plan).await {
+        let outcome = match self.manager.apply_changes(&plan).await {
+            Ok(outcome) => outcome,
+            Err(e) => return Ok(failed_batch(total, e, transaction_id, started)),
+        };
+        // A best-effort direct apply that stopped mid-plan comes back as `Ok`
+        // carrying its error (M5 S2). Reporting it as today's whole-plan
+        // failure envelope keeps the wire shape unchanged here; turning it
+        // into a per-operation partial report is turbovault-qim.
+        if let Some(e) = outcome.error {
             return Ok(failed_batch(total, e, transaction_id, started));
         }
 
@@ -212,7 +220,10 @@ impl BatchTools {
                 expected_hash,
             )
             .await?;
-        self.manager.apply_changes(&plan).await?;
+        // All-or-nothing contract: a best-effort direct apply that stopped
+        // mid-plan comes back as `Ok` carrying its error (M5 S2), so re-raise
+        // it rather than reporting a half-rewritten move as a success.
+        self.manager.apply_changes(&plan).await?.into_result()?;
         Ok(updated)
     }
 
@@ -230,7 +241,8 @@ impl BatchTools {
         let (plan, updated) = self
             .fold_delete_with_stale_links(ChangePlan::new(message.to_string()), path, expected_hash)
             .await?;
-        self.manager.apply_changes(&plan).await?;
+        // Same all-or-nothing re-raise as `move_file_with_link_updates`.
+        self.manager.apply_changes(&plan).await?.into_result()?;
         Ok(updated)
     }
 

--- a/crates/turbovault-tools/src/batch_tools.rs
+++ b/crates/turbovault-tools/src/batch_tools.rs
@@ -1,11 +1,12 @@
 //! Batch operation tools for coordinated multi-file operations
 
+use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 use turbovault_batch::{BatchOperation, BatchResult, OperationRecord};
-use turbovault_core::ChangePlan;
 use turbovault_core::prelude::*;
+use turbovault_core::{Change, ChangePlan};
 use turbovault_vault::{EditEngine, VaultManager};
 
 /// Batch operation tools
@@ -32,19 +33,20 @@ impl BatchTools {
     /// and per-op CAS preconditions) and applies it through
     /// [`VaultManager::apply_changes`] — so the SAME batch surface runs on
     /// both substrates. `message` becomes the git commit subject (ignored on
-    /// direct). On a direct vault the plan gets today's `DirectSubstrate::apply`
-    /// semantics (precondition-gate → sequential → `atomic:true`); direct
-    /// best-effort `failed_at` reporting is M5.2.
+    /// direct).
     ///
     /// Reindex is flushed first so any link-aware op (`MoveNote`/`DeleteNote`)
     /// resolves against a coherent graph. A batch failure (stale precondition,
     /// intra-batch path collision, unreadable link source) is reported as a
     /// soft `BatchResult { success: false, errors }` — NOT a hard `Err` — so the
-    /// pre-M4d batch wire shape (R10) holds. On git `apply_changes` aborts the
-    /// whole plan atomically (nothing written). On direct only the precondition
-    /// GATE is atomic — the apply loop is sequential with no rollback, so a
-    /// mid-loop failure can leave partial state while this still reports
-    /// `executed: 0`; true direct best-effort/`failed_at` reporting is M5.2.
+    /// pre-M4d batch wire shape (R10) holds.
+    ///
+    /// On git `apply_changes` aborts the whole plan atomically (nothing
+    /// written). On direct only the precondition GATE is atomic — the apply
+    /// loop is sequential with no rollback, so a mid-loop failure leaves the
+    /// earlier operations on disk. That partial is REPORTED, not hidden
+    /// (TV-016): `executed`/`changes`/`records` cover the operations that
+    /// landed and `failed_at` names the one that stopped the batch.
     pub async fn batch_execute(
         &self,
         operations: Vec<BatchOperation>,
@@ -69,16 +71,14 @@ impl BatchTools {
         }
 
         self.manager.flush_reindex().await;
-        // A batch failure (intra-batch collision, a stale/absent precondition,
-        // an unreadable link source) is reported as `success: false` in the
-        // BatchResult envelope — NOT propagated as a hard error — preserving
-        // the pre-M4d wire shape (R10): the batch tool call itself succeeds and
-        // the caller inspects `success`/`errors`. On git `apply_changes` is
-        // whole-plan atomic (nothing written on failure); on direct only the
-        // precondition gate is atomic — a mid-apply failure may leave partial
-        // state (M5.2 adds `failed_at`).
-        let mut plan = match self.plan(&operations).await {
-            Ok(plan) => plan,
+        // A batch failure that wrote NOTHING (intra-batch collision, a
+        // stale/absent precondition, an unreadable link source, any git
+        // failure) is reported as `success: false` in the BatchResult
+        // envelope — NOT propagated as a hard error — preserving the pre-M4d
+        // wire shape (R10): the batch tool call itself succeeds and the caller
+        // inspects `success`/`errors`.
+        let (mut plan, op_spans) = match self.plan_with_op_spans(&operations).await {
+            Ok(planned) => planned,
             Err(e) => return Ok(failed_batch(total, e, transaction_id, started)),
         };
         plan.message = message.to_string();
@@ -86,35 +86,55 @@ impl BatchTools {
             Ok(outcome) => outcome,
             Err(e) => return Ok(failed_batch(total, e, transaction_id, started)),
         };
-        // A best-effort direct apply that stopped mid-plan comes back as `Ok`
-        // carrying its error (M5 S2). Reporting it as today's whole-plan
-        // failure envelope keeps the wire shape unchanged here; turning it
-        // into a per-operation partial report is turbovault-qim.
-        if let Some(e) = outcome.error {
-            return Ok(failed_batch(total, e, transaction_id, started));
-        }
 
-        let changes = operations.iter().map(describe_op).collect();
-        let records = operations
-            .iter()
-            .enumerate()
-            .map(|(idx, op)| OperationRecord {
-                operation_index: idx,
-                operation: format!("{:?}", op),
-                success: true,
-                error: None,
-                affected_files: op.affected_files(),
-            })
-            .collect();
+        // A best-effort direct apply that stopped mid-plan comes back as `Ok`
+        // carrying its error and the CHANGE index that stopped it. Translate
+        // that into the operation-level report the wire speaks (TV-016): the
+        // operations before the failing one genuinely landed and must be
+        // counted, listed and recorded as successes.
+        if let Some(error) = outcome.error {
+            let stopped_at = outcome.failed_at.unwrap_or(plan.changes.len());
+            // The failing operation is the first whose span extends past the
+            // change that stopped the loop (`> `, not `contains`, so an
+            // operation contributing zero changes can't swallow the index).
+            let failed_op = op_spans
+                .iter()
+                .position(|span| span.end > stopped_at)
+                .unwrap_or(total.saturating_sub(1));
+
+            let mut records = op_records(&operations[..failed_op], &plan, &op_spans);
+            records.push(OperationRecord {
+                operation_index: failed_op,
+                operation: format!("{:?}", operations[failed_op]),
+                success: false,
+                error: Some(error.to_string()),
+                // Only the changes this operation applied BEFORE the failure
+                // — usually none, but a multi-change operation (a move plus
+                // its backlink rewrites) can stop partway through its own span.
+                affected_files: changed_paths(&plan.changes[op_spans[failed_op].start..stopped_at]),
+            });
+
+            return Ok(BatchResult {
+                success: false,
+                executed: failed_op,
+                total,
+                failed_at: Some(failed_op),
+                changes: operations[..failed_op].iter().map(describe_op).collect(),
+                errors: vec![error.to_string()],
+                records,
+                transaction_id,
+                duration_ms: started.elapsed().as_millis() as u64,
+            });
+        }
 
         Ok(BatchResult {
             success: true,
             executed: total,
             total,
             failed_at: None,
-            changes,
+            changes: operations.iter().map(describe_op).collect(),
             errors: vec![],
-            records,
+            records: op_records(&operations, &plan, &op_spans),
             transaction_id,
             duration_ms: started.elapsed().as_millis() as u64,
         })
@@ -138,12 +158,30 @@ impl BatchTools {
     /// (turbovault-0g4.5): a path may be mutated by at most one operation
     /// per batch.
     pub async fn plan(&self, operations: &[BatchOperation]) -> Result<ChangePlan> {
+        Ok(self.plan_with_op_spans(operations).await?.0)
+    }
+
+    /// [`Self::plan`] plus, per operation, the half-open range of
+    /// `plan.changes` that operation contributed. The batch report needs that
+    /// mapping in both directions: change index -> operation index (the
+    /// substrate's `failed_at` counts CHANGES; the wire reports OPERATIONS)
+    /// and operation index -> paths (so `records[].affected_files` names what
+    /// the plan actually touches, including the link-rewrite upserts a
+    /// `MoveNote`/`DeleteNote` discovers from the link graph and never
+    /// declares itself — TV-016).
+    async fn plan_with_op_spans(
+        &self,
+        operations: &[BatchOperation],
+    ) -> Result<(ChangePlan, Vec<Range<usize>>)> {
         let mut plan = ChangePlan::new(format!("batch_execute ({} ops)", operations.len()));
         let mut seen_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut op_spans = Vec::with_capacity(operations.len());
 
         for (idx, op) in operations.iter().enumerate() {
+            let before_changes = plan.changes.len();
             let before = plan.touched_paths().len();
             plan = self.translate_op(plan, op).await?;
+            op_spans.push(before_changes..plan.changes.len());
             if let Some(dup) = plan
                 .touched_paths()
                 .into_iter()
@@ -157,7 +195,7 @@ impl BatchTools {
             }
         }
 
-        Ok(plan)
+        Ok((plan, op_spans))
     }
 
     /// Atomic move + inbound-wikilink rewrite, as a plan. Ports
@@ -714,10 +752,48 @@ fn remove_expecting(plan: ChangePlan, path: &str, expected_hash: Option<&str>) -
     p
 }
 
+/// A `success: true` [`OperationRecord`] per operation, with `affected_files`
+/// read off the operation's span of the applied [`ChangePlan`].
+///
+/// The paths come from the PLAN, not from `BatchOperation::affected_files`
+/// (the operation's DECLARED paths): a `MoveNote`/`DeleteNote` folds an
+/// inbound-backlink rewrite for every linker it finds in the link graph, and
+/// the operation itself cannot name those files (TV-016 manifestation B).
+fn op_records(
+    operations: &[BatchOperation],
+    plan: &ChangePlan,
+    op_spans: &[Range<usize>],
+) -> Vec<OperationRecord> {
+    operations
+        .iter()
+        .enumerate()
+        .map(|(idx, op)| OperationRecord {
+            operation_index: idx,
+            operation: format!("{:?}", op),
+            success: true,
+            error: None,
+            affected_files: changed_paths(&plan.changes[op_spans[idx].clone()]),
+        })
+        .collect()
+}
+
+/// The paths a run of plan changes mutates — the span-scoped counterpart of
+/// [`ChangePlan::touched_paths`].
+fn changed_paths(changes: &[Change]) -> Vec<String> {
+    changes
+        .iter()
+        .flat_map(Change::touched_paths)
+        .map(String::from)
+        .collect()
+}
+
 /// The soft `success: false` [`BatchResult`] a manager-routed batch returns
-/// when the plan cannot be built or applied — nothing was written (the plan
-/// aborts atomically). Mirrors the pre-M4d executor's failure envelope so the
-/// batch tool's wire shape is unchanged (R10).
+/// when the plan cannot be built or applied and NOTHING was written — the
+/// plan aborted at the precondition gate, or on git, where every apply is
+/// all-or-nothing. Mirrors the pre-M4d executor's failure envelope so the
+/// batch tool's wire shape is unchanged (R10). A direct apply that stopped
+/// mid-plan does NOT come here: it left state behind, so `batch_execute`
+/// reports it per-operation instead.
 fn failed_batch(
     total: usize,
     error: Error,

--- a/crates/turbovault-tools/tests/test_async_error_paths.rs
+++ b/crates/turbovault-tools/tests/test_async_error_paths.rs
@@ -223,11 +223,10 @@ async fn test_batch_tools_partial_failure_rollback() {
     assert!(result.is_ok());
     let batch_result = result.unwrap();
     assert!(!batch_result.success);
-    // write-substrate-layering M4d/M4e: the manager-routed batch folds every
-    // op into ONE ChangePlan and reports `executed: 0` on any apply failure
-    // (per-index `failed_at` tracking on the direct backend is M5.2 future
-    // work) — it does NOT mean nothing landed on disk; see below.
-    assert_eq!(batch_result.executed, 0);
+    // TV-016: operations 0 and 1 landed before the delete of a nonexistent
+    // file failed, and the report says so.
+    assert_eq!(batch_result.executed, 2);
+    assert_eq!(batch_result.failed_at, Some(2));
 
     // Note: the direct backend's apply loop is sequential with no rollback
     // (only the precondition GATE is atomic) — operations 0 and 1 already

--- a/crates/turbovault-tools/tests/test_batch_tools.rs
+++ b/crates/turbovault-tools/tests/test_batch_tools.rs
@@ -527,3 +527,119 @@ async fn test_plan_rejects_intra_batch_same_path_collision() {
         "got: {msg}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// TV-016 (turbovault-qim): the direct batch must REPORT what it mutated
+// ---------------------------------------------------------------------------
+
+/// (A) The ticket's repro. A direct batch is best-effort: op 0 lands, op 1
+/// fails, op 2 is never attempted. The response must say exactly that —
+/// `executed: 1`, `failed_at: Some(1)`, op 0 in `changes` and on disk, and a
+/// record per attempted op — instead of the pre-fix `executed: 0` /
+/// `failed_at: null` / empty `changes` + `records`, which claimed nothing
+/// happened while va.md sat on disk.
+#[tokio::test]
+async fn test_batch_partial_failure_reports_the_op_that_landed() {
+    let (temp_dir, manager) = setup_test_vault().await;
+    let tools = BatchTools::new(manager.clone());
+
+    let ops = vec![
+        BatchOperation::CreateNote {
+            path: "va.md".to_string(),
+            content: "# VA".to_string(),
+            force: None,
+        },
+        BatchOperation::DeleteNote {
+            path: "vb-absent.md".to_string(), // fails: no such file
+            expected_hash: None,
+            on_backlinks: None,
+        },
+        BatchOperation::CreateNote {
+            path: "vc.md".to_string(),
+            content: "# VC".to_string(),
+            force: None,
+        },
+    ];
+
+    let result = tools.batch_execute(ops, "tv-016 partial").await.unwrap();
+
+    assert!(
+        !result.success,
+        "a batch that stopped mid-plan is not a success"
+    );
+    assert_eq!(result.executed, 1, "op 0 genuinely landed");
+    assert_eq!(result.failed_at, Some(1), "op 1 is the op that failed");
+    assert_eq!(result.total, 3);
+    assert_eq!(
+        result.changes,
+        vec!["created va.md".to_string()],
+        "changes lists the ops that applied, not the whole batch"
+    );
+
+    assert_eq!(
+        result.records.len(),
+        2,
+        "one record per ATTEMPTED op — op 2 was never reached"
+    );
+    assert_eq!(result.records[0].operation_index, 0);
+    assert!(result.records[0].success);
+    assert!(result.records[0].error.is_none());
+    assert_eq!(result.records[0].affected_files, vec!["va.md".to_string()]);
+    assert_eq!(result.records[1].operation_index, 1);
+    assert!(!result.records[1].success);
+    assert!(
+        result.records[1].error.is_some(),
+        "the failing op carries its error"
+    );
+    assert!(
+        !result.errors.is_empty(),
+        "the batch still surfaces the error"
+    );
+
+    // The report has to match the disk, which is the whole point.
+    assert!(temp_dir.path().join("va.md").exists());
+    assert!(!temp_dir.path().join("vc.md").exists());
+}
+
+/// (B) A SUCCESSFUL batch `MoveNote` rewrites every inbound wikilink in the
+/// same plan, so the linker it rewrote is a file this operation mutated —
+/// `affected_files` must name it. Pre-fix it was built from the operation's
+/// DECLARED paths (`BatchOperation::affected_files`), which cannot know about
+/// a linker the plan discovered from the link graph.
+#[tokio::test]
+async fn test_batch_move_reports_backlink_rewritten_linker_in_affected_files() {
+    let (temp_dir, manager) =
+        setup_vault_with_files(&[("bt.md", "# Target\n"), ("bl.md", "See [[bt]] here.\n")]).await;
+    let tools = BatchTools::new(manager.clone());
+
+    let ops = vec![BatchOperation::MoveNote {
+        from: "bt.md".to_string(),
+        to: "bt-renamed.md".to_string(),
+        expected_hash: None,
+        update_backlinks: None,
+    }];
+
+    let result = tools.batch_execute(ops, "tv-016 move").await.unwrap();
+
+    assert!(result.success, "errors: {:?}", result.errors);
+    assert_eq!(result.executed, 1);
+    let affected = &result.records[0].affected_files;
+    assert!(
+        affected.contains(&"bl.md".to_string()),
+        "the rewritten linker is a file this op mutated: {affected:?}"
+    );
+    assert!(affected.contains(&"bt.md".to_string()), "{affected:?}");
+    assert!(
+        affected.contains(&"bt-renamed.md".to_string()),
+        "{affected:?}"
+    );
+
+    // The linker really was rewritten on disk — affected_files is not a lie
+    // in the other direction either.
+    assert_eq!(
+        tokio::fs::read_to_string(temp_dir.path().join("bl.md"))
+            .await
+            .unwrap(),
+        "See [[bt-renamed]] here.\n"
+    );
+}

--- a/crates/turbovault-tools/tests/test_batch_tools.rs
+++ b/crates/turbovault-tools/tests/test_batch_tools.rs
@@ -208,11 +208,11 @@ async fn test_batch_execute_rollback_on_error() {
     assert!(result.is_ok());
     let batch_result = result.unwrap();
     assert!(!batch_result.success);
-    // write-substrate-layering M4d/M4e: the manager-routed batch folds every
-    // op into ONE ChangePlan and reports `executed: 0` on any apply failure
-    // (per-index `failed_at` tracking on the direct backend is M5.2 future
-    // work) — it does NOT mean nothing landed on disk; see below.
-    assert_eq!(batch_result.executed, 0);
+    // TV-016: the direct backend's apply loop is sequential with no rollback,
+    // so operation 0 landed. `executed` counts what landed, `failed_at` names
+    // the operation that stopped the batch.
+    assert_eq!(batch_result.executed, 1);
+    assert_eq!(batch_result.failed_at, Some(1));
 
     // Note: the direct backend's apply loop is sequential with no rollback
     // (only the precondition GATE is atomic) — operation 0 (success1.md) was
@@ -294,11 +294,11 @@ async fn test_batch_execute_atomic_guarantees() {
     assert!(result2.is_ok());
     let batch_result2 = result2.unwrap();
     assert!(!batch_result2.success);
-    // See test_batch_execute_rollback_on_error: the manager-routed batch
-    // reports `executed: 0` on any apply failure (M5.2 adds per-index
-    // `failed_at`); atomic3.md still landed (asserted below) since the
-    // direct backend's apply loop is sequential with no rollback.
-    assert_eq!(batch_result2.executed, 0);
+    // See test_batch_execute_rollback_on_error: atomic3.md landed (asserted
+    // below) since the direct backend's apply loop is sequential with no
+    // rollback, and TV-016 makes the report say so.
+    assert_eq!(batch_result2.executed, 1);
+    assert_eq!(batch_result2.failed_at, Some(1));
 
     // Verify first batch files still exist (different batch, unaffected)
     let vault_path = manager.vault_path();

--- a/crates/turbovault-tools/tests/test_batch_tools.rs
+++ b/crates/turbovault-tools/tests/test_batch_tools.rs
@@ -534,25 +534,52 @@ async fn test_plan_rejects_intra_batch_same_path_collision() {
 
 /// (A) The ticket's repro. A direct batch is best-effort: op 0 lands, op 1
 /// fails, op 2 is never attempted. The response must say exactly that —
-/// `executed: 1`, `failed_at: Some(1)`, op 0 in `changes` and on disk, and a
-/// record per attempted op — instead of the pre-fix `executed: 0` /
-/// `failed_at: null` / empty `changes` + `records`, which claimed nothing
-/// happened while va.md sat on disk.
+/// `executed: 1`, `failed_at: Some(1)`, op 0 in `changes`, on disk AND in the
+/// link graph, and a record per attempted op — instead of the pre-fix
+/// `executed: 0` / `failed_at: null` / empty `changes` + `records`, which
+/// claimed nothing happened while va.md sat on disk.
+///
+/// THE FAILING OP MUST FAIL IN THE APPLY LOOP, NOT AT THE PRECONDITION GATE.
+/// `DirectSubstrate::apply` checks every precondition before applying any
+/// change and aborts the whole plan with nothing written, so a precondition
+/// failure can never leave the partial this test exists to pin — a scenario
+/// built on one would silently stop testing anything. Hence a `WriteNote`
+/// with `expected_hash: None`, which contributes NO precondition (the gate
+/// never even reads the path), targeting a path whose parent component is an
+/// existing regular FILE: the apply loop's `create_dir_all` cannot turn a
+/// regular file into a directory. That refusal comes from the kernel, so it
+/// is deterministic, holds when the process runs as root, and is not a
+/// semantic the write-safety matrix can ever redefine.
+///
+/// It replaces the ticket's original failing op — a `DeleteNote` of an ABSENT
+/// file — which the ratified spec says must SUCCEED:
+/// `docs/write-safety-suite/wss-precondition-matrix.csv`, row
+/// `delete_note,Exists`, all-absent (`-----`) column, is `Ok`. Once the
+/// direct backend catches up to that cell the old batch stops failing and the
+/// old test goes red for a FIX rather than a regression.
 #[tokio::test]
 async fn test_batch_partial_failure_reports_the_op_that_landed() {
-    let (temp_dir, manager) = setup_test_vault().await;
+    let (temp_dir, manager) = setup_vault_with_files(&[
+        ("existing.md", "# Existing\n"),
+        // A regular FILE, not a directory — nothing can be created under it.
+        ("blocker.md", "# Blocker\n"),
+    ])
+    .await;
     let tools = BatchTools::new(manager.clone());
 
     let ops = vec![
         BatchOperation::CreateNote {
             path: "va.md".to_string(),
-            content: "# VA".to_string(),
+            content: "# VA\n\nSee [[existing]].\n".to_string(),
             force: None,
         },
-        BatchOperation::DeleteNote {
-            path: "vb-absent.md".to_string(), // fails: no such file
+        BatchOperation::WriteNote {
+            // Fails in the apply loop: create_dir_all("blocker.md") hits the
+            // existing regular file. No expected_hash => no precondition, so
+            // the gate never touches this path.
+            path: "blocker.md/child.md".to_string(),
+            content: "# never lands".to_string(),
             expected_hash: None,
-            on_backlinks: None,
         },
         BatchOperation::CreateNote {
             path: "vc.md".to_string(),
@@ -587,9 +614,15 @@ async fn test_batch_partial_failure_reports_the_op_that_landed() {
     assert_eq!(result.records[0].affected_files, vec!["va.md".to_string()]);
     assert_eq!(result.records[1].operation_index, 1);
     assert!(!result.records[1].success);
+    let failure = result.records[1]
+        .error
+        .as_deref()
+        .expect("the failing op carries its error");
     assert!(
-        result.records[1].error.is_some(),
-        "the failing op carries its error"
+        failure.starts_with("I/O error:"),
+        "the apply loop must have stopped on a filesystem failure — a \
+         precondition rejection would have aborted at the gate with nothing \
+         written, and this test would be pinning nothing. Got: {failure}"
     );
     assert!(
         !result.errors.is_empty(),
@@ -599,6 +632,27 @@ async fn test_batch_partial_failure_reports_the_op_that_landed() {
     // The report has to match the disk, which is the whole point.
     assert!(temp_dir.path().join("va.md").exists());
     assert!(!temp_dir.path().join("vc.md").exists());
+    assert!(
+        temp_dir.path().join("blocker.md").is_file(),
+        "the failing write must not have clobbered the blocker"
+    );
+
+    // ...and the manager indexed what landed, so the op that survived the
+    // partial is visible to every read path, not just to `ls`.
+    let linkers = {
+        let lg = manager.link_graph();
+        let graph = lg.read().await;
+        graph
+            .backlinks(&temp_dir.path().join("existing.md"))
+            .unwrap()
+            .into_iter()
+            .map(|(path, _links)| path)
+            .collect::<Vec<_>>()
+    };
+    assert!(
+        linkers.contains(&temp_dir.path().join("va.md")),
+        "the landed op must be in the link graph, not only on disk: {linkers:?}"
+    );
 }
 
 /// (B) A SUCCESSFUL batch `MoveNote` rewrites every inbound wikilink in the

--- a/crates/turbovault-vault/src/manager.rs
+++ b/crates/turbovault-vault/src/manager.rs
@@ -545,10 +545,20 @@ impl VaultManager {
             .upsert(rel_path.clone(), content.as_bytes())
             .with_precondition(rel_path, precondition);
 
-        let outcome = self.substrate.apply(&plan).await?;
+        self.apply_one(&plan).await
+    }
+
+    /// The single-op mutators' shared tail: apply, index whatever landed
+    /// (R7), then re-raise a best-effort apply's error so they keep their
+    /// all-or-nothing `Result` contract. Their plans hold ONE change, so
+    /// "what landed" is all-or-nothing anyway — the re-raise is what stops
+    /// a failed single write from being reported as a success now that
+    /// `DirectSubstrate::apply` returns `Ok` for a stopped apply loop.
+    async fn apply_one(&self, plan: &ChangePlan) -> Result<()> {
+        let outcome = self.substrate.apply(plan).await?;
         self.sync_index(&outcome.changed).await;
-        self.fire_change_listener(outcome.changed);
-        Ok(())
+        self.fire_change_listener(outcome.changed.clone());
+        outcome.into_result().map(|_| ())
     }
 
     /// Apply an arbitrary multi-change [`ChangePlan`] — the R3 multi-change
@@ -559,6 +569,16 @@ impl VaultManager {
     /// bypass for callers (batch, rollback, …) that build their own plans.
     /// Delegates to the substrate and runs the same post-apply link-
     /// graph/cache sync (R7) as the single-op mutators.
+    ///
+    /// A best-effort direct apply that stopped mid-plan (M5 S2) comes back as
+    /// `Ok(outcome)` with `atomic: false`, `failed_at: Some(i)` and
+    /// `error: Some(_)` — the sync above still runs over the prefix that
+    /// landed, so a partially-applied plan is never invisible to the link
+    /// graph, file cache and search index. Callers that want all-or-nothing
+    /// `Result` semantics re-raise with [`ApplyOutcome::into_result`]; the
+    /// batch reports the partial per-operation instead. A whole-plan abort
+    /// (a stale precondition, or any git failure) is still a hard `Err` with
+    /// nothing written.
     #[instrument(skip(self, plan), fields(changes = plan.changes.len()), name = "vault_apply_changes")]
     pub async fn apply_changes(&self, plan: &ChangePlan) -> Result<ApplyOutcome> {
         for touched in plan.touched_paths() {
@@ -689,10 +709,7 @@ impl VaultManager {
             .remove(rel_path.clone())
             .with_precondition(rel_path, precondition);
 
-        let outcome = self.substrate.apply(&plan).await?;
-        self.sync_index(&outcome.changed).await;
-        self.fire_change_listener(outcome.changed);
-        Ok(())
+        self.apply_one(&plan).await
     }
 
     /// Move file within vault with audit trail, graph update, and dual
@@ -727,10 +744,7 @@ impl VaultManager {
             .with_precondition(rel_from, src_precondition)
             .with_precondition(rel_to, dest_precondition);
 
-        let outcome = self.substrate.apply(&plan).await?;
-        self.sync_index(&outcome.changed).await;
-        self.fire_change_listener(outcome.changed);
-        Ok(())
+        self.apply_one(&plan).await
     }
 
     /// Get backlinks for a file

--- a/crates/turbovault-vault/src/manager.rs
+++ b/crates/turbovault-vault/src/manager.rs
@@ -1361,6 +1361,110 @@ mod tests {
         );
     }
 
+    /// M5 S2 (`turbovault-qae.6.3`): a multi-change DIRECT plan is applied
+    /// best-effort — sequential, stop at the first failure, no rollback — so
+    /// the outcome must SAY so instead of claiming atomicity it does not
+    /// have. Change 0 lands, change 1 fails, change 2 is never attempted:
+    /// `atomic` false, `failed_at` Some(1), the typed error survives to the
+    /// manager boundary, and what landed is indexed (R7) rather than being
+    /// discarded along with the error.
+    ///
+    /// The same plan on a GIT vault is all-or-nothing: it aborts with
+    /// nothing written, and every GitSubstrate apply reports `atomic` true.
+    #[tokio::test]
+    async fn test_direct_partial_apply_reports_failed_at_and_indexes_what_landed() {
+        // Change 1 renames a file that does not exist: on direct the apply
+        // loop fails there (ENOENT) with change 0 already on disk; on git
+        // the rename source is missing from the base tree, so the whole plan
+        // aborts before any commit.
+        let partial_plan = || {
+            ChangePlan::new("partial apply")
+                .create("landed.md", "# Landed")
+                .with_change(Change::Rename {
+                    from: "ghost.md".to_string(),
+                    to: "moved.md".to_string(),
+                })
+                .create("never.md", "# Never")
+        };
+
+        // -------- direct: best-effort, partial state, honest report --------
+        let temp_dir = TempDir::new().unwrap();
+        let manager = VaultManager::new(create_test_config(temp_dir.path())).unwrap();
+
+        let outcome = manager.apply_changes(&partial_plan()).await.unwrap();
+
+        assert!(
+            !outcome.atomic,
+            "a multi-change direct plan is best-effort, not atomic"
+        );
+        assert_eq!(
+            outcome.failed_at,
+            Some(1),
+            "failed_at must name the change that stopped the loop"
+        );
+        assert!(
+            matches!(outcome.error, Some(Error::Io(_))),
+            "the loop failure's typed error kind must survive to the manager \
+             boundary, got {:?}",
+            outcome.error
+        );
+        assert_eq!(
+            outcome.changed,
+            vec![("landed.md".to_string(), true)],
+            "only the changes that actually landed are reported"
+        );
+        assert!(
+            temp_dir.path().join("landed.md").exists(),
+            "change 0 landed"
+        );
+        assert!(
+            !temp_dir.path().join("never.md").exists(),
+            "change 2 must not be attempted after change 1 failed"
+        );
+
+        // The partial is INDEXED, not just on disk: pre-M5-S2 the `?` in the
+        // apply loop skipped sync_index entirely, leaving landed.md invisible
+        // to the link graph, file cache and search index.
+        assert_eq!(
+            manager.get_stats().await.unwrap().total_files,
+            1,
+            "the change that landed must be in the link graph, not just on disk"
+        );
+
+        // -------- git: unchanged all-or-nothing, always atomic --------
+        let git_dir = TempDir::new().unwrap();
+        init_git_repo(git_dir.path());
+        let git_manager = VaultManager::new(create_git_test_config(git_dir.path())).unwrap();
+
+        let ok = git_manager
+            .apply_changes(
+                &ChangePlan::new("git multi")
+                    .create("a.md", "# A")
+                    .create("b.md", "# B"),
+            )
+            .await
+            .unwrap();
+        assert!(
+            ok.atomic,
+            "every GitSubstrate apply is one all-or-nothing commit"
+        );
+        assert_eq!(ok.failed_at, None);
+        assert!(ok.error.is_none());
+
+        let head_before = head_oid(git_dir.path());
+        assert!(
+            git_manager.apply_changes(&partial_plan()).await.is_err(),
+            "git must abort the whole plan, not apply it best-effort"
+        );
+        assert_eq!(
+            head_oid(git_dir.path()),
+            head_before,
+            "an aborted git plan lands no commit"
+        );
+        assert!(!git_dir.path().join("landed.md").exists());
+        assert!(!git_dir.path().join("never.md").exists());
+    }
+
     #[tokio::test]
     async fn test_write_file_creates_directories() {
         let temp_dir = TempDir::new().unwrap();

--- a/crates/turbovault-vault/src/substrate.rs
+++ b/crates/turbovault-vault/src/substrate.rs
@@ -29,21 +29,46 @@ use crate::edit::compute_hash;
 
 /// Outcome of applying one [`ChangePlan`] to a substrate (design §6.3) — the
 /// substrate-level analogue of `BatchResult`.
-#[derive(Debug, Clone, Default)]
+///
+/// NOT `Clone`: [`Self::error`] carries a typed [`Error`], which is not
+/// clonable (it wraps `io::Error`). Clone the individual fields instead.
+#[derive(Debug, Default)]
 pub struct ApplyOutcome {
-    /// `(vault-relative path, present-after-apply)` for every path the plan
-    /// touched — feeds the manager's link-graph + file-cache update (R7).
+    /// `(vault-relative path, present-after-apply)` for every path that
+    /// actually landed — feeds the manager's link-graph + file-cache update
+    /// (R7). On a partial direct apply this is the prefix of the plan that
+    /// ran before [`Self::failed_at`], NOT the whole plan.
     pub changed: Vec<(String, bool)>,
     /// git: the commit oid as hex. direct: `None`.
     pub commit: Option<String>,
-    /// `true` when every change in the plan landed atomically (git: always,
-    /// one commit; direct: single-change plans only — M3a's manager never
-    /// builds multi-change plans, so this is filled trivially here; true
-    /// best-effort semantics for direct batches land in M4/M5).
+    /// `true` when the plan was applied all-or-nothing: git always (one
+    /// commit), direct only for a single-change plan. A multi-change direct
+    /// plan is best-effort — sequential, no rollback — so it reports `false`
+    /// whether or not it happened to run to completion.
     pub atomic: bool,
-    /// Direct best-effort only: the change index that stopped a multi-change
-    /// plan. Always `None` in M3a.
+    /// The index into `plan.changes` of the change that stopped a
+    /// best-effort direct apply; `None` when every change landed. Never
+    /// `Some` on git, which aborts the whole plan instead.
     pub failed_at: Option<usize>,
+    /// The typed error that stopped the apply loop — carried out alongside
+    /// the accounting for what DID land, rather than discarded by a `?`.
+    /// `Some` exactly when [`Self::failed_at`] is `Some`; see
+    /// [`Self::into_result`] for the all-or-nothing callers that re-raise it.
+    pub error: Option<Error>,
+}
+
+impl ApplyOutcome {
+    /// Re-raise a best-effort apply's error, for callers that want
+    /// all-or-nothing `Result` semantics (every single-op mutator, and the
+    /// link-aware tool-layer writes). Callers run their post-apply index
+    /// sync over [`Self::changed`] FIRST, so whatever landed is still
+    /// indexed before the error surfaces.
+    pub fn into_result(self) -> Result<Self> {
+        match self.error {
+            Some(e) => Err(e),
+            None => Ok(self),
+        }
+    }
 }
 
 /// Dispatches a [`ChangePlan`] to whichever backend a vault is configured
@@ -177,19 +202,41 @@ impl DirectSubstrate {
             Self::check_precondition(path, precondition, before.as_deref())?;
         }
 
-        for change in &plan.changes {
-            match change {
-                Change::Upsert { path, content } => self.upsert(path, content).await?,
-                Change::Remove { path } => self.remove(path).await?,
-                Change::Rename { from, to } => self.rename(from, to).await?,
+        // Past the gate the apply is BEST-EFFORT (design R4): the changes run
+        // in order, the first failure stops the loop, and nothing already
+        // written is rolled back. A single-change plan is still all-or-
+        // nothing by construction — one change either lands or does not.
+        let atomic = plan.changes.len() <= 1;
+
+        for (idx, change) in plan.changes.iter().enumerate() {
+            let applied = match change {
+                Change::Upsert { path, content } => self.upsert(path, content).await,
+                Change::Remove { path } => self.remove(path).await,
+                Change::Rename { from, to } => self.rename(from, to).await,
+            };
+            if let Err(e) = applied {
+                // Report what landed instead of discarding it with `?` —
+                // the changes before `idx` are genuinely on disk and the
+                // manager still has to index them. The typed error rides
+                // along so an all-or-nothing caller can re-raise it
+                // (`ApplyOutcome::into_result`) and the batch can report it
+                // per-operation.
+                return Ok(ApplyOutcome {
+                    changed: changes_to_outcome(&plan.changes[..idx]),
+                    commit: None,
+                    atomic,
+                    failed_at: Some(idx),
+                    error: Some(e),
+                });
             }
         }
 
         Ok(ApplyOutcome {
             changed: changes_to_outcome(&plan.changes),
             commit: None,
-            atomic: true,
+            atomic,
             failed_at: None,
+            error: None,
         })
     }
 
@@ -483,8 +530,11 @@ impl GitSubstrate {
         Ok(ApplyOutcome {
             changed,
             commit: Some(changeset.commit.to_string()),
+            // One commit, all-or-nothing: git never leaves a partial, so it
+            // never reports one either.
             atomic: true,
             failed_at: None,
+            error: None,
         })
     }
 }

--- a/crates/turbovault/tests/test_tool_visibility_integration.rs
+++ b/crates/turbovault/tests/test_tool_visibility_integration.rs
@@ -80,13 +80,11 @@ async fn batch_response_reports_partial_failure_contract() {
         .expect("batch response should expose structured content");
     assert_eq!(response["success"], false);
     assert_eq!(response["data"]["success"], false);
-    // M4d: the direct batch routes through `manager.apply_changes`. Per-op
-    // `executed`/`failed_at` reporting is NOT provided this bite — direct
-    // best-effort reporting (failed_at / partial-rollback) is M5.2 — so the
-    // batch reports a plain `success: false` with the aborting error and no
-    // per-op index.
-    assert_eq!(response["data"]["executed"], 0);
-    assert!(response["data"]["failed_at"].is_null());
+    // TV-016: the direct batch is best-effort, and the wire reports the
+    // partial it leaves — the CreateNote landed, the DeleteNote of a missing
+    // path is the operation that stopped the batch.
+    assert_eq!(response["data"]["executed"], 1);
+    assert_eq!(response["data"]["failed_at"], 1);
     assert_eq!(response["meta"]["execution_mode"], "sequential_direct");
     assert!(
         response["warnings"][0]


### PR DESCRIPTION
On the `direct` backend, a partially-applied batch reports `executed: 0`, `failed_at: null`
and empty `changes`/`records` — while the earlier operation's file is genuinely on disk.
Found by dogfooding. Both the legacy executor and the git backend report this accurately, so
it is a regression rather than a long-standing gap.

## Root cause

`DirectSubstrate::apply` has two phases. The precondition gate checks every precondition
before applying anything and aborts the whole plan with nothing written — genuinely atomic.
The apply loop then used `?`, so a mid-loop failure **discarded the accounting for changes
already written** and returned `Err`. `BatchTools::batch_execute` funnels any `Err` into an
envelope hardcoded to `executed: 0`.

`ApplyOutcome.atomic` and `.failed_at` were likewise hardcoded to `true`/`None`. That was
accurate when only single-change plans existed; it became false once batches were routed
through the same path, and the fields were already carried to the wire for exactly this.

## What changes

- A **gate** failure still returns `Err` — nothing was written, the caller retries the whole plan.
- An **apply-loop** failure returns `Ok(ApplyOutcome)` carrying what landed, `failed_at`, and the
  error. `VaultManager` indexes the prefix that landed, so a partially-applied plan is no longer
  invisible to the link graph, file cache and search index.
- `batch_execute` translates that into per-operation reporting. Because the substrate counts
  *changes* and the wire reports *operations*, the plan builder now also returns per-op change
  spans — which is what lets `records[].affected_files` name backlink-rewritten linkers without
  a per-op branch.

## Wire / API notes

`ApplyOutcome` gains `error: Option<Error>` and consequently **loses `Clone`**, since `Error`
wraps `io::Error`. Anything calling `.clone()` on it breaks. `Arc<Error>` would restore it if
you would rather keep the derive — happy to switch.

## It corrects four assertions currently on `main`

#44 changed these from correct values to `executed: 0`, each with a comment deferring the real
values to a later phase:

- `test_tool_visibility_integration.rs::batch_response_reports_partial_failure_contract`
  (`executed == 1`, `failed_at == 1` → `0`/`null`)
- `test_async_error_paths.rs::test_batch_tools_partial_failure_rollback` (`2` → `0`)
- `test_batch_tools.rs::test_batch_execute_rollback_on_error` (`1` → `0`)
- `test_batch_tools.rs::test_batch_execute_atomic_guarantees` (`1` → `0`)

Each asserts a few lines later that the earlier file *does* exist, so `executed: 0` contradicted
the same test's own next assertion.

## On the test scenario

The partial is induced by an I/O failure (an upsert whose parent component is a regular file),
deliberately **not** by deleting an absent file — `wss-precondition-matrix.csv` specifies
delete-of-absent as `Ok`, so a test built on that would go red the moment the direct backend
honours it. The four tests above all still use delete-of-absent and will need the same treatment
when that cell lands; tracked separately.

## Overlap

Touches the same functions as #45 (caller metadata onto audit entries). Whichever lands first,
happy to rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
