### PR TITLE
feat(vault): choose the write backend when registering a vault

### DIFF
--- a/crates/turbovault-core/src/config.rs
+++ b/crates/turbovault-core/src/config.rs
@@ -31,6 +31,24 @@ pub enum WriteBackend {
     Git,
 }
 
+/// turbovault-kdq: parse the backend out of a runtime registration parameter
+/// (the `write_backend` MCP argument, the `--vault-write-backend` CLI flag).
+/// Accepts exactly the serde spellings, `legacy` alias included, so a config
+/// value and a wire value can never disagree.
+impl std::str::FromStr for WriteBackend {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "direct" | "legacy" => Ok(Self::Direct),
+            "git" => Ok(Self::Git),
+            other => Err(Error::config_error(format!(
+                "Unknown write_backend '{other}' (expected 'direct' or 'git')"
+            ))),
+        }
+    }
+}
+
 /// How the git substrate merges a fan-out's wip branch back into main
 /// (mirrors `turbovault_git::MergeStrategy` as a serializable config type so
 /// `turbovault-core` doesn't pick up a git2/libgit2 dependency). The consumer

--- a/crates/turbovault-tools/src/lib.rs
+++ b/crates/turbovault-tools/src/lib.rs
@@ -219,7 +219,7 @@ pub use turbovault_git::{
     CommitLocks, FanoutInfo, MergeStrategy as GitMergeStrategy, Oid, OrphanFanout, VaultRepo,
 };
 pub use validation_tools::{ValidationReportInfo, ValidationTools};
-pub use vault_lifecycle::VaultLifecycleTools;
+pub use vault_lifecycle::{VaultLifecycleTools, direct_over_git_repo_warning};
 pub use viewer::{ViewerTools, VisualizationResult};
 
 #[cfg(feature = "sql")]

--- a/crates/turbovault-tools/src/vault_lifecycle.rs
+++ b/crates/turbovault-tools/src/vault_lifecycle.rs
@@ -5,6 +5,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use turbovault_core::config::{VaultGitConfig, WriteBackend};
 use turbovault_core::prelude::*;
 
 /// Vault lifecycle operations
@@ -25,6 +26,11 @@ impl VaultLifecycleTools {
     /// - `name`: Unique vault identifier (no spaces)
     /// - `path`: Directory to create vault in (supports tilde expansion)
     /// - `template`: Optional template name ("default", "research", "team")
+    /// - `write_backend`: Which write path serves the vault. `Direct` is the
+    ///   pre-turbovault-kdq behaviour and stays the default for callers that
+    ///   don't choose.
+    /// - `git`: Per-vault git substrate settings, only meaningful with
+    ///   `WriteBackend::Git`. `None` = the substrate defaults.
     ///
     /// # Returns
     /// VaultInfo with the created vault details (includes fully resolved path)
@@ -38,6 +44,8 @@ impl VaultLifecycleTools {
         name: &str,
         path: &Path,
         template: Option<&str>,
+        write_backend: WriteBackend,
+        git: Option<VaultGitConfig>,
     ) -> Result<VaultInfo> {
         // Validation: name format
         if name.is_empty() {
@@ -112,7 +120,7 @@ impl VaultLifecycleTools {
         }
 
         // Create vault configuration (uses expanded path)
-        let config = VaultConfig::builder(name, &expanded_path).build()?;
+        let config = Self::build_config(name, &expanded_path, write_backend, git)?;
 
         // Register with multi-vault manager
         self.multi_manager.add_vault(config).await?;
@@ -126,10 +134,20 @@ impl VaultLifecycleTools {
     /// # Arguments
     /// - `name`: Unique vault identifier
     /// - `path`: Existing vault directory path (supports tilde expansion)
+    /// - `write_backend`: Which write path serves the vault (`Direct` unless
+    ///   the caller chooses git — turbovault-kdq).
+    /// - `git`: Per-vault git substrate settings, only meaningful with
+    ///   `WriteBackend::Git`.
     ///
     /// # Returns
     /// VaultInfo with the registered vault details
-    pub async fn add_vault_from_path(&self, name: &str, path: &Path) -> Result<VaultInfo> {
+    pub async fn add_vault_from_path(
+        &self,
+        name: &str,
+        path: &Path,
+        write_backend: WriteBackend,
+        git: Option<VaultGitConfig>,
+    ) -> Result<VaultInfo> {
         // Validation: name format
         if name.is_empty() || name.contains(' ') {
             return Err(Error::config_error(
@@ -165,13 +183,29 @@ impl VaultLifecycleTools {
         }
 
         // Create vault config
-        let config = VaultConfig::builder(name, &expanded_path).build()?;
+        let config = Self::build_config(name, &expanded_path, write_backend, git)?;
 
         // Register with multi-vault manager
         self.multi_manager.add_vault(config).await?;
 
         // Return vault info
         self.get_vault_info(name).await
+    }
+
+    /// turbovault-kdq: the single place a runtime-registered vault's config is
+    /// assembled, so `create_vault` and `add_vault_from_path` can never drift
+    /// on how the backend selection reaches the builder.
+    fn build_config(
+        name: &str,
+        path: &Path,
+        write_backend: WriteBackend,
+        git: Option<VaultGitConfig>,
+    ) -> Result<VaultConfig> {
+        let mut builder = VaultConfig::builder(name, path).write_backend(write_backend);
+        if let Some(git) = git {
+            builder = builder.git(git);
+        }
+        builder.build()
     }
 
     /// List all registered vaults

--- a/crates/turbovault-tools/src/vault_lifecycle.rs
+++ b/crates/turbovault-tools/src/vault_lifecycle.rs
@@ -54,8 +54,8 @@ impl VaultLifecycleTools {
     /// - `write_backend`: Which write path serves the vault. `Direct` is the
     ///   pre-turbovault-kdq behaviour and stays the default for callers that
     ///   don't choose.
-    /// - `git`: Per-vault git substrate settings, only meaningful with
-    ///   `WriteBackend::Git`. `None` = the substrate defaults.
+    /// - `backend_opts`: Settings for the selected backend. Only `Git` has any,
+    ///   so `None` = the substrate defaults; `Some` with `Direct` is an error.
     ///
     /// # Returns
     /// VaultInfo with the created vault details (includes fully resolved path)
@@ -64,13 +64,14 @@ impl VaultLifecycleTools {
     /// - Invalid name (empty, spaces)
     /// - Path I/O errors
     /// - Vault already registered
+    /// - `backend_opts` supplied for a backend that has none
     pub async fn create_vault(
         &self,
         name: &str,
         path: &Path,
         template: Option<&str>,
         write_backend: WriteBackend,
-        git: Option<VaultGitConfig>,
+        backend_opts: Option<VaultGitConfig>,
     ) -> Result<VaultInfo> {
         // Validation: name format
         if name.is_empty() {
@@ -111,6 +112,10 @@ impl VaultLifecycleTools {
         // Expand tilde and convert to absolute path
         let expanded_path = Self::expand_path(path)?;
 
+        // Build the config before touching the filesystem: a rejected backend
+        // selection must not leave a half-created vault directory behind.
+        let config = Self::build_config(name, &expanded_path, write_backend, backend_opts)?;
+
         // If path doesn't exist, create it
         if !expanded_path.exists() {
             tokio::fs::create_dir_all(&expanded_path)
@@ -144,9 +149,6 @@ impl VaultLifecycleTools {
             self.initialize_default_structure(&expanded_path).await?;
         }
 
-        // Create vault configuration (uses expanded path)
-        let config = Self::build_config(name, &expanded_path, write_backend, git)?;
-
         // Register with multi-vault manager
         self.multi_manager.add_vault(config).await?;
 
@@ -161,8 +163,8 @@ impl VaultLifecycleTools {
     /// - `path`: Existing vault directory path (supports tilde expansion)
     /// - `write_backend`: Which write path serves the vault (`Direct` unless
     ///   the caller chooses git — turbovault-kdq).
-    /// - `git`: Per-vault git substrate settings, only meaningful with
-    ///   `WriteBackend::Git`.
+    /// - `backend_opts`: Settings for the selected backend. Only `Git` has any;
+    ///   `Some` with `Direct` is an error.
     ///
     /// # Returns
     /// VaultInfo with the registered vault details
@@ -171,7 +173,7 @@ impl VaultLifecycleTools {
         name: &str,
         path: &Path,
         write_backend: WriteBackend,
-        git: Option<VaultGitConfig>,
+        backend_opts: Option<VaultGitConfig>,
     ) -> Result<VaultInfo> {
         // Validation: name format
         if name.is_empty() || name.contains(' ') {
@@ -208,7 +210,7 @@ impl VaultLifecycleTools {
         }
 
         // Create vault config
-        let config = Self::build_config(name, &expanded_path, write_backend, git)?;
+        let config = Self::build_config(name, &expanded_path, write_backend, backend_opts)?;
 
         // Register with multi-vault manager
         self.multi_manager.add_vault(config).await?;
@@ -218,17 +220,35 @@ impl VaultLifecycleTools {
     }
 
     /// turbovault-kdq: the single place a runtime-registered vault's config is
-    /// assembled, so `create_vault` and `add_vault_from_path` can never drift
-    /// on how the backend selection reaches the builder.
-    fn build_config(
+    /// assembled, so `create_vault`, `add_vault_from_path` and the `--vault`
+    /// CLI shorthand can never drift on how the backend selection reaches the
+    /// builder — or on what they do when the selection is contradictory.
+    ///
+    /// `backend_opts` are the *selected* backend's settings. This does not
+    /// touch [`VaultConfig`]'s own shape: the options still land in its `git`
+    /// field, and the YAML config format is unchanged. The generic name is a
+    /// wire-level one, because `write_backend` picks the backend and its
+    /// companion argument should not be named after one of the choices.
+    pub fn build_config(
         name: &str,
         path: &Path,
         write_backend: WriteBackend,
-        git: Option<VaultGitConfig>,
+        backend_opts: Option<VaultGitConfig>,
     ) -> Result<VaultConfig> {
+        // The direct backend has no options. Accepting the pair and dropping
+        // them would hand back a vault without the settings the caller asked
+        // for, with no signal at all — so refuse, and name both values so the
+        // caller can see which of the two to change.
+        if write_backend == WriteBackend::Direct && backend_opts.is_some() {
+            return Err(Error::config_error(
+                "backend_opts was supplied with write_backend=direct, which has no backend \
+                 options: pass write_backend=git to use them, or omit backend_opts"
+                    .to_string(),
+            ));
+        }
         let mut builder = VaultConfig::builder(name, path).write_backend(write_backend);
-        if let Some(git) = git {
-            builder = builder.git(git);
+        if let Some(backend_opts) = backend_opts {
+            builder = builder.git(backend_opts);
         }
         let config = builder.build()?;
         // turbovault-74p: this is the funnel both registration entry points

--- a/crates/turbovault-tools/src/vault_lifecycle.rs
+++ b/crates/turbovault-tools/src/vault_lifecycle.rs
@@ -7,6 +7,31 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use turbovault_core::config::{VaultGitConfig, WriteBackend};
 use turbovault_core::prelude::*;
+use turbovault_git::VaultRepo;
+
+/// turbovault-74p: the direct-over-git footgun signal.
+///
+/// Returns the warning text when `config` puts the `Direct` backend over a
+/// path that IS a usable git repository — every write then lands straight on
+/// the filesystem and never commits, so the working tree silently drifts from
+/// HEAD. Returns `None` otherwise.
+///
+/// A pure function returning the message rather than an in-place `log::warn!`
+/// on purpose: every registration site stays a one-liner, and the predicate is
+/// testable without a global logger fixture. It only *warns* — the
+/// registration still succeeds and nothing about the write path changes.
+pub fn direct_over_git_repo_warning(config: &VaultConfig) -> Option<String> {
+    if config.write_backend != WriteBackend::Direct || !VaultRepo::is_git_repo(&config.path) {
+        return None;
+    }
+    Some(format!(
+        "Vault '{}' at {} is a Git repository but is registered with write_backend=direct: \
+         its writes will not be committed and the working tree will drift from HEAD. \
+         Register it with write_backend=git to write through the Git substrate.",
+        config.name,
+        config.path.display()
+    ))
+}
 
 /// Vault lifecycle operations
 pub struct VaultLifecycleTools {
@@ -205,7 +230,13 @@ impl VaultLifecycleTools {
         if let Some(git) = git {
             builder = builder.git(git);
         }
-        builder.build()
+        let config = builder.build()?;
+        // turbovault-74p: this is the funnel both registration entry points
+        // pass through, so the footgun check belongs here rather than in each.
+        if let Some(warning) = direct_over_git_repo_warning(&config) {
+            log::warn!("{warning}");
+        }
+        Ok(config)
     }
 
     /// List all registered vaults

--- a/crates/turbovault-tools/tests/test_vault_lifecycle.rs
+++ b/crates/turbovault-tools/tests/test_vault_lifecycle.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use tempfile::TempDir;
+use turbovault_core::config::WriteBackend;
 use turbovault_core::{MultiVaultManager, ServerConfig};
 use turbovault_tools::VaultLifecycleTools;
 
@@ -30,7 +31,7 @@ async fn every_template_creates_and_registers_its_expected_structure() {
     for (template, directories) in templates {
         let path = root.path().join(template);
         let info = tools
-            .create_vault(template, &path, Some(template))
+            .create_vault(template, &path, Some(template), WriteBackend::Direct, None)
             .await
             .unwrap_or_else(|error| panic!("create {template} template: {error}"));
 
@@ -81,7 +82,7 @@ async fn default_creation_and_registered_directory_validation_report_real_state(
     let default_path = root.path().join("implicit-default");
 
     tools
-        .create_vault("implicit", &default_path, None)
+        .create_vault("implicit", &default_path, None, WriteBackend::Direct, None)
         .await
         .expect("create implicit default template");
     assert!(default_path.join("Areas").is_dir());
@@ -92,7 +93,7 @@ async fn default_creation_and_registered_directory_validation_report_real_state(
         .await
         .expect("plain directory");
     tools
-        .add_vault_from_path("plain", &plain_path)
+        .add_vault_from_path("plain", &plain_path, WriteBackend::Direct, None)
         .await
         .expect("register plain directory");
 
@@ -134,14 +135,25 @@ async fn lifecycle_rejects_invalid_names_templates_paths_and_duplicates() {
 
     for name in ["", "contains spaces", &"x".repeat(65)] {
         let path = root.path().join("invalid-name");
-        assert!(tools.create_vault(name, &path, None).await.is_err());
+        assert!(
+            tools
+                .create_vault(name, &path, None, WriteBackend::Direct, None)
+                .await
+                .is_err()
+        );
         assert!(!path.exists());
     }
 
     let invalid_template_path = root.path().join("invalid-template");
     assert!(
         tools
-            .create_vault("invalid-template", &invalid_template_path, Some("unknown"))
+            .create_vault(
+                "invalid-template",
+                &invalid_template_path,
+                Some("unknown"),
+                WriteBackend::Direct,
+                None,
+            )
             .await
             .is_err()
     );
@@ -149,7 +161,7 @@ async fn lifecycle_rejects_invalid_names_templates_paths_and_duplicates() {
 
     let missing_path = root.path().join("missing");
     let missing = tools
-        .add_vault_from_path("missing", &missing_path)
+        .add_vault_from_path("missing", &missing_path, WriteBackend::Direct, None)
         .await
         .expect_err("registration must not create a missing path");
     assert!(missing.to_string().contains("Use create_vault"));
@@ -159,10 +171,15 @@ async fn lifecycle_rejects_invalid_names_templates_paths_and_duplicates() {
     tokio::fs::write(&file_path, "not a directory")
         .await
         .expect("file fixture");
-    assert!(tools.create_vault("file", &file_path, None).await.is_err());
     assert!(
         tools
-            .add_vault_from_path("other-file", &file_path)
+            .create_vault("file", &file_path, None, WriteBackend::Direct, None)
+            .await
+            .is_err()
+    );
+    assert!(
+        tools
+            .add_vault_from_path("other-file", &file_path, WriteBackend::Direct, None)
             .await
             .is_err()
     );
@@ -172,18 +189,24 @@ async fn lifecycle_rejects_invalid_names_templates_paths_and_duplicates() {
         .await
         .expect("registered directory");
     tools
-        .add_vault_from_path("registered", &registered_path)
+        .add_vault_from_path("registered", &registered_path, WriteBackend::Direct, None)
         .await
         .expect("first registration");
     assert!(
         tools
-            .add_vault_from_path("registered", &registered_path)
+            .add_vault_from_path("registered", &registered_path, WriteBackend::Direct, None)
             .await
             .is_err()
     );
     assert!(
         tools
-            .create_vault("registered", &root.path().join("duplicate"), None)
+            .create_vault(
+                "registered",
+                &root.path().join("duplicate"),
+                None,
+                WriteBackend::Direct,
+                None,
+            )
             .await
             .is_err()
     );

--- a/crates/turbovault-tools/tests/test_vault_tilde_expansion.rs
+++ b/crates/turbovault-tools/tests/test_vault_tilde_expansion.rs
@@ -1,5 +1,6 @@
 //! Test tilde expansion in vault paths
 
+use turbovault_core::config::WriteBackend;
 use turbovault_core::prelude::*;
 use turbovault_tools::VaultLifecycleTools;
 
@@ -26,7 +27,7 @@ async fn test_add_vault_with_absolute_temp_path() {
 
     // Add existing vault
     let vault_info = lifecycle_tools
-        .add_vault_from_path("test_add", &test_dir)
+        .add_vault_from_path("test_add", &test_dir, WriteBackend::Direct, None)
         .await
         .unwrap();
 

--- a/crates/turbovault/src/cli.rs
+++ b/crates/turbovault/src/cli.rs
@@ -8,10 +8,9 @@ use clap::Parser;
 use std::path::PathBuf;
 use turbomcp::telemetry::TelemetryConfig;
 use turbomcp::{McpServerExt, ProtocolConfig, VisibilityLayer};
-use turbovault_core::VaultConfig;
 use turbovault_core::cache::VaultCache;
 use turbovault_core::config::{VaultGitConfig, WriteBackend};
-use turbovault_tools::{OutputFormat, direct_over_git_repo_warning};
+use turbovault_tools::{OutputFormat, VaultLifecycleTools, direct_over_git_repo_warning};
 
 /// TurboVault Server - AI-powered vault management
 #[derive(Parser, Debug)]
@@ -27,11 +26,11 @@ pub struct Args {
     #[arg(long, env = "TURBOVAULT_VAULT_WRITE_BACKEND")]
     vault_write_backend: Option<WriteBackend>,
 
-    /// Git substrate settings for the --vault shorthand, as JSON
-    /// (e.g. '{"branch":"main","require_commit_message":true}'). Only
-    /// meaningful with --vault-write-backend git.
-    #[arg(long, env = "TURBOVAULT_VAULT_GIT")]
-    vault_git: Option<String>,
+    /// Settings for the --vault shorthand's selected write backend, as JSON
+    /// (e.g. '{"branch":"main","require_commit_message":true}'). Only the git
+    /// backend has any, so this requires --vault-write-backend git.
+    #[arg(long, env = "TURBOVAULT_VAULT_BACKEND_OPTS")]
+    vault_backend_opts: Option<String>,
 
     /// Configuration profile to use (development, production, etc.)
     #[arg(short, long, default_value = "development", env = "TURBOVAULT_PROFILE")]
@@ -287,14 +286,14 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         // Expand tilde and environment variables in the path
         let vault_path = expand_vault_path(&vault_path)?;
         let write_backend = args.vault_write_backend.unwrap_or_default();
-        let git = args
-            .vault_git
+        let backend_opts = args
+            .vault_backend_opts
             .as_deref()
             .map(serde_json::from_str::<VaultGitConfig>)
             .transpose()
-            .map_err(|error| format!("Invalid --vault-git JSON: {error}"))?;
+            .map_err(|error| format!("Invalid --vault-backend-opts JSON: {error}"))?;
         log::info!("Adding vault from CLI argument: {:?}", vault_path);
-        register_default_vault(&server, &vault_path, write_backend, git).await?;
+        register_default_vault(&server, &vault_path, write_backend, backend_opts).await?;
     } else {
         log::info!("No vault path provided. Use add_vault MCP tool to register a vault.");
         log::info!("Available tools: add_vault, list_vaults, set_active_vault");
@@ -567,7 +566,7 @@ async fn register_default_vault(
     server: &ObsidianMcpServer,
     vault_path: &std::path::Path,
     write_backend: WriteBackend,
-    git: Option<VaultGitConfig>,
+    backend_opts: Option<VaultGitConfig>,
 ) -> Result<DefaultVaultRegistration, Box<dyn std::error::Error>> {
     if server.multi_vault().vault_exists("default").await {
         return match server.multi_vault().get_vault_config("default").await {
@@ -597,18 +596,13 @@ async fn register_default_vault(
         };
     }
 
-    let mut builder = VaultConfig::builder("default", vault_path).write_backend(write_backend);
-    if let Some(git) = git {
-        builder = builder.git(git);
-    }
-    let vault_config = builder
-        .build()
-        .map_err(|error| format!("Failed to create vault config: {error}"))?;
-    // turbovault-74p: --vault over a path that is already a git repo is the
-    // live footgun (it registers a shadow Direct vault beside the real one).
-    if let Some(warning) = direct_over_git_repo_warning(&vault_config) {
-        log::warn!("{warning}");
-    }
+    // Through the same funnel the MCP tools use, so the shorthand cannot drift
+    // on the backend selection — including the turbovault-74p footgun warning,
+    // which --vault over an existing git repo is the live case of, and the
+    // refusal of backend options for a backend that has none.
+    let vault_config =
+        VaultLifecycleTools::build_config("default", vault_path, write_backend, backend_opts)
+            .map_err(|error| format!("Failed to create vault config: {error}"))?;
     server
         .multi_vault()
         .add_vault(vault_config)

--- a/crates/turbovault/src/cli.rs
+++ b/crates/turbovault/src/cli.rs
@@ -10,6 +10,7 @@ use turbomcp::telemetry::TelemetryConfig;
 use turbomcp::{McpServerExt, ProtocolConfig, VisibilityLayer};
 use turbovault_core::VaultConfig;
 use turbovault_core::cache::VaultCache;
+use turbovault_core::config::{VaultGitConfig, WriteBackend};
 use turbovault_tools::OutputFormat;
 
 /// TurboVault Server - AI-powered vault management
@@ -19,6 +20,18 @@ pub struct Args {
     /// Path to the Obsidian vault directory
     #[arg(short, long, env = "OBSIDIAN_VAULT_PATH")]
     vault: Option<PathBuf>,
+
+    /// Write backend for the --vault shorthand: `direct` (default) or `git`
+    /// (turbovault-kdq). Vaults registered from --config carry their own
+    /// `write_backend` key and ignore this.
+    #[arg(long, env = "TURBOVAULT_VAULT_WRITE_BACKEND")]
+    vault_write_backend: Option<WriteBackend>,
+
+    /// Git substrate settings for the --vault shorthand, as JSON
+    /// (e.g. '{"branch":"main","require_commit_message":true}'). Only
+    /// meaningful with --vault-write-backend git.
+    #[arg(long, env = "TURBOVAULT_VAULT_GIT")]
+    vault_git: Option<String>,
 
     /// Configuration profile to use (development, production, etc.)
     #[arg(short, long, default_value = "development", env = "TURBOVAULT_PROFILE")]
@@ -268,8 +281,15 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(vault_path) = args.vault {
         // Expand tilde and environment variables in the path
         let vault_path = expand_vault_path(&vault_path)?;
+        let write_backend = args.vault_write_backend.unwrap_or_default();
+        let git = args
+            .vault_git
+            .as_deref()
+            .map(serde_json::from_str::<VaultGitConfig>)
+            .transpose()
+            .map_err(|error| format!("Invalid --vault-git JSON: {error}"))?;
         log::info!("Adding vault from CLI argument: {:?}", vault_path);
-        register_default_vault(&server, &vault_path).await?;
+        register_default_vault(&server, &vault_path, write_backend, git).await?;
     } else {
         log::info!("No vault path provided. Use add_vault MCP tool to register a vault.");
         log::info!("Available tools: add_vault, list_vaults, set_active_vault");
@@ -536,6 +556,8 @@ enum DefaultVaultRegistration {
 async fn register_default_vault(
     server: &ObsidianMcpServer,
     vault_path: &std::path::Path,
+    write_backend: WriteBackend,
+    git: Option<VaultGitConfig>,
 ) -> Result<DefaultVaultRegistration, Box<dyn std::error::Error>> {
     if server.multi_vault().vault_exists("default").await {
         return match server.multi_vault().get_vault_config("default").await {
@@ -565,7 +587,11 @@ async fn register_default_vault(
         };
     }
 
-    let vault_config = VaultConfig::builder("default", vault_path)
+    let mut builder = VaultConfig::builder("default", vault_path).write_backend(write_backend);
+    if let Some(git) = git {
+        builder = builder.git(git);
+    }
+    let vault_config = builder
         .build()
         .map_err(|error| format!("Failed to create vault config: {error}"))?;
     server
@@ -755,15 +781,19 @@ mod tests {
         let server = ObsidianMcpServer::new().unwrap();
 
         assert_eq!(
-            register_default_vault(&server, first.path()).await.unwrap(),
+            register_default_vault(&server, first.path(), WriteBackend::Direct, None)
+                .await
+                .unwrap(),
             DefaultVaultRegistration::Added
         );
         assert_eq!(
-            register_default_vault(&server, first.path()).await.unwrap(),
+            register_default_vault(&server, first.path(), WriteBackend::Direct, None)
+                .await
+                .unwrap(),
             DefaultVaultRegistration::AlreadyRegistered
         );
         assert_eq!(
-            register_default_vault(&server, second.path())
+            register_default_vault(&server, second.path(), WriteBackend::Direct, None)
                 .await
                 .unwrap(),
             DefaultVaultRegistration::KeptCached {

--- a/crates/turbovault/src/cli.rs
+++ b/crates/turbovault/src/cli.rs
@@ -11,7 +11,7 @@ use turbomcp::{McpServerExt, ProtocolConfig, VisibilityLayer};
 use turbovault_core::VaultConfig;
 use turbovault_core::cache::VaultCache;
 use turbovault_core::config::{VaultGitConfig, WriteBackend};
-use turbovault_tools::OutputFormat;
+use turbovault_tools::{OutputFormat, direct_over_git_repo_warning};
 
 /// TurboVault Server - AI-powered vault management
 #[derive(Parser, Debug)]
@@ -212,6 +212,11 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
                 // Add each cached vault to the multi-vault manager
                 for vault_config in cached_vaults {
+                    // turbovault-74p: a cached Direct vault over a git repo is
+                    // the same bypass, restored — warn on every recovery too.
+                    if let Some(warning) = direct_over_git_repo_warning(&vault_config) {
+                        log::warn!("{warning}");
+                    }
                     match server.multi_vault().add_vault(vault_config.clone()).await {
                         Ok(_) => {
                             log::info!(
@@ -459,6 +464,11 @@ async fn register_configured_vaults(
             )
             .into());
         }
+        // turbovault-74p: the inverse mismatch — direct over a git repo — is a
+        // silent bypass rather than an error, so it warns and registers.
+        if let Some(warning) = direct_over_git_repo_warning(&vault) {
+            log::warn!("{warning}");
+        }
         log::info!(
             "Registering configured vault '{}' ({:?}) with write_backend={:?}",
             vault.name,
@@ -594,6 +604,11 @@ async fn register_default_vault(
     let vault_config = builder
         .build()
         .map_err(|error| format!("Failed to create vault config: {error}"))?;
+    // turbovault-74p: --vault over a path that is already a git repo is the
+    // live footgun (it registers a shadow Direct vault beside the real one).
+    if let Some(warning) = direct_over_git_repo_warning(&vault_config) {
+        log::warn!("{warning}");
+    }
     server
         .multi_vault()
         .add_vault(vault_config)

--- a/crates/turbovault/src/cli.rs
+++ b/crates/turbovault/src/cli.rs
@@ -659,6 +659,24 @@ mod tests {
         assert!(args.require_read_only_tools);
     }
 
+    /// The --vault shorthand's backend selection is a wire-visible name with no
+    /// golden catalog behind it, so pin the spelling here.
+    #[test]
+    fn parses_the_vault_backend_selection_flags() {
+        let args = args(&[
+            "--vault-write-backend",
+            "git",
+            "--vault-backend-opts",
+            r#"{"branch":"main"}"#,
+        ]);
+
+        assert_eq!(args.vault_write_backend, Some(WriteBackend::Git));
+        assert_eq!(
+            args.vault_backend_opts.as_deref(),
+            Some(r#"{"branch":"main"}"#)
+        );
+    }
+
     #[test]
     fn stdio_always_resolves_to_json_output() {
         let args = args(&[

--- a/crates/turbovault/src/tools/providers/tool_catalog.json
+++ b/crates/turbovault/src/tools/providers/tool_catalog.json
@@ -910,6 +910,23 @@
             "string",
             "null"
           ]
+        },
+        "write_backend": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "title": "Nullable_string",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "git": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "title": "Nullable_Map_of_AnyValue",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
         }
       },
       "required": [
@@ -941,6 +958,23 @@
           "$schema": "https://json-schema.org/draft/2020-12/schema",
           "title": "string",
           "type": "string"
+        },
+        "write_backend": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "title": "Nullable_string",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "git": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "title": "Nullable_Map_of_AnyValue",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
         }
       },
       "required": [

--- a/crates/turbovault/src/tools/providers/tool_catalog.json
+++ b/crates/turbovault/src/tools/providers/tool_catalog.json
@@ -889,7 +889,7 @@
   },
   {
     "name": "create_vault",
-    "description": "Create and register a new Obsidian vault at the specified filesystem path with an optional template",
+    "description": "Create and register a new Obsidian vault at the specified filesystem path with an optional template. Optional write_backend selects the write path: 'direct' (default) or 'git'. Optional backend_opts holds that backend's settings; 'direct' has none, 'git' accepts branch, author {name, email}, merge_strategy ('merge-commit' or 'fast-forward'), include_ignored, require_commit_message. Passing backend_opts with write_backend 'direct' is an error",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -919,7 +919,7 @@
             "null"
           ]
         },
-        "git": {
+        "backend_opts": {
           "$schema": "https://json-schema.org/draft/2020-12/schema",
           "title": "Nullable_Map_of_AnyValue",
           "type": [
@@ -945,7 +945,7 @@
   },
   {
     "name": "add_vault",
-    "description": "Register an existing Obsidian vault with the MCP server and auto-initialize",
+    "description": "Register an existing Obsidian vault with the MCP server and auto-initialize. Optional write_backend selects the write path: 'direct' (default) or 'git'. Optional backend_opts holds that backend's settings; 'direct' has none, 'git' accepts branch, author {name, email}, merge_strategy ('merge-commit' or 'fast-forward'), include_ignored, require_commit_message. Passing backend_opts with write_backend 'direct' is an error",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -967,7 +967,7 @@
             "null"
           ]
         },
-        "git": {
+        "backend_opts": {
           "$schema": "https://json-schema.org/draft/2020-12/schema",
           "title": "Nullable_Map_of_AnyValue",
           "type": [

--- a/crates/turbovault/src/tools/providers/vault.rs
+++ b/crates/turbovault/src/tools/providers/vault.rs
@@ -7,26 +7,30 @@ use turbovault_core::config::{VaultGitConfig, WriteBackend};
 
 use super::super::*;
 
-/// turbovault-kdq: resolve the optional `write_backend` + `git` registration
-/// arguments into the typed pair the builder wants. Omitting `write_backend`
-/// yields `Direct` — the pre-kdq behaviour, unchanged.
+/// turbovault-kdq: resolve the optional `write_backend` + `backend_opts`
+/// registration arguments into the typed pair the builder wants. Omitting
+/// `write_backend` yields `Direct` — the pre-kdq behaviour, unchanged.
+///
+/// Whether the pair is *coherent* is not decided here: `VaultLifecycleTools`
+/// is the funnel every registration passes through (the CLI shorthand
+/// included), so the direct-plus-options refusal lives there.
 fn parse_backend_selection(
     write_backend: Option<String>,
-    git: Option<HashMap<String, serde_json::Value>>,
+    backend_opts: Option<HashMap<String, serde_json::Value>>,
 ) -> McpResult<(WriteBackend, Option<VaultGitConfig>)> {
     let backend = match write_backend {
         Some(raw) => raw.parse::<WriteBackend>().map_err(to_mcp_error)?,
         None => WriteBackend::default(),
     };
-    let git = git
+    let backend_opts = backend_opts
         .map(|settings| {
             serde_json::from_value::<VaultGitConfig>(serde_json::Value::Object(
                 settings.into_iter().collect(),
             ))
         })
         .transpose()
-        .map_err(|error| McpError::invalid_request(format!("Invalid git settings: {error}")))?;
-    Ok((backend, git))
+        .map_err(|error| McpError::invalid_request(format!("Invalid backend_opts: {error}")))?;
+    Ok((backend, backend_opts))
 }
 
 #[derive(Clone)]
@@ -51,8 +55,11 @@ impl VaultProvider {
     // ==================== Vault Lifecycle (Multi-Vault Management) ====================
 
     /// Create a new Obsidian vault
+    // The `backend_opts` schema is a free-form object with no field names, so
+    // this description is the only place a calling agent can discover the keys
+    // it accepts. Spell them out here or they are undiscoverable.
     #[tool(
-        description = "Create and register a new Obsidian vault at the specified filesystem path with an optional template",
+        description = "Create and register a new Obsidian vault at the specified filesystem path with an optional template. Optional write_backend selects the write path: 'direct' (default) or 'git'. Optional backend_opts holds that backend's settings; 'direct' has none, 'git' accepts branch, author {name, email}, merge_strategy ('merge-commit' or 'fast-forward'), include_ignored, require_commit_message. Passing backend_opts with write_backend 'direct' is an error",
         usage = "Use for programmatic vault creation. The new vault is registered immediately; use set_active_vault if another vault is currently active",
         performance = "Fast (<50ms), creates .obsidian directory and config files",
         related = ["set_active_vault", "list_vaults"],
@@ -65,9 +72,9 @@ impl VaultProvider {
         path: String,
         template: Option<String>,
         write_backend: Option<String>,
-        git: Option<HashMap<String, serde_json::Value>>,
+        backend_opts: Option<HashMap<String, serde_json::Value>>,
     ) -> McpResult<serde_json::Value> {
-        let (write_backend, git) = parse_backend_selection(write_backend, git)?;
+        let (write_backend, backend_opts) = parse_backend_selection(write_backend, backend_opts)?;
         let tools = VaultLifecycleTools::new(self.multi_vault_mgr.clone());
         let vault_info = tools
             .create_vault(
@@ -75,7 +82,7 @@ impl VaultProvider {
                 Path::new(&path),
                 template.as_deref(),
                 write_backend,
-                git,
+                backend_opts,
             )
             .await
             .map_err(to_mcp_error)?;
@@ -93,7 +100,7 @@ impl VaultProvider {
 
     /// Add an existing vault (automatically initializes it for better DX)
     #[tool(
-        description = "Register an existing Obsidian vault with the MCP server and auto-initialize",
+        description = "Register an existing Obsidian vault with the MCP server and auto-initialize. Optional write_backend selects the write path: 'direct' (default) or 'git'. Optional backend_opts holds that backend's settings; 'direct' has none, 'git' accepts branch, author {name, email}, merge_strategy ('merge-commit' or 'fast-forward'), include_ignored, require_commit_message. Passing backend_opts with write_backend 'direct' is an error",
         usage = "Use as first step when working with existing vaults. Idempotent and safe to call multiple times",
         performance = "Depends on vault size: 100ms for small vaults, 1-5s for large (1000+ files) due to initialization",
         related = ["list_vaults", "set_active_vault", "get_vault_context"],
@@ -105,12 +112,12 @@ impl VaultProvider {
         name: String,
         path: String,
         write_backend: Option<String>,
-        git: Option<HashMap<String, serde_json::Value>>,
+        backend_opts: Option<HashMap<String, serde_json::Value>>,
     ) -> McpResult<serde_json::Value> {
-        let (write_backend, git) = parse_backend_selection(write_backend, git)?;
+        let (write_backend, backend_opts) = parse_backend_selection(write_backend, backend_opts)?;
         let tools = VaultLifecycleTools::new(self.multi_vault_mgr.clone());
         let vault_info = tools
-            .add_vault_from_path(&name, Path::new(&path), write_backend, git)
+            .add_vault_from_path(&name, Path::new(&path), write_backend, backend_opts)
             .await
             .map_err(to_mcp_error)?;
 

--- a/crates/turbovault/src/tools/providers/vault.rs
+++ b/crates/turbovault/src/tools/providers/vault.rs
@@ -1,8 +1,33 @@
 //! VaultProvider MCP capabilities.
 
+use std::collections::HashMap;
 use std::ops::Deref;
 
+use turbovault_core::config::{VaultGitConfig, WriteBackend};
+
 use super::super::*;
+
+/// turbovault-kdq: resolve the optional `write_backend` + `git` registration
+/// arguments into the typed pair the builder wants. Omitting `write_backend`
+/// yields `Direct` — the pre-kdq behaviour, unchanged.
+fn parse_backend_selection(
+    write_backend: Option<String>,
+    git: Option<HashMap<String, serde_json::Value>>,
+) -> McpResult<(WriteBackend, Option<VaultGitConfig>)> {
+    let backend = match write_backend {
+        Some(raw) => raw.parse::<WriteBackend>().map_err(to_mcp_error)?,
+        None => WriteBackend::default(),
+    };
+    let git = git
+        .map(|settings| {
+            serde_json::from_value::<VaultGitConfig>(serde_json::Value::Object(
+                settings.into_iter().collect(),
+            ))
+        })
+        .transpose()
+        .map_err(|error| McpError::invalid_request(format!("Invalid git settings: {error}")))?;
+    Ok((backend, git))
+}
 
 #[derive(Clone)]
 pub(super) struct VaultProvider(CoreToolHandler);
@@ -39,10 +64,19 @@ impl VaultProvider {
         name: String,
         path: String,
         template: Option<String>,
+        write_backend: Option<String>,
+        git: Option<HashMap<String, serde_json::Value>>,
     ) -> McpResult<serde_json::Value> {
+        let (write_backend, git) = parse_backend_selection(write_backend, git)?;
         let tools = VaultLifecycleTools::new(self.multi_vault_mgr.clone());
         let vault_info = tools
-            .create_vault(&name, Path::new(&path), template.as_deref())
+            .create_vault(
+                &name,
+                Path::new(&path),
+                template.as_deref(),
+                write_backend,
+                git,
+            )
             .await
             .map_err(to_mcp_error)?;
 
@@ -66,10 +100,17 @@ impl VaultProvider {
         examples = ["Add personal vault", "Register work vault", "Connect to shared knowledge base"],
         tags = ["write", "admin"],
     )]
-    async fn add_vault(&self, name: String, path: String) -> McpResult<serde_json::Value> {
+    async fn add_vault(
+        &self,
+        name: String,
+        path: String,
+        write_backend: Option<String>,
+        git: Option<HashMap<String, serde_json::Value>>,
+    ) -> McpResult<serde_json::Value> {
+        let (write_backend, git) = parse_backend_selection(write_backend, git)?;
         let tools = VaultLifecycleTools::new(self.multi_vault_mgr.clone());
         let vault_info = tools
-            .add_vault_from_path(&name, Path::new(&path))
+            .add_vault_from_path(&name, Path::new(&path), write_backend, git)
             .await
             .map_err(to_mcp_error)?;
 

--- a/crates/turbovault/tests/test_mcp_e2e_git_substrate.rs
+++ b/crates/turbovault/tests/test_mcp_e2e_git_substrate.rs
@@ -81,9 +81,11 @@ async fn setup_git_vault() -> (TempDir, &'static str, ObsidianMcpServer) {
     repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
         .unwrap();
 
-    // Registered directly through the multi-vault manager (not the
-    // `add_vault` MCP tool, which only exposes name+path = Direct;
-    // turbovault-xj8) so this suite can select `write_backend: git`.
+    // Registered directly through the multi-vault manager rather than the
+    // `add_vault` MCP tool. Since turbovault-kdq that tool *can* select
+    // `write_backend: git` (see test_vault_registration_backend.rs); this
+    // suite keeps the direct route so its subject stays the substrate, not
+    // the registration surface.
     let vault_config = VaultConfig::builder("e2e", tmp.path())
         .write_backend(WriteBackend::Git)
         .git(VaultGitConfig::default())

--- a/crates/turbovault/tests/test_vault_registration_backend.rs
+++ b/crates/turbovault/tests/test_vault_registration_backend.rs
@@ -43,6 +43,21 @@ async fn call(
         .unwrap_or_else(|| panic!("tool {name:?} returned no structured content"))
 }
 
+/// Call a tool expecting failure, returning the message the caller would see.
+async fn call_err(server: &ObsidianMcpServer, name: &str, arguments: serde_json::Value) -> String {
+    match server
+        .call_tool(name, arguments, &RequestContext::new())
+        .await
+    {
+        Err(error) => error.to_string(),
+        Ok(result) if result.is_error() => result
+            .first_text()
+            .unwrap_or("tool returned an error without text")
+            .to_string(),
+        Ok(_) => panic!("tool {name:?} unexpectedly succeeded"),
+    }
+}
+
 /// A git repo with HEAD born — the substrate's baseline requirement.
 fn init_repo(path: &std::path::Path) {
     let mut opts = git2::RepositoryInitOptions::new();
@@ -122,6 +137,76 @@ async fn add_vault_selects_the_git_backend_and_omitting_it_stays_direct() {
             .unwrap()
             .write_backend,
         WriteBackend::Direct
+    );
+}
+
+/// The options argument is named after the *slot* (`backend_opts`), not after
+/// one backend, and it has to reach the substrate config rather than merely
+/// appear in the schema — otherwise the rename is cosmetic.
+#[tokio::test]
+#[serial_test::serial]
+async fn backend_opts_reaches_the_git_substrate_config() {
+    let repo = TempDir::new().unwrap();
+    init_repo(repo.path());
+    let server = ObsidianMcpServer::new().unwrap();
+
+    call(
+        &server,
+        "add_vault",
+        serde_json::json!({
+            "name": "optsvault",
+            "path": repo.path(),
+            "write_backend": "git",
+            "backend_opts": { "branch": "main", "require_commit_message": true },
+        }),
+    )
+    .await;
+
+    let git = server
+        .multi_vault()
+        .get_vault_config("optsvault")
+        .await
+        .unwrap()
+        .git
+        .expect("backend_opts must reach the vault's git substrate config");
+    assert_eq!(git.branch.as_deref(), Some("main"));
+    assert!(git.require_commit_message);
+}
+
+/// `backend_opts` carries the *selected* backend's settings, and Direct has
+/// none. Accepting the pair and dropping the options would be a silent wrong
+/// answer — the caller asked for substrate settings and got a vault with none,
+/// with nothing to notice it by. The refusal must name both values so the
+/// caller knows which of the two to change.
+#[tokio::test]
+#[serial_test::serial]
+async fn backend_opts_with_the_direct_backend_is_refused_naming_both_values() {
+    let plain = TempDir::new().unwrap();
+    let server = ObsidianMcpServer::new().unwrap();
+
+    let message = call_err(
+        &server,
+        "add_vault",
+        serde_json::json!({
+            "name": "mismatched",
+            "path": plain.path(),
+            "write_backend": "direct",
+            "backend_opts": { "require_commit_message": true },
+        }),
+    )
+    .await;
+
+    assert!(
+        message.contains("backend_opts"),
+        "the refusal must name the ignored argument: {message:?}"
+    );
+    assert!(
+        message.contains("direct"),
+        "the refusal must name the backend that has no options: {message:?}"
+    );
+    assert!(
+        !server.multi_vault().vault_exists("mismatched").await,
+        "a refused registration must not leave a vault behind"
     );
 }
 

--- a/crates/turbovault/tests/test_vault_registration_backend.rs
+++ b/crates/turbovault/tests/test_vault_registration_backend.rs
@@ -11,12 +11,15 @@
 //!
 //! Back-compat is half of the contract: omitting the parameter MUST still
 //! yield a `Direct` vault, which is why both directions live in one test.
+//!
+//! turbovault-74p rides along here: it is the same registration surface seen
+//! from the other side — what happens when the caller does *not* choose.
 
 use tempfile::TempDir;
 use turbomcp::{McpHandler, RequestContext};
 use turbovault::ObsidianMcpServer;
-use turbovault_core::config::WriteBackend;
-use turbovault_tools::VaultRepo;
+use turbovault_core::config::{VaultConfig, WriteBackend};
+use turbovault_tools::{VaultRepo, direct_over_git_repo_warning};
 
 /// Call a tool through the real handler dispatch, panicking loudly on error.
 async fn call(
@@ -119,5 +122,41 @@ async fn add_vault_selects_the_git_backend_and_omitting_it_stays_direct() {
             .unwrap()
             .write_backend,
         WriteBackend::Direct
+    );
+}
+
+/// turbovault-74p: a Direct vault over a git repo is a silent git bypass —
+/// every write lands on the filesystem and never commits, so the working tree
+/// drifts from HEAD with nothing to notice it by. Registration must say so.
+///
+/// The signal is tested through the pure warning function rather than by
+/// capturing the log line: same predicate, no global logger fixture.
+#[test]
+fn registering_a_git_repo_as_direct_warns_while_a_plain_path_stays_quiet() {
+    let repo = TempDir::new().unwrap();
+    init_repo(repo.path());
+    let shadow = VaultConfig::builder("shadow", repo.path()).build().unwrap();
+    assert_eq!(shadow.write_backend, WriteBackend::Direct);
+
+    let warning = direct_over_git_repo_warning(&shadow)
+        .expect("a Direct vault over a git repository must warn");
+    let lowercased = warning.to_lowercase();
+    assert!(
+        lowercased.contains("not be committed"),
+        "the warning must state that writes will not be committed: {warning:?}"
+    );
+    assert!(
+        warning.contains("write_backend"),
+        "the warning must name the parameter that selects the git backend: {warning:?}"
+    );
+
+    // A Direct vault over a plain directory is the ordinary case: no signal.
+    let plain = TempDir::new().unwrap();
+    let ordinary = VaultConfig::builder("ordinary", plain.path())
+        .build()
+        .unwrap();
+    assert!(
+        direct_over_git_repo_warning(&ordinary).is_none(),
+        "a non-git path must not warn"
     );
 }

--- a/crates/turbovault/tests/test_vault_registration_backend.rs
+++ b/crates/turbovault/tests/test_vault_registration_backend.rs
@@ -1,0 +1,123 @@
+//! turbovault-kdq: runtime vault registration can select the write backend.
+//!
+//! Before this, `add_vault` / `create_vault` / `--vault` only ever produced
+//! `Direct` vaults — the only route to a git-backed vault was a startup
+//! `--config` yaml or the non-wire-exposed SDK. These tests pin the wire
+//! contract of the new parameter from the outside: they drive the real
+//! `#[tool]` handler through `ObsidianMcpServer::call_tool` (the same dispatch
+//! turbomcp routes a JSON-RPC request to) and assert the *effect* — a vault
+//! registered with `write_backend: "git"` commits its writes — rather than
+//! just the config field.
+//!
+//! Back-compat is half of the contract: omitting the parameter MUST still
+//! yield a `Direct` vault, which is why both directions live in one test.
+
+use tempfile::TempDir;
+use turbomcp::{McpHandler, RequestContext};
+use turbovault::ObsidianMcpServer;
+use turbovault_core::config::WriteBackend;
+use turbovault_tools::VaultRepo;
+
+/// Call a tool through the real handler dispatch, panicking loudly on error.
+async fn call(
+    server: &ObsidianMcpServer,
+    name: &str,
+    arguments: serde_json::Value,
+) -> serde_json::Value {
+    let result = server
+        .call_tool(name, arguments, &RequestContext::new())
+        .await
+        .unwrap_or_else(|error| panic!("tool {name:?} failed: {error}"));
+    assert!(
+        !result.is_error(),
+        "tool {name:?} returned an error: {}",
+        result
+            .first_text()
+            .unwrap_or("tool returned an error without text")
+    );
+    result
+        .structured_content
+        .unwrap_or_else(|| panic!("tool {name:?} returned no structured content"))
+}
+
+/// A git repo with HEAD born — the substrate's baseline requirement.
+fn init_repo(path: &std::path::Path) {
+    let mut opts = git2::RepositoryInitOptions::new();
+    opts.initial_head("main");
+    let repo = git2::Repository::init_opts(path, &opts).unwrap();
+    let tree_oid = {
+        let mut idx = repo.index().unwrap();
+        idx.write_tree().unwrap()
+    };
+    let tree = repo.find_tree(tree_oid).unwrap();
+    let sig = git2::Signature::now("Init", "init@example").unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+        .unwrap();
+}
+
+fn head_oid(path: &std::path::Path) -> Option<git2::Oid> {
+    VaultRepo::open(path).ok().and_then(|r| r.head_oid())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn add_vault_selects_the_git_backend_and_omitting_it_stays_direct() {
+    let repo = TempDir::new().unwrap();
+    init_repo(repo.path());
+    let server = ObsidianMcpServer::new().unwrap();
+
+    // Selected over the wire: the vault is registered on the git substrate…
+    call(
+        &server,
+        "add_vault",
+        serde_json::json!({
+            "name": "gitvault",
+            "path": repo.path(),
+            "write_backend": "git",
+        }),
+    )
+    .await;
+    let config = server
+        .multi_vault()
+        .get_vault_config("gitvault")
+        .await
+        .unwrap();
+    assert_eq!(config.write_backend, WriteBackend::Git);
+
+    // …and the manager `add_vault` publishes actually commits its writes.
+    server
+        .multi_vault()
+        .set_active_vault("gitvault")
+        .await
+        .unwrap();
+    let head_before = head_oid(repo.path()).unwrap();
+    call(
+        &server,
+        "write_note",
+        serde_json::json!({ "path": "note.md", "content": "# Note\n" }),
+    )
+    .await;
+    assert_ne!(
+        head_oid(repo.path()).unwrap(),
+        head_before,
+        "a git-backend write must land a commit"
+    );
+
+    // Back-compat: the parameter omitted is exactly the pre-kdq behaviour.
+    let plain = TempDir::new().unwrap();
+    call(
+        &server,
+        "add_vault",
+        serde_json::json!({ "name": "plainvault", "path": plain.path() }),
+    )
+    .await;
+    assert_eq!(
+        server
+            .multi_vault()
+            .get_vault_config("plainvault")
+            .await
+            .unwrap()
+            .write_backend,
+        WriteBackend::Direct
+    );
+}


### PR DESCRIPTION
`add_vault`, `create_vault` and the `--vault` CLI shorthand all build a `VaultConfig` without
setting `write_backend`, and the builder defaults to `Direct`. So **every runtime-registered vault
is a direct vault** — over MCP an agent cannot create or attach a git-backed one at all. The only
routes today are a startup `--config` file or the SDK, neither of which is wire-exposed.

## What changes

An optional `write_backend` plus a `backend_opts` object on both MCP tools and the CLI shorthand,
threaded into the builder. **Omitting them reproduces today's behaviour exactly**, and the YAML
config format is untouched.

On naming: the options argument is `backend_opts`, not `git`, because `write_backend` selects the
backend and its companion argument should not be named after one particular backend — if `direct`
ever gains settings there is already somewhere to put them. The config file keeps its `git:` key;
that wire/config asymmetry is deliberate rather than an oversight, and the alternative (moving
either backend's options in the YAML) would break existing configs for cosmetics.

Passing `backend_opts` together with the direct backend is an **error naming both values**, not a
silently dropped parameter.

## Also: the inverse footgun

Registering a path that *is* a git repository as a `Direct` vault means every write lands on the
filesystem and never commits — the working tree drifts from HEAD with no signal. This adds a
warning at registration.

Warning only. Refusing, or auto-detecting and switching the backend, are both wire-visible
behaviour changes that look like yours to make; a warning adds the signal without changing
anything that currently works.

## Note

`VaultLifecycleTools::build_config` became `pub` so the CLI shorthand and the MCP tools share one
guard rather than keeping two copies of the builder-plus-warning block. Additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
