### PR TITLE
feat(partial-reads): line and section slices on read_note

### DIFF
--- a/crates/turbovault-tools/src/file_tools.rs
+++ b/crates/turbovault-tools/src/file_tools.rs
@@ -106,6 +106,17 @@ impl SliceSpec {
     /// rejected here rather than resolved by guessing: there is no defensible
     /// answer to "the first 10 lines *and* the last 10 lines".
     fn selector(&self) -> Result<Option<Selector>> {
+        // Markdown has six heading levels. The wire type is `u8`, so the
+        // generated JSON schema advertises 0-255; reject the rest here rather
+        // than silently matching nothing.
+        if let Some(level) = self.heading_level
+            && !(1..=6).contains(&level)
+        {
+            return Err(Error::validation_error(format!(
+                "heading_level must be between 1 and 6, got {level}"
+            )));
+        }
+
         let take = match (self.first_sections, self.last_sections) {
             (Some(_), Some(_)) => {
                 return Err(Error::validation_error(
@@ -356,21 +367,6 @@ impl FileTools {
     pub async fn read_file(&self, path: &str) -> Result<String> {
         let file_path = PathBuf::from(path);
         self.manager.read_file(&file_path).await
-    }
-
-    /// Read part of a file from the vault.
-    ///
-    /// Reads the full raw content through [`Self::read_file`], inheriting its
-    /// frontmatter-preserving guarantee, then applies `spec`. Returns
-    /// `Ok(None)` when `spec` selects nothing, so the caller can fall through
-    /// to the unchanged whole-file path.
-    pub async fn read_file_slice(
-        &self,
-        path: &str,
-        spec: &SliceSpec,
-    ) -> Result<Option<SliceResult>> {
-        let content = self.read_file(path).await?;
-        slice_content(&content, spec)
     }
 
     /// Write a file to the vault with mode support (creates directories as needed)
@@ -1528,6 +1524,33 @@ Did: c
     }
 
     #[test]
+    fn test_slice_rejects_out_of_range_heading_level() {
+        for level in [0u8, 7, 200] {
+            let spec = SliceSpec {
+                heading_level: Some(level),
+                ..Default::default()
+            };
+            let err = slice_content(LOG, &spec).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("heading_level must be between 1 and 6"),
+                "level {level}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_slice_accepts_all_valid_heading_levels() {
+        for level in 1u8..=6 {
+            let spec = SliceSpec {
+                heading_level: Some(level),
+                ..Default::default()
+            };
+            assert!(slice_content(LOG, &spec).is_ok(), "level {level}");
+        }
+    }
+
+    #[test]
     fn test_slice_rejects_first_and_last_sections_together() {
         let spec = SliceSpec {
             first_sections: Some(1),
@@ -1551,104 +1574,5 @@ Did: c
             );
             assert_eq!(r.sections_matched, Some(0), "probe: {probe:?}");
         }
-    }
-
-    // ---- partial reads through the vault ----
-
-    fn slice_manager(vault_dir: &std::path::Path) -> Arc<VaultManager> {
-        use turbovault_core::{ServerConfig, VaultConfig};
-        let mut config = ServerConfig::new();
-        config
-            .vaults
-            .push(VaultConfig::builder("test", vault_dir).build().unwrap());
-        Arc::new(VaultManager::new(config).unwrap())
-    }
-
-    /// `read_file_slice` must return the same bytes `read_file` would, for the
-    /// portion selected — including the frontmatter `read_file` preserves.
-    #[tokio::test]
-    async fn test_read_file_slice_tail() {
-        let temp = tempfile::TempDir::new().unwrap();
-        std::fs::write(
-            temp.path().join("log.md"),
-            "---\ntitle: Log\n---\n\n## First\nbody\n\n## Second\nmore\n",
-        )
-        .unwrap();
-        let tools = FileTools::new(slice_manager(temp.path()));
-
-        let result = tools
-            .read_file_slice(
-                "log.md",
-                &SliceSpec {
-                    tail_lines: Some(2),
-                    ..Default::default()
-                },
-            )
-            .await
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(result.content, "## Second\nmore\n");
-        assert_eq!(result.total_lines, 9);
-        assert!(result.truncated);
-    }
-
-    #[tokio::test]
-    async fn test_read_file_slice_sections() {
-        let temp = tempfile::TempDir::new().unwrap();
-        std::fs::write(temp.path().join("log.md"), LOG).unwrap();
-        let tools = FileTools::new(slice_manager(temp.path()));
-
-        let result = tools
-            .read_file_slice(
-                "log.md",
-                &SliceSpec {
-                    heading_level: Some(2),
-                    last_sections: Some(1),
-                    ..Default::default()
-                },
-            )
-            .await
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(result.content, "## 2026-08-22\nDid: c\n");
-        assert_eq!(result.sections_matched, Some(3));
-    }
-
-    /// No selector: `None`, so the caller keeps using the whole-file path.
-    #[tokio::test]
-    async fn test_read_file_slice_without_selector_returns_none() {
-        let temp = tempfile::TempDir::new().unwrap();
-        std::fs::write(temp.path().join("log.md"), LOG).unwrap();
-        let tools = FileTools::new(slice_manager(temp.path()));
-
-        let result = tools
-            .read_file_slice("log.md", &SliceSpec::default())
-            .await
-            .unwrap();
-        assert!(result.is_none());
-    }
-
-    /// A missing file must surface as an I/O error, not an empty slice.
-    #[tokio::test]
-    async fn test_read_file_slice_propagates_read_error() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let tools = FileTools::new(slice_manager(temp.path()));
-
-        let err = tools
-            .read_file_slice(
-                "nope.md",
-                &SliceSpec {
-                    tail_lines: Some(1),
-                    ..Default::default()
-                },
-            )
-            .await
-            .unwrap_err();
-        assert!(
-            matches!(err, Error::Io(_) | Error::FileNotFound { .. }),
-            "got: {err:?}"
-        );
     }
 }

--- a/crates/turbovault-tools/src/file_tools.rs
+++ b/crates/turbovault-tools/src/file_tools.rs
@@ -358,6 +358,21 @@ impl FileTools {
         self.manager.read_file(&file_path).await
     }
 
+    /// Read part of a file from the vault.
+    ///
+    /// Reads the full raw content through [`Self::read_file`], inheriting its
+    /// frontmatter-preserving guarantee, then applies `spec`. Returns
+    /// `Ok(None)` when `spec` selects nothing, so the caller can fall through
+    /// to the unchanged whole-file path.
+    pub async fn read_file_slice(
+        &self,
+        path: &str,
+        spec: &SliceSpec,
+    ) -> Result<Option<SliceResult>> {
+        let content = self.read_file(path).await?;
+        slice_content(&content, spec)
+    }
+
     /// Write a file to the vault with mode support (creates directories as needed)
     ///
     /// `message` is the commit subject the underlying `VaultManager` write
@@ -1536,5 +1551,104 @@ Did: c
             );
             assert_eq!(r.sections_matched, Some(0), "probe: {probe:?}");
         }
+    }
+
+    // ---- partial reads through the vault ----
+
+    fn slice_manager(vault_dir: &std::path::Path) -> Arc<VaultManager> {
+        use turbovault_core::{ServerConfig, VaultConfig};
+        let mut config = ServerConfig::new();
+        config
+            .vaults
+            .push(VaultConfig::builder("test", vault_dir).build().unwrap());
+        Arc::new(VaultManager::new(config).unwrap())
+    }
+
+    /// `read_file_slice` must return the same bytes `read_file` would, for the
+    /// portion selected — including the frontmatter `read_file` preserves.
+    #[tokio::test]
+    async fn test_read_file_slice_tail() {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("log.md"),
+            "---\ntitle: Log\n---\n\n## First\nbody\n\n## Second\nmore\n",
+        )
+        .unwrap();
+        let tools = FileTools::new(slice_manager(temp.path()));
+
+        let result = tools
+            .read_file_slice(
+                "log.md",
+                &SliceSpec {
+                    tail_lines: Some(2),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.content, "## Second\nmore\n");
+        assert_eq!(result.total_lines, 9);
+        assert!(result.truncated);
+    }
+
+    #[tokio::test]
+    async fn test_read_file_slice_sections() {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::write(temp.path().join("log.md"), LOG).unwrap();
+        let tools = FileTools::new(slice_manager(temp.path()));
+
+        let result = tools
+            .read_file_slice(
+                "log.md",
+                &SliceSpec {
+                    heading_level: Some(2),
+                    last_sections: Some(1),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.content, "## 2026-08-22\nDid: c\n");
+        assert_eq!(result.sections_matched, Some(3));
+    }
+
+    /// No selector: `None`, so the caller keeps using the whole-file path.
+    #[tokio::test]
+    async fn test_read_file_slice_without_selector_returns_none() {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::write(temp.path().join("log.md"), LOG).unwrap();
+        let tools = FileTools::new(slice_manager(temp.path()));
+
+        let result = tools
+            .read_file_slice("log.md", &SliceSpec::default())
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    /// A missing file must surface as an I/O error, not an empty slice.
+    #[tokio::test]
+    async fn test_read_file_slice_propagates_read_error() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let tools = FileTools::new(slice_manager(temp.path()));
+
+        let err = tools
+            .read_file_slice(
+                "nope.md",
+                &SliceSpec {
+                    tail_lines: Some(1),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::Io(_) | Error::FileNotFound { .. }),
+            "got: {err:?}"
+        );
     }
 }

--- a/crates/turbovault-tools/src/file_tools.rs
+++ b/crates/turbovault-tools/src/file_tools.rs
@@ -49,6 +49,104 @@ pub struct NoteInfo {
     pub has_frontmatter: Option<bool>,
 }
 
+/// Which part of a note a partial read should return.
+///
+/// A default (all-`None`) spec selects nothing, and [`slice_content`] reports
+/// that by returning `Ok(None)` so the caller can read the whole file instead.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SliceSpec {
+    /// Return only the first N lines.
+    pub head_lines: Option<usize>,
+    /// Return only the last N lines.
+    pub tail_lines: Option<usize>,
+}
+
+impl SliceSpec {
+    /// Is any selector set?
+    pub fn selects_anything(&self) -> bool {
+        self.head_lines.is_some() || self.tail_lines.is_some()
+    }
+}
+
+/// The outcome of a partial read.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SliceResult {
+    /// The selected content — a verbatim substring of the original.
+    pub content: String,
+    /// Whether anything was omitted.
+    pub truncated: bool,
+    /// Line count of the complete file.
+    pub total_lines: usize,
+    /// Returned line span, 1-indexed and inclusive. `None` for an empty file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub returned_lines: Option<(usize, usize)>,
+}
+
+/// Byte offset at which each line of `content` starts.
+///
+/// A trailing newline ends the last line rather than beginning a new one, so
+/// `"a\nb\n"` yields `[0, 2]` — two lines, not three. An empty string yields
+/// `[0]`, which callers must treat as zero lines.
+fn line_start_offsets(content: &str) -> Vec<usize> {
+    let mut starts = vec![0usize];
+    for (idx, byte) in content.bytes().enumerate() {
+        if byte == b'\n' && idx + 1 < content.len() {
+            starts.push(idx + 1);
+        }
+    }
+    starts
+}
+
+/// Apply a partial-read selector to `content`.
+///
+/// Returns `Ok(None)` when `spec` selects nothing, so the caller can return the
+/// whole file unchanged. Contradictory specs are an error rather than a guess.
+///
+/// Slicing happens on line boundaries by byte offset, so the result is always a
+/// verbatim substring: line endings and any trailing newline survive intact.
+pub fn slice_content(content: &str, spec: &SliceSpec) -> Result<Option<SliceResult>> {
+    let starts = line_start_offsets(content);
+    let total_lines = if content.is_empty() { 0 } else { starts.len() };
+
+    // Matching the two options as a pair makes the four cases exhaustive, so no
+    // arm needs to reason about which selector "must" be set.
+    let (start, end, first_line, last_line) = match (spec.head_lines, spec.tail_lines) {
+        (Some(_), Some(_)) => {
+            return Err(Error::validation_error(
+                "Cannot combine head_lines with tail_lines",
+            ));
+        }
+        // No selector: let the caller read the whole file instead.
+        (None, None) => return Ok(None),
+        (Some(n), None) => {
+            let kept = n.min(total_lines);
+            // Keeping every line means slicing to the end, trailing newline
+            // included; `starts[total_lines]` would be one past the last line.
+            let end = if kept >= total_lines {
+                content.len()
+            } else {
+                starts[kept]
+            };
+            (0, end, 1, kept)
+        }
+        (None, Some(n)) => {
+            let skipped = total_lines.saturating_sub(n);
+            // `skipped == total_lines` (n == 0) has no line start to point at.
+            let start = starts.get(skipped).copied().unwrap_or(content.len());
+            (start, content.len(), skipped + 1, total_lines)
+        }
+    };
+
+    Ok(Some(SliceResult {
+        content: content[start..end].to_string(),
+        truncated: start > 0 || end < content.len(),
+        total_lines,
+        // An empty selection has no meaningful span: `last_line` sits below
+        // `first_line` (head_lines: 0 gives 1..0, tail_lines: 0 gives 5..4).
+        returned_lines: (first_line <= last_line).then_some((first_line, last_line)),
+    }))
+}
+
 /// File tools context
 #[derive(Clone)]
 pub struct FileTools {
@@ -832,5 +930,171 @@ mod tests {
         let overlay = serde_json::json!({"a": 1});
         deep_merge(&mut base, overlay);
         assert_eq!(base["a"], 1);
+    }
+
+    // ---- partial reads: positional selector ----
+
+    /// Four lines, trailing newline. Line starts: 0, 2, 4, 6.
+    const FOUR: &str = "a\nb\nc\nd\n";
+
+    fn head(n: usize) -> SliceResult {
+        slice_content(
+            FOUR,
+            &SliceSpec {
+                head_lines: Some(n),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .unwrap()
+    }
+
+    fn tail(n: usize) -> SliceResult {
+        slice_content(
+            FOUR,
+            &SliceSpec {
+                tail_lines: Some(n),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .unwrap()
+    }
+
+    #[test]
+    fn test_slice_no_selector_returns_none() {
+        assert!(
+            slice_content(FOUR, &SliceSpec::default())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_slice_head() {
+        let r = head(2);
+        assert_eq!(r.content, "a\nb\n");
+        assert!(r.truncated);
+        assert_eq!(r.total_lines, 4);
+        assert_eq!(r.returned_lines, Some((1, 2)));
+    }
+
+    #[test]
+    fn test_slice_tail() {
+        let r = tail(2);
+        assert_eq!(r.content, "c\nd\n");
+        assert!(r.truncated);
+        assert_eq!(r.returned_lines, Some((3, 4)));
+    }
+
+    #[test]
+    fn test_slice_n_larger_than_file_is_not_truncated() {
+        for r in [head(99), tail(99)] {
+            assert_eq!(r.content, FOUR);
+            assert!(!r.truncated);
+            assert_eq!(r.returned_lines, Some((1, 4)));
+        }
+    }
+
+    #[test]
+    fn test_slice_exact_line_count_is_not_truncated() {
+        for r in [head(4), tail(4)] {
+            assert_eq!(r.content, FOUR);
+            assert!(!r.truncated);
+        }
+    }
+
+    #[test]
+    fn test_slice_zero_lines() {
+        for r in [head(0), tail(0)] {
+            assert_eq!(r.content, "");
+            assert!(r.truncated);
+            assert_eq!(r.returned_lines, None);
+        }
+    }
+
+    #[test]
+    fn test_slice_empty_file() {
+        let r = slice_content(
+            "",
+            &SliceSpec {
+                tail_lines: Some(3),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(r.content, "");
+        assert!(!r.truncated);
+        assert_eq!(r.total_lines, 0);
+        assert_eq!(r.returned_lines, None);
+    }
+
+    #[test]
+    fn test_slice_no_trailing_newline() {
+        let content = "a\nb\nc";
+        let r = slice_content(
+            content,
+            &SliceSpec {
+                tail_lines: Some(2),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(r.content, "b\nc");
+        assert_eq!(r.total_lines, 3);
+        assert_eq!(r.returned_lines, Some((2, 3)));
+    }
+
+    /// The slice must be a byte-for-byte substring: CRLF endings survive.
+    #[test]
+    fn test_slice_preserves_crlf() {
+        let content = "a\r\nb\r\nc\r\n";
+        let r = slice_content(
+            content,
+            &SliceSpec {
+                head_lines: Some(2),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(r.content, "a\r\nb\r\n");
+        assert_eq!(r.total_lines, 3);
+    }
+
+    /// Line boundaries never split a UTF-8 codepoint.
+    #[test]
+    fn test_slice_multibyte_content() {
+        let content = "🎒 resources\nzweite Zeile\n";
+        let r = slice_content(
+            content,
+            &SliceSpec {
+                tail_lines: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(r.content, "zweite Zeile\n");
+    }
+
+    #[test]
+    fn test_slice_rejects_head_and_tail_together() {
+        let spec = SliceSpec {
+            head_lines: Some(1),
+            tail_lines: Some(1),
+        };
+        let err = slice_content(FOUR, &spec).unwrap_err();
+        assert!(err.to_string().contains("head_lines"), "got: {err}");
+    }
+
+    #[test]
+    fn test_line_start_offsets() {
+        assert_eq!(line_start_offsets("a\nb\n"), vec![0, 2]);
+        assert_eq!(line_start_offsets("a\nb"), vec![0, 2]);
+        assert_eq!(line_start_offsets(""), vec![0]);
+        assert_eq!(line_start_offsets("\n"), vec![0]);
     }
 }

--- a/crates/turbovault-tools/src/file_tools.rs
+++ b/crates/turbovault-tools/src/file_tools.rs
@@ -51,6 +51,11 @@ pub struct NoteInfo {
 
 /// Which part of a note a partial read should return.
 ///
+/// This mirrors the flat, all-optional shape the MCP tool layer receives, so
+/// every field is independently settable and some combinations are nonsense.
+/// [`SliceSpec::selector`] converts it into a [`Selector`], which can only
+/// represent a valid request.
+///
 /// A default (all-`None`) spec selects nothing, and [`slice_content`] reports
 /// that by returning `Ok(None)` so the caller can read the whole file instead.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -59,27 +64,123 @@ pub struct SliceSpec {
     pub head_lines: Option<usize>,
     /// Return only the last N lines.
     pub tail_lines: Option<usize>,
+    /// Only headings at this level delimit a selectable section.
+    pub heading_level: Option<u8>,
+    /// Exact heading text a section must have to be selectable. Compared
+    /// against the heading without its `#` markers, case-sensitively.
+    pub heading_equals: Option<String>,
+    /// Take the first N matching sections.
+    pub first_sections: Option<usize>,
+    /// Take the last N matching sections.
+    pub last_sections: Option<usize>,
+}
+
+/// Which end of the matching-section list to take from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Take {
+    First(usize),
+    Last(usize),
+}
+
+/// A validated partial-read request: exactly one selector, already checked.
+///
+/// Constructing this is the only place combination rules are enforced, so the
+/// slicing code below never has to ask which fields were set.
+enum Selector {
+    /// The first N lines.
+    Head(usize),
+    /// The last N lines.
+    Tail(usize),
+    /// Heading-delimited sections, filtered then taken from one end.
+    Sections {
+        level: Option<u8>,
+        heading: Option<String>,
+        take: Option<Take>,
+    },
 }
 
 impl SliceSpec {
-    /// Is any selector set?
-    pub fn selects_anything(&self) -> bool {
-        self.head_lines.is_some() || self.tail_lines.is_some()
+    /// Normalise the flat spec into a validated [`Selector`].
+    ///
+    /// `Ok(None)` means nothing was selected. Contradictory combinations are
+    /// rejected here rather than resolved by guessing: there is no defensible
+    /// answer to "the first 10 lines *and* the last 10 lines".
+    fn selector(&self) -> Result<Option<Selector>> {
+        let take = match (self.first_sections, self.last_sections) {
+            (Some(_), Some(_)) => {
+                return Err(Error::validation_error(
+                    "Cannot combine first_sections with last_sections",
+                ));
+            }
+            (Some(n), None) => Some(Take::First(n)),
+            (None, Some(n)) => Some(Take::Last(n)),
+            (None, None) => None,
+        };
+
+        let positional = match (self.head_lines, self.tail_lines) {
+            (Some(_), Some(_)) => {
+                return Err(Error::validation_error(
+                    "Cannot combine head_lines with tail_lines",
+                ));
+            }
+            (Some(n), None) => Some(Selector::Head(n)),
+            (None, Some(n)) => Some(Selector::Tail(n)),
+            (None, None) => None,
+        };
+
+        let wants_sections =
+            self.heading_level.is_some() || self.heading_equals.is_some() || take.is_some();
+
+        match (positional, wants_sections) {
+            (Some(_), true) => Err(Error::validation_error(
+                "Cannot combine line selectors (head_lines/tail_lines) with section \
+                 selectors (heading_level/heading_equals/first_sections/last_sections)",
+            )),
+            (Some(selector), false) => Ok(Some(selector)),
+            (None, true) => Ok(Some(Selector::Sections {
+                level: self.heading_level,
+                heading: self.heading_equals.clone(),
+                take,
+            })),
+            (None, false) => Ok(None),
+        }
     }
+}
+
+/// One heading-delimited section returned by a structural slice.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SectionSlice {
+    /// Heading text, without the leading `#` markers.
+    pub heading: String,
+    /// Heading level (1-6).
+    pub level: u8,
+    /// First line of the section, 1-indexed — the heading itself.
+    pub start_line: usize,
+    /// Last line of the section, 1-indexed and inclusive.
+    pub end_line: usize,
 }
 
 /// The outcome of a partial read.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SliceResult {
-    /// The selected content — a verbatim substring of the original.
+    /// The selected content. A verbatim substring for a line slice; for a
+    /// section slice, the selected sections concatenated in document order
+    /// (byte-identical to the original when they are adjacent).
     pub content: String,
     /// Whether anything was omitted.
     pub truncated: bool,
     /// Line count of the complete file.
     pub total_lines: usize,
-    /// Returned line span, 1-indexed and inclusive. `None` for an empty file.
+    /// Returned line span, 1-indexed and inclusive. Line slices only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub returned_lines: Option<(usize, usize)>,
+    /// Sections matching the filter, before `first_sections`/`last_sections`
+    /// was applied. Section slices only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sections_matched: Option<usize>,
+    /// The sections actually returned. Section slices only.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub sections: Vec<SectionSlice>,
 }
 
 /// Byte offset at which each line of `content` starts.
@@ -97,6 +198,18 @@ fn line_start_offsets(content: &str) -> Vec<usize> {
     starts
 }
 
+/// 1-indexed number of the line containing byte `offset`.
+///
+/// `starts` is sorted, so a binary search either lands exactly on a line start
+/// (`Ok(i)` → line `i + 1`) or reports the insertion point (`Err(i)`), in which
+/// case the offset falls inside line `i`.
+fn line_of_offset(starts: &[usize], offset: usize) -> usize {
+    match starts.binary_search(&offset) {
+        Ok(idx) => idx + 1,
+        Err(idx) => idx.max(1),
+    }
+}
+
 /// Apply a partial-read selector to `content`.
 ///
 /// Returns `Ok(None)` when `spec` selects nothing, so the caller can return the
@@ -105,20 +218,31 @@ fn line_start_offsets(content: &str) -> Vec<usize> {
 /// Slicing happens on line boundaries by byte offset, so the result is always a
 /// verbatim substring: line endings and any trailing newline survive intact.
 pub fn slice_content(content: &str, spec: &SliceSpec) -> Result<Option<SliceResult>> {
+    let Some(selector) = spec.selector()? else {
+        // No selector: let the caller read the whole file instead.
+        return Ok(None);
+    };
+
     let starts = line_start_offsets(content);
     let total_lines = if content.is_empty() { 0 } else { starts.len() };
 
-    // Matching the two options as a pair makes the four cases exhaustive, so no
-    // arm needs to reason about which selector "must" be set.
-    let (start, end, first_line, last_line) = match (spec.head_lines, spec.tail_lines) {
-        (Some(_), Some(_)) => {
-            return Err(Error::validation_error(
-                "Cannot combine head_lines with tail_lines",
-            ));
+    let (start, end, first_line, last_line) = match selector {
+        // Sections produce many disjoint slices, so they build their own result.
+        Selector::Sections {
+            level,
+            heading,
+            take,
+        } => {
+            return Ok(Some(slice_sections(
+                content,
+                &starts,
+                total_lines,
+                level,
+                heading.as_deref(),
+                take,
+            )));
         }
-        // No selector: let the caller read the whole file instead.
-        (None, None) => return Ok(None),
-        (Some(n), None) => {
+        Selector::Head(n) => {
             let kept = n.min(total_lines);
             // Keeping every line means slicing to the end, trailing newline
             // included; `starts[total_lines]` would be one past the last line.
@@ -129,7 +253,7 @@ pub fn slice_content(content: &str, spec: &SliceSpec) -> Result<Option<SliceResu
             };
             (0, end, 1, kept)
         }
-        (None, Some(n)) => {
+        Selector::Tail(n) => {
             let skipped = total_lines.saturating_sub(n);
             // `skipped == total_lines` (n == 0) has no line start to point at.
             let start = starts.get(skipped).copied().unwrap_or(content.len());
@@ -144,7 +268,76 @@ pub fn slice_content(content: &str, spec: &SliceSpec) -> Result<Option<SliceResu
         // An empty selection has no meaningful span: `last_line` sits below
         // `first_line` (head_lines: 0 gives 1..0, tail_lines: 0 gives 5..4).
         returned_lines: (first_line <= last_line).then_some((first_line, last_line)),
+        sections_matched: None,
+        sections: Vec::new(),
     }))
+}
+
+/// Select heading-delimited sections from `content`.
+///
+/// Headings come from [`turbovault_parser::parse_headings`], so a `#` inside a
+/// fenced code block is correctly not treated as a heading, and each heading
+/// carries a byte offset we can slice at directly.
+///
+/// A section runs from its heading to the next heading whose level is
+/// numerically **less than or equal to** its own — a sibling or an ancestor —
+/// or to end of file. Deeper headings do not end it, so subheadings and their
+/// content stay inside the parent section.
+fn slice_sections(
+    content: &str,
+    starts: &[usize],
+    total_lines: usize,
+    level: Option<u8>,
+    heading_equals: Option<&str>,
+    take: Option<Take>,
+) -> SliceResult {
+    let headings = turbovault_parser::parse_headings(content);
+
+    // Indices into `headings`, not the headings themselves: the boundary scan
+    // below needs to look at what follows a match in the full document order.
+    let matched: Vec<usize> = headings
+        .iter()
+        .enumerate()
+        .filter(|(_, h)| level.is_none_or(|want| h.level == want))
+        .filter(|(_, h)| heading_equals.is_none_or(|want| h.text == want))
+        .map(|(idx, _)| idx)
+        .collect();
+
+    let sections_matched = matched.len();
+    let selected: &[usize] = match take {
+        Some(Take::First(n)) => &matched[..n.min(sections_matched)],
+        Some(Take::Last(n)) => &matched[sections_matched.saturating_sub(n)..],
+        None => &matched,
+    };
+
+    let mut out = String::new();
+    let mut sections = Vec::with_capacity(selected.len());
+    for &idx in selected {
+        let heading = &headings[idx];
+        let start = heading.position.offset;
+        let end = headings[idx + 1..]
+            .iter()
+            .find(|next| next.level <= heading.level)
+            .map_or(content.len(), |next| next.position.offset);
+
+        sections.push(SectionSlice {
+            heading: heading.text.clone(),
+            level: heading.level,
+            start_line: line_of_offset(starts, start),
+            // `end` is exclusive, so the last byte of the section is `end - 1`.
+            end_line: line_of_offset(starts, end.saturating_sub(1)),
+        });
+        out.push_str(&content[start..end]);
+    }
+
+    SliceResult {
+        truncated: out.len() < content.len(),
+        content: out,
+        total_lines,
+        returned_lines: None,
+        sections_matched: Some(sections_matched),
+        sections,
+    }
 }
 
 /// File tools context
@@ -1085,6 +1278,7 @@ mod tests {
         let spec = SliceSpec {
             head_lines: Some(1),
             tail_lines: Some(1),
+            ..Default::default()
         };
         let err = slice_content(FOUR, &spec).unwrap_err();
         assert!(err.to_string().contains("head_lines"), "got: {err}");
@@ -1096,5 +1290,251 @@ mod tests {
         assert_eq!(line_start_offsets("a\nb"), vec![0, 2]);
         assert_eq!(line_start_offsets(""), vec![0]);
         assert_eq!(line_start_offsets("\n"), vec![0]);
+    }
+
+    // ---- partial reads: structural selector ----
+
+    /// A log-shaped note: three level-2 entries, one with a level-3 subheading.
+    const LOG: &str = "\
+# Log
+
+intro text
+
+## 2026-08-20
+Did: a
+
+## 2026-08-21
+Did: b
+### Detail
+nested text
+
+## 2026-08-22
+Did: c
+";
+
+    fn sections(content: &str, spec: SliceSpec) -> SliceResult {
+        slice_content(content, &spec).unwrap().unwrap()
+    }
+
+    fn level2(take: SliceSpec) -> SliceSpec {
+        SliceSpec {
+            heading_level: Some(2),
+            ..take
+        }
+    }
+
+    #[test]
+    fn test_sections_last_n() {
+        let r = sections(
+            LOG,
+            level2(SliceSpec {
+                last_sections: Some(2),
+                ..Default::default()
+            }),
+        );
+        assert_eq!(r.sections_matched, Some(3));
+        assert_eq!(r.sections.len(), 2);
+        assert_eq!(r.sections[0].heading, "2026-08-21");
+        assert_eq!(r.sections[1].heading, "2026-08-22");
+        assert!(r.truncated);
+        // The intro and the first entry are gone; the nested block survives.
+        assert!(!r.content.contains("2026-08-20"));
+        assert!(r.content.starts_with("## 2026-08-21\n"));
+        assert!(r.content.contains("### Detail\nnested text\n"));
+    }
+
+    /// D4: a level-2 section ends at the next level-2 heading, not at its own
+    /// level-3 subheading.
+    #[test]
+    fn test_sections_subheading_does_not_end_section() {
+        let r = sections(
+            LOG,
+            level2(SliceSpec {
+                heading_equals: Some("2026-08-21".to_string()),
+                ..Default::default()
+            }),
+        );
+        assert_eq!(r.sections.len(), 1);
+        assert_eq!(
+            r.content,
+            "## 2026-08-21\nDid: b\n### Detail\nnested text\n\n"
+        );
+        // Lines 8-12: the heading, its body, the nested block, and the
+        // trailing blank line that belongs to this section.
+        assert_eq!(r.sections[0].start_line, 8);
+        assert_eq!(r.sections[0].end_line, 12);
+    }
+
+    /// A level-3 section ends at the next level-2 heading — an ancestor.
+    #[test]
+    fn test_sections_ancestor_ends_section() {
+        let r = sections(
+            LOG,
+            SliceSpec {
+                heading_level: Some(3),
+                ..Default::default()
+            },
+        );
+        assert_eq!(r.sections.len(), 1);
+        assert_eq!(r.sections[0].heading, "Detail");
+        assert_eq!(r.content, "### Detail\nnested text\n\n");
+    }
+
+    /// The last section runs to end of file.
+    #[test]
+    fn test_sections_last_runs_to_eof() {
+        let r = sections(
+            LOG,
+            level2(SliceSpec {
+                last_sections: Some(1),
+                ..Default::default()
+            }),
+        );
+        assert_eq!(r.content, "## 2026-08-22\nDid: c\n");
+        assert_eq!(r.sections[0].start_line, 13);
+        assert_eq!(r.sections[0].end_line, 14);
+    }
+
+    /// A level-1 heading swallows everything below it.
+    #[test]
+    fn test_sections_level_one_takes_whole_document() {
+        let r = sections(
+            LOG,
+            SliceSpec {
+                heading_level: Some(1),
+                ..Default::default()
+            },
+        );
+        assert_eq!(r.content, LOG);
+        assert!(!r.truncated);
+    }
+
+    #[test]
+    fn test_sections_first_n() {
+        let r = sections(
+            LOG,
+            level2(SliceSpec {
+                first_sections: Some(1),
+                ..Default::default()
+            }),
+        );
+        assert_eq!(r.sections.len(), 1);
+        assert_eq!(r.sections[0].heading, "2026-08-20");
+    }
+
+    #[test]
+    fn test_sections_take_more_than_matched() {
+        let r = sections(
+            LOG,
+            level2(SliceSpec {
+                last_sections: Some(99),
+                ..Default::default()
+            }),
+        );
+        assert_eq!(r.sections.len(), 3);
+        assert_eq!(r.sections_matched, Some(3));
+    }
+
+    #[test]
+    fn test_sections_pattern_matching_nothing() {
+        let r = sections(
+            LOG,
+            level2(SliceSpec {
+                heading_equals: Some("nope".to_string()),
+                ..Default::default()
+            }),
+        );
+        assert_eq!(r.sections_matched, Some(0));
+        assert!(r.sections.is_empty());
+        assert_eq!(r.content, "");
+        assert!(r.truncated);
+    }
+
+    /// A `#` inside a fenced code block is not a heading.
+    #[test]
+    fn test_sections_ignores_headings_in_code_fences() {
+        let content = "## Real\n\n```bash\n# not a heading\n## also not\n```\n\n## Second\n";
+        let r = sections(
+            content,
+            level2(SliceSpec {
+                first_sections: Some(1),
+                ..Default::default()
+            }),
+        );
+        assert_eq!(r.sections_matched, Some(2));
+        assert!(r.content.contains("# not a heading"));
+        assert!(r.content.contains("## also not"));
+        assert!(!r.content.contains("## Second"));
+    }
+
+    /// Frontmatter shifts byte offsets; line numbers must still line up.
+    #[test]
+    fn test_sections_with_frontmatter() {
+        let content = "---\ntitle: Log\n---\n\n## First\nbody\n\n## Second\nmore\n";
+        let r = sections(
+            content,
+            level2(SliceSpec {
+                last_sections: Some(1),
+                ..Default::default()
+            }),
+        );
+        assert_eq!(r.content, "## Second\nmore\n");
+        assert_eq!(r.sections[0].start_line, 8);
+        assert_eq!(r.total_lines, 9);
+    }
+
+    #[test]
+    fn test_sections_no_headings_at_all() {
+        let r = sections(
+            "just prose\nno headings\n",
+            level2(SliceSpec {
+                last_sections: Some(3),
+                ..Default::default()
+            }),
+        );
+        assert_eq!(r.sections_matched, Some(0));
+        assert_eq!(r.content, "");
+    }
+
+    // ---- partial reads: validation ----
+
+    #[test]
+    fn test_slice_rejects_line_and_section_selectors_together() {
+        let spec = SliceSpec {
+            tail_lines: Some(10),
+            heading_level: Some(2),
+            ..Default::default()
+        };
+        let err = slice_content(LOG, &spec).unwrap_err();
+        assert!(
+            err.to_string().contains("Cannot combine line selectors"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_slice_rejects_first_and_last_sections_together() {
+        let spec = SliceSpec {
+            first_sections: Some(1),
+            last_sections: Some(1),
+            ..Default::default()
+        };
+        let err = slice_content(LOG, &spec).unwrap_err();
+        assert!(err.to_string().contains("first_sections"), "got: {err}");
+    }
+
+    /// Exact match only: a prefix of a real heading selects nothing.
+    #[test]
+    fn test_sections_heading_equals_is_not_a_substring_match() {
+        for probe in ["2026-08", "08-21", "2026-08-21 "] {
+            let r = sections(
+                LOG,
+                level2(SliceSpec {
+                    heading_equals: Some(probe.to_string()),
+                    ..Default::default()
+                }),
+            );
+            assert_eq!(r.sections_matched, Some(0), "probe: {probe:?}");
+        }
     }
 }

--- a/crates/turbovault-tools/src/file_tools.rs
+++ b/crates/turbovault-tools/src/file_tools.rs
@@ -144,8 +144,9 @@ impl SliceSpec {
 
         match (positional, wants_sections) {
             (Some(_), true) => Err(Error::validation_error(
-                "Cannot combine line selectors (head_lines/tail_lines) with section \
-                 selectors (heading_level/heading_equals/first_sections/last_sections)",
+                "Cannot combine a line selector (head_lines or tail_lines) with a \
+                 heading selector (heading_level, heading_equals, last_sections). \
+                 Pick one or the other",
             )),
             (Some(selector), false) => Ok(Some(selector)),
             (None, true) => Ok(Some(Selector::Sections {
@@ -1518,7 +1519,7 @@ Did: c
         };
         let err = slice_content(LOG, &spec).unwrap_err();
         assert!(
-            err.to_string().contains("Cannot combine line selectors"),
+            err.to_string().contains("Cannot combine a line selector"),
             "got: {err}"
         );
     }

--- a/crates/turbovault-tools/src/lib.rs
+++ b/crates/turbovault-tools/src/lib.rs
@@ -199,7 +199,10 @@ pub use batch_tools::BatchTools;
 pub use diff_tools::{DiffResult, DiffSummary, DiffTools};
 pub use duplicate_tools::{CompareResult, DuplicateGroup, DuplicateTools};
 pub use export_tools::ExportTools;
-pub use file_tools::{FileTools, NoteInfo, WriteMode, obsidian_uri};
+pub use file_tools::{
+    FileTools, NoteInfo, SectionSlice, SliceResult, SliceSpec, WriteMode, obsidian_uri,
+    slice_content,
+};
 pub use graph_tools::{BrokenLinkInfo, GraphTools, HealthInfo};
 pub use grounding::{GroundingAnalysis, GroundingTools, UngroundedNote, UngroundedReport};
 pub use metadata_tools::MetadataTools;

--- a/crates/turbovault/src/tools.rs
+++ b/crates/turbovault/src/tools.rs
@@ -15,8 +15,8 @@ use turbovault_tools::{
     AnalysisTools, AuditTools, BatchOperation, BatchTools, CommitLocks, DiffTools, DuplicateTools,
     ExportTools, FanoutInfo, FileTools, GitMergeStrategy, GraphTools, GroundingTools,
     MetadataTools, OkfTools, QualityTools, RelationshipTools, SearchEngine, SearchQuery,
-    SearchTools, SimilarityEngine, TemplateEngine, VaultLifecycleTools, VaultRepo, ViewerTools,
-    WriteMode, obsidian_uri,
+    SearchTools, SimilarityEngine, SliceResult, SliceSpec, TemplateEngine, VaultLifecycleTools,
+    VaultRepo, ViewerTools, WriteMode, obsidian_uri, slice_content,
 };
 use turbovault_vault::{ChangeListener, VaultManager};
 

--- a/crates/turbovault/src/tools/providers/files.rs
+++ b/crates/turbovault/src/tools/providers/files.rs
@@ -21,28 +21,95 @@ impl Deref for FileProvider {
     }
 }
 
+/// Response payload for a partial `read_note`.
+///
+/// [`SliceResult`] is flattened in, so its `skip_serializing_if` attributes
+/// still apply: a line slice carries `returned_lines` and no section fields, a
+/// section slice the reverse. Note the absence of `hash` — see `read_note`.
+#[derive(serde::Serialize)]
+struct PartialReadPayload<'a> {
+    path: &'a str,
+    uri: String,
+    #[serde(flatten)]
+    slice: SliceResult,
+}
+
 #[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
 impl FileProvider {
     // ==================== File Operations ====================
 
-    /// Read the contents of a note
+    /// Read the contents of a note, optionally only part of it
     #[tool(
-        description = "Read complete markdown content of a note from active vault",
-        usage = "Use before editing, analyzing, or displaying notes. Supports all Obsidian Flavored Markdown syntax including wikilinks [[note]], embeds ![[image.png]], and block references ^block-id",
-        performance = "Fast (<10ms typical). Returns path, content, and content hash for conflict detection",
-        related = ["write_note", "edit_note", "get_backlinks"],
-        examples = ["daily/2024-01-15.md", "projects/website-redesign.md"],
+        description = "Read markdown content of a note from active vault, either whole or a selected part",
+        usage = "Use before editing, analyzing, or displaying notes. Supports all Obsidian Flavored Markdown syntax including wikilinks [[note]], embeds ![[image.png]], and block references ^block-id. Omit every optional parameter to read the whole note. To read part of a long note, pass EITHER line selectors (head_lines or tail_lines, not both) OR section selectors (heading_level, heading_equals, last_sections) - mixing the two is an error. heading_level must be 1-6 and sets which heading level delimits a section; a section runs to the next heading of the same or a higher level, so subheadings stay inside it. heading_equals matches heading text exactly, case-sensitively, without the leading # markers. Omit last_sections to get every matching section. A partial read returns no hash, so do not follow it with a whole-file write_note: use edit_note for a targeted change, or read the note again in full first.",
+        performance = "Fast (<10ms typical). A whole-file read returns path, content and a content hash for conflict detection. A partial read returns the selected content plus truncated, total_lines, and either returned_lines or sections - and deliberately no hash",
+        related = ["edit_note", "write_note", "get_backlinks"],
+        examples = [
+            "path: daily/2024-01-15.md (whole note)",
+            "path: projects/log.md, tail_lines: 40 (last 40 lines)",
+            "path: projects/log.md, heading_level: 2, last_sections: 3 (last 3 entries)",
+            "path: projects/log.md, heading_level: 2, heading_equals: 2026-08-15 (one named entry)",
+        ],
         tags = ["read"],
         read_only = true,
     )]
-    async fn read_note(&self, path: String) -> McpResult<serde_json::Value> {
+    async fn read_note(
+        &self,
+        path: String,
+        head_lines: Option<usize>,
+        tail_lines: Option<usize>,
+        heading_level: Option<u8>,
+        heading_equals: Option<String>,
+        last_sections: Option<usize>,
+    ) -> McpResult<serde_json::Value> {
         let (vault_name, manager) = self.get_vault_pair().await?;
         let tools = FileTools::new(manager);
         let content = tools.read_file(&path).await.map_err(to_mcp_error)?;
+        let uri = obsidian_uri(&vault_name, &path);
+
+        // `SliceSpec::first_sections` stays available to library callers; it is
+        // simply not exposed as a tool parameter. `heading_equals` already
+        // reaches a named section anywhere in the file, and omitting the count
+        // returns every match, so the only phrasing lost is "the first N
+        // sections".
+        let spec = SliceSpec {
+            head_lines,
+            tail_lines,
+            heading_level,
+            heading_equals,
+            last_sections,
+            ..Default::default()
+        };
+        // Contradictory selectors are the caller's mistake, not a server fault.
+        let slice =
+            slice_content(&content, &spec).map_err(|e| McpError::invalid_request(e.to_string()))?;
+
+        // A partial read deliberately returns no `hash`. That token asserts the
+        // caller has seen this file's current state, which is false when only
+        // part of it was returned: handing it to `write_note` would let a
+        // whole-file overwrite satisfy its precondition and silently destroy
+        // the unread remainder. `edit_note` needs no token, and a caller that
+        // really wants to replace the file can re-read it in full.
+        if let Some(slice) = slice {
+            let sections_returned = slice.sections.len();
+            let mut response = StandardResponse::new(
+                &vault_name,
+                "read_note",
+                PartialReadPayload {
+                    path: &path,
+                    uri,
+                    slice,
+                },
+            );
+            if sections_returned > 0 {
+                response = response.with_count(sections_returned);
+            }
+            return response
+                .with_next_steps(&["edit_note", "get_backlinks"])
+                .to_json();
+        }
 
         let hash = self.hash_for_active_backend(&content).await?;
-
-        let uri = obsidian_uri(&vault_name, &path);
         StandardResponse::new(
             &vault_name,
             "read_note",

--- a/crates/turbovault/src/tools/providers/tool_catalog.json
+++ b/crates/turbovault/src/tools/providers/tool_catalog.json
@@ -18,7 +18,7 @@
   },
   {
     "name": "read_note",
-    "description": "Read complete markdown content of a note from active vault",
+    "description": "Read markdown content of a note from active vault, either whole or a selected part",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -26,6 +26,55 @@
           "$schema": "https://json-schema.org/draft/2020-12/schema",
           "title": "string",
           "type": "string"
+        },
+        "head_lines": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "title": "Nullable_uint",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
+        },
+        "tail_lines": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "title": "Nullable_uint",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
+        },
+        "heading_level": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "title": "Nullable_uint8",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "heading_equals": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "title": "Nullable_string",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "last_sections": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "title": "Nullable_uint",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
         }
       },
       "required": [

--- a/crates/turbovault/tests/test_mcp_provider_workflows.rs
+++ b/crates/turbovault/tests/test_mcp_provider_workflows.rs
@@ -2057,7 +2057,7 @@ async fn read_note_rejects_contradictory_slice_selectors() {
         ),
         (
             json!({"path": "notes/log.md", "tail_lines": 2, "heading_level": 2}),
-            "Cannot combine line selectors",
+            "Cannot combine a line selector",
         ),
         (
             json!({"path": "notes/log.md", "heading_level": 0}),

--- a/crates/turbovault/tests/test_mcp_provider_workflows.rs
+++ b/crates/turbovault/tests/test_mcp_provider_workflows.rs
@@ -1882,3 +1882,198 @@ async fn audit_create_delete_and_unsupported_rollbacks_keep_public_state_consist
     assert_eq!(stats["data"]["operations_by_type"]["MOVE"], 1);
     assert_eq!(stats["data"]["operations_by_type"]["ROLLBACK"], 2);
 }
+
+const PARTIAL_LOG: &str = r#"---
+type: log
+---
+# Progress Log
+
+## 2026-08-20
+Did: a
+
+## 2026-08-21
+Did: b
+### Detail
+nested
+
+## 2026-08-22
+Did: c
+"#;
+
+/// Partial `read_note` reads: the selectors, the metadata, and above all the
+/// deliberate absence of a content hash.
+#[tokio::test]
+async fn read_note_partial_reads_omit_the_hash_and_report_what_was_returned() {
+    let (_temp, server) = registered_server("partial-reads").await;
+    write_note(&server, "notes/log.md", PARTIAL_LOG).await;
+
+    // Baseline: no selector means the pre-existing whole-file contract.
+    let whole = call(&server, "read_note", json!({"path": "notes/log.md"})).await;
+    assert_eq!(whole["data"]["content"], PARTIAL_LOG);
+    assert!(
+        whole["data"]["hash"].is_string(),
+        "a whole-file read must still return a hash"
+    );
+    assert!(whole["data"]["truncated"].is_null());
+    assert_eq!(
+        whole["next_steps"],
+        json!(["write_note", "get_backlinks"]),
+        "whole-file next_steps must not change"
+    );
+
+    // Line slice from the end.
+    let tail = call(
+        &server,
+        "read_note",
+        json!({"path": "notes/log.md", "tail_lines": 2}),
+    )
+    .await;
+    assert_eq!(tail["data"]["content"], "## 2026-08-22\nDid: c\n");
+    assert_eq!(tail["data"]["truncated"], true);
+    assert_eq!(tail["data"]["total_lines"], 15);
+    assert_eq!(tail["data"]["returned_lines"], json!([14, 15]));
+    assert!(
+        tail["data"]["hash"].is_null(),
+        "a partial read must not return a hash: it would certify a file the \
+         caller has only partly seen, letting a whole-file write_note pass its \
+         precondition and destroy the remainder"
+    );
+    assert!(
+        tail["data"]["sections"].is_null(),
+        "line slices carry no section metadata"
+    );
+    assert_eq!(tail["next_steps"], json!(["edit_note", "get_backlinks"]));
+
+    // Section slice from the end. The level-3 subheading stays inside its
+    // level-2 parent rather than ending it.
+    let sections = call(
+        &server,
+        "read_note",
+        json!({"path": "notes/log.md", "heading_level": 2, "last_sections": 2}),
+    )
+    .await;
+    assert_eq!(sections["data"]["sections_matched"], 3);
+    assert_eq!(sections["count"], 2);
+    assert!(sections["data"]["hash"].is_null());
+    assert!(sections["data"]["returned_lines"].is_null());
+    let returned = sections["data"]["content"].as_str().expect("slice content");
+    assert!(returned.starts_with("## 2026-08-21\n"));
+    assert!(returned.contains("### Detail\nnested\n"));
+    assert!(!returned.contains("2026-08-20"));
+    assert_eq!(sections["data"]["sections"][0]["heading"], "2026-08-21");
+    assert_eq!(sections["data"]["sections"][0]["level"], 2);
+    assert_eq!(sections["data"]["sections"][1]["heading"], "2026-08-22");
+
+    // A named section, wherever it sits in the file.
+    let named = call(
+        &server,
+        "read_note",
+        json!({
+            "path": "notes/log.md",
+            "heading_level": 2,
+            "heading_equals": "2026-08-20",
+        }),
+    )
+    .await;
+    assert_eq!(named["data"]["sections_matched"], 1);
+    assert_eq!(named["data"]["content"], "## 2026-08-20\nDid: a\n\n");
+
+    // Exact match: a prefix selects nothing rather than the nearest heading.
+    let prefix = call(
+        &server,
+        "read_note",
+        json!({"path": "notes/log.md", "heading_level": 2, "heading_equals": "2026-08"}),
+    )
+    .await;
+    assert_eq!(prefix["data"]["sections_matched"], 0);
+    assert_eq!(prefix["data"]["content"], "");
+
+    // The note is untouched by any of the above.
+    let after = call(&server, "read_note", json!({"path": "notes/log.md"})).await;
+    assert_eq!(after["data"]["content"], PARTIAL_LOG);
+}
+
+/// Without a hash from the partial read, a whole-file overwrite is refused —
+/// the reason the hash is withheld in the first place.
+#[tokio::test]
+async fn read_note_partial_read_cannot_be_followed_by_an_unhashed_overwrite() {
+    let (_temp, server) = registered_server("partial-read-guard").await;
+    write_note(&server, "notes/log.md", PARTIAL_LOG).await;
+
+    let partial = call(
+        &server,
+        "read_note",
+        json!({"path": "notes/log.md", "tail_lines": 2}),
+    )
+    .await;
+    assert!(partial["data"]["hash"].is_null());
+
+    let refused = call_error(
+        &server,
+        "write_note",
+        json!({"path": "notes/log.md", "content": "## 2026-08-22\nDid: c edited\n"}),
+    )
+    .await;
+    assert!(
+        !refused.is_empty(),
+        "an unhashed overwrite of an existing note must be refused"
+    );
+
+    // The note survived the attempt intact.
+    let after = call(&server, "read_note", json!({"path": "notes/log.md"})).await;
+    assert_eq!(after["data"]["content"], PARTIAL_LOG);
+
+    // edit_note is the intended follow-up and needs no hash.
+    let edited = call(
+        &server,
+        "edit_note",
+        json!({
+            "path": "notes/log.md",
+            "edits": "<<<<<<< SEARCH\nDid: c\n=======\nDid: c edited\n>>>>>>> REPLACE\n",
+        }),
+    )
+    .await;
+    assert_eq!(edited["success"], true);
+    let after_edit = call(&server, "read_note", json!({"path": "notes/log.md"})).await;
+    assert!(
+        after_edit["data"]["content"]
+            .as_str()
+            .expect("content")
+            .contains("Did: c edited")
+    );
+}
+
+/// Contradictory selectors are the caller's mistake and must be reported, not
+/// silently resolved.
+#[tokio::test]
+async fn read_note_rejects_contradictory_slice_selectors() {
+    let (_temp, server) = registered_server("partial-read-validation").await;
+    write_note(&server, "notes/log.md", PARTIAL_LOG).await;
+
+    let cases = [
+        (
+            json!({"path": "notes/log.md", "head_lines": 2, "tail_lines": 2}),
+            "head_lines",
+        ),
+        (
+            json!({"path": "notes/log.md", "tail_lines": 2, "heading_level": 2}),
+            "Cannot combine line selectors",
+        ),
+        (
+            json!({"path": "notes/log.md", "heading_level": 0}),
+            "heading_level must be between 1 and 6",
+        ),
+        (
+            json!({"path": "notes/log.md", "heading_level": 7}),
+            "heading_level must be between 1 and 6",
+        ),
+    ];
+
+    for (arguments, expected) in cases {
+        let error = call_error(&server, "read_note", arguments.clone()).await;
+        assert!(
+            error.contains(expected),
+            "arguments {arguments} should mention {expected:?}, got: {error}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #52.

`read_note` gains five optional parameters for reading part of a note instead of
all of it. Omitting all of them leaves the existing whole-file behaviour
byte-for-byte unchanged, `hash` included.

```
head_lines: N       first N lines
tail_lines: N       last N lines
heading_level: 1-6  which heading level delimits a section
heading_equals: S   exact heading text, case-sensitive, no # markers
last_sections: N    last N matching sections
```

Line selectors and heading selectors are mutually exclusive; passing both is a
validation error rather than a guess. Omitting `last_sections` returns every
matching section, which is how a single named section is fetched from anywhere
in a file.

The motivating case is an append-only log with one `##` entry per day: reading
the last three entries of a 463-line note returns 21 lines.

## Answers to the open questions in #52

I asked for guidance before implementing and did not want to block, so these are
the choices I made. Each is cheap to change if you would rather have it
differently.

**1. Parameter naming — counts, not indices.** `head_lines`/`tail_lines` are
counts. A count needs no prior knowledge of the file, whereas expressing "the
last 30 lines" as an index range requires knowing the total line count in
advance, and no existing tool reports it. A range can express "first N" but not
"last N"; that asymmetry decided it. Consequence: mid-file line ranges are not
expressible, which I think is acceptable because `heading_equals` reaches a
named section anywhere in a file and keeps working as the file grows, where a
line number does not.

**2. Combined selectors — rejected.** "The first 10 lines *and* the last 10
lines" has no single defensible answer: two disjoint chunks would stop the
result being a substring and `returned_lines` could not describe it. Silently
picking one interpretation seemed worse than an error.

**3. `heading_pattern` → `heading_equals`.** The issue proposed a regex; this
implements exact match instead. In practice `heading_level` already does the
work a shape-matching pattern would, and `Regex::is_match` is unanchored, so
`heading_pattern: "2026"` would silently also match a heading reading "Notes
about 2026" — a surprise worth avoiding in an LLM-facing API. Rust's `regex`
crate would have been *safe* to expose (finite automata, linear time, no
ReDoS); this was a usability call, not a security one. `heading_contains` could
be added later if a shape match is wanted.

**4. Streaming — deferred.** Section selection needs the whole content to parse
headings, so streaming would only ever help the line selectors. The signature
does not preclude it.

## The hash is deliberately omitted on a partial read

`read_note` returns a `hash` that callers pass back as `write_note`'s
`expected_hash`, becoming `Precondition::ExpectBlob`. That token asserts the
caller has seen the file's current state — false when only part of it was
returned. A caller could read 50 lines, submit those 50 lines as a whole-file
write with a valid hash, and the precondition would pass, silently destroying
the remainder.

Omitting it makes an unhashed `write_note` fall back to `ExpectAbsent`, which
refuses to clobber an existing file. `hash_for_active_backend` is now called
only on the no-selector path, so this is structural rather than a convention to
remember. `edit_note` uses `for_in_place` and needs no token, so it leads
`related` and the `usage` text points at it.

There is an integration test for exactly this: partial read, then an unhashed
whole-file `write_note`, asserted refused with the note intact.

## Where the code lives

- `crates/turbovault-tools/src/file_tools.rs` — `SliceSpec`, `SliceResult`,
  `SectionSlice`, and `slice_content`. Slicing is done on line boundaries by
  byte offset so the result is a verbatim substring: CRLF endings and trailing
  newlines survive, and a line boundary cannot split a UTF-8 codepoint.
- `crates/turbovault/src/tools/providers/files.rs` — the tool parameters,
  response shape and `#[tool]` metadata.

Section slicing uses `turbovault_parser::parse_headings`, whose
`SourcePosition` offsets allow slicing the raw content directly, so a section
is returned verbatim rather than rebuilt from a parsed representation. Using
the parser rather than scanning for lines beginning `#` also means a comment
inside a fenced code block is correctly not treated as a heading.

**Section boundary rule:** a section runs from its heading to the next heading
whose level is numerically less than or equal to its own — a sibling or an
ancestor — or to end of file. So a level-2 section ends at the next level-2 or
level-1 heading and *includes* any level-3 subheadings and their content.
Ending it at the next heading of any kind would truncate a section at its own
first subheading. This is the bulk of the added tests.

## Notes for review

**`tool_catalog.json` is regenerated.** Adding parameters changes `read_note`'s
`inputSchema`, and that fixture is pinned byte-for-byte with no blessing
mechanism, so the 51-line diff there is mechanical. I regenerated it with a
throwaway test which is not part of this PR. If a `--bless` path would be
useful I am happy to add one separately.

**`heading_level` is validated at runtime, not in the schema.** The wire type is
`u8`, so the derived schema advertises `0-255`. Markdown has six levels, so
`SliceSpec::selector` rejects anything outside `1..=6`; without that an
out-of-range level would silently match nothing. Constraining the schema itself
would need a newtype, which seemed heavier than the problem.

**`first_sections` is not exposed as a tool parameter.** With it, `read_note`
reached 8 arguments and clippy's `too_many_arguments` fires at 7; no MCP tool in
this repo currently carries an `allow` for it. It remains on `SliceSpec` for
library callers. Little is lost, since `heading_equals` reaches a named section
anywhere and omitting `last_sections` returns every match, so the only
unavailable phrasing is "the first N sections". Say the word if you would rather
have the `allow` and the symmetry.

**`FileTools::read_file_slice` appears and disappears** across the four commits.
I added it as an async wrapper, then removed it when the tool layer turned out
to need `slice_content` directly: `Ok(None)` carries no content, so a wrapper
would force a second read on the whole-file path. Reviewing the final diff
rather than commit-by-commit avoids the detour.

## Testing

- `cargo test --workspace --all-features --all-targets` green
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean

Unit tests cover both selectors, the boundary rule (sibling, ancestor, nested
subheadings included, last section to EOF), exact-match near-misses including a
trailing space, CRLF and multi-byte content, empty files, counts larger than the
file, and every rejected combination. Integration tests in
`test_mcp_provider_workflows.rs` drive the public MCP facade and assert the
whole-file path is unchanged, that a partial read carries no hash, and that a
following unhashed overwrite is refused.

Also verified by hand against a real 2,400-note vault through both Claude Code
and Claude Desktop.

## Attribution

Planned and implemented with Claude Opus 5. I made the API decisions recorded
above, reviewed every diff, and ran the test suite and clippy locally before
each commit. This is my first contribution here, so I would rather over-explain
the reasoning than have you infer it from the diff.
