### PR TITLE
chore(ci): clear four advisories, fix drain_collect, audit on a schedule

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,27 @@
+# cargo-audit configuration.
+#
+# Nothing is ignored lightly. An advisory belongs here only when it cannot be
+# fixed from this repository, and each entry says why and what would let us drop
+# it. A permanently red audit job is worse than no audit job, because people
+# stop reading it.
+
+[advisories]
+ignore = [
+    # rkyv 0.7.46, reached only as rust_decimal 1.42 -> gluesql-core 0.19 ->
+    # gluesql 0.19 -> turbovault-sql. The advisory asks for rkyv >= 0.8.17,
+    # which is a major bump that rust_decimal has not made, and gluesql 0.19.0
+    # is the newest release, so there is no version of this chain we can select
+    # that resolves it.
+    #
+    # Reachability: only under the `sql` feature, which is off by default, and
+    # only through GlueSQL's decimal handling. TurboVault never deserializes an
+    # rkyv archive, and the vulnerability requires a crafted archive as input.
+    #
+    # Note this suppresses the ID, not the version, so it would also hide the
+    # advisory if rkyv 0.8.x were downgraded below 0.8.17. Cargo.lock is
+    # committed and pins 0.8.17, so that takes a deliberate change to happen.
+    #
+    # Drop this entry when rust_decimal moves to rkyv 0.8, or when gluesql
+    # drops the dependency. Re-check on the next gluesql release.
+    "RUSTSEC-2026-0235",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # New advisories are published against code that has not changed, so a job
+  # that only runs on push and pull_request reports "green" on a main nobody
+  # has audited in weeks. Monday morning, UTC.
+  schedule:
+    - cron: '0 6 * * 1'
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Plugin contract review follow-up**: Plugin-local and fully namespaced tool names are centrally validated against MCP SEP-986, enabled namespaces are described during MCP initialization only when plugins are registered, feature-on tests are required for every vertical, and core/plugin complete-note writes share preparation and cache-finalization orchestration.
 
+### Security
+
+- **Cleared four advisories in the dependency lock**: `h2` 0.4.14 to 0.4.18 (RUSTSEC-2026-0258, unbounded empty DATA frames) and `rkyv` 0.8.16 to 0.8.17 (RUSTSEC-2026-0233, -0234 and -0235, use-after-free and out-of-bounds reads on crafted archives). `rust_decimal` moves to 1.42.1 alongside them.
+
+  One advisory is left, and is now recorded in `.cargo/audit.toml` with the reason: `rkyv` 0.7.46 arrives through `rust_decimal` and GlueSQL, wants a major bump neither has made, and is only reachable under the default-off `sql` feature.
+
+- **CI audits on a schedule, not only on a diff**: advisories get published against code that has not changed, so a job wired to push and pull request alone kept reporting green on a `main` that had gone unaudited for weeks. All four of these landed in that window. CI now also runs weekly.
+
 ## [1.6.0] - 2026-07-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -709,7 +709,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1101,7 +1101,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1181,7 +1181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1214,7 +1214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca7d44d22004409a61c393afb3369c8f7bb74abcae49fe249ee01dcc3002113"
 dependencies = [
  "bytes",
- "rkyv 0.8.16",
+ "rkyv 0.8.17",
  "serde",
  "simdutf8",
 ]
@@ -1595,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2535,7 +2535,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3485,9 +3485,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck 0.8.2",
  "bytes",
@@ -3498,7 +3498,7 @@ dependencies = [
  "ptr_meta 0.3.1",
  "rancor",
  "rend 0.5.3",
- "rkyv_derive 0.8.16",
+ "rkyv_derive 0.8.17",
  "smallvec",
  "tinyvec",
  "uuid",
@@ -3517,9 +3517,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3562,9 +3562,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.42.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -3602,7 +3602,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3659,7 +3659,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4079,7 +4079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4381,10 +4381,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4897,7 +4897,7 @@ dependencies = [
  "base64",
  "chrono",
  "hashbrown 0.17.1",
- "rkyv 0.8.16",
+ "rkyv 0.8.17",
  "serde",
  "serde_json",
  "tokio-util",
@@ -5771,7 +5771,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/turbovault-parser/src/blocks.rs
+++ b/crates/turbovault-parser/src/blocks.rs
@@ -416,7 +416,7 @@ fn process_event(event: Event, state: &mut BlockParserState, blocks: &mut Vec<Co
             if state.item_depth == 1 {
                 let (content, mut inline, remaining_blocks) = if !state.paragraph_buffer.is_empty()
                 {
-                    let all_blocks: Vec<ContentBlock> = state.item_blocks.drain(..).collect();
+                    let all_blocks: Vec<ContentBlock> = std::mem::take(&mut state.item_blocks);
                     (
                         state.paragraph_buffer.clone(),
                         state.inline_buffer.clone(),
@@ -428,7 +428,7 @@ fn process_event(event: Event, state: &mut BlockParserState, blocks: &mut Vec<Co
                     let remaining: Vec<ContentBlock> = state.item_blocks.drain(1..).collect();
                     (content, inline, remaining)
                 } else {
-                    let all_blocks: Vec<ContentBlock> = state.item_blocks.drain(..).collect();
+                    let all_blocks: Vec<ContentBlock> = std::mem::take(&mut state.item_blocks);
                     (String::new(), Vec::new(), all_blocks)
                 };
 


### PR DESCRIPTION
`cargo audit` reports four vulnerabilities against the current lock, and `cargo clippy` fails outright on the 18 August toolchain. Both are true of `main` today, independent of any open PR.

```
h2   0.4.14  RUSTSEC-2026-0258  unbounded empty DATA frames
rkyv 0.8.16  RUSTSEC-2026-0233  use-after-free on a crafted archive
rkyv 0.8.16  RUSTSEC-2026-0234  out-of-bounds read, hash tables
rkyv 0.8.16  RUSTSEC-2026-0235  out-of-bounds read, Rc/Arc
```

All four are fixed by versions already published, so that part is a lockfile move: `h2` to 0.4.18 and `rkyv` to 0.8.17, with `rust_decimal` going to 1.42.1 alongside them. No manifest constraint changes.

A fifth, RUSTSEC-2026-0235 against `rkyv` 0.7.46, cannot be fixed here. It arrives through `rust_decimal` 1.42 and GlueSQL 0.19, the advisory asks for a major bump neither has made, and 0.19.0 is the newest gluesql release, so no selectable version of that chain resolves it. It is only reachable under the `sql` feature, which is off by default. It goes in a new `.cargo/audit.toml` with that reasoning and the condition that would let us drop it, rather than sitting red forever.

Separately, clippy 0.1.98 promoted `drain_collect` to an error under `-D warnings`, so the two `drain(..).collect()` calls in `turbovault-parser` now fail the lint job. `std::mem::take` is what the lint asks for and what the code meant. The neighbouring `drain(1..)` is a genuine partial drain and stays.

The reason none of this was visible is the last change. CI ran on `push` and `pull_request` only, so it last audited `main` on 26 July and reported green ever since, while all four advisories were published into a tree that had not changed. An audit wired to a diff cannot see an advisory, because the advisory is the thing that moved. CI now also runs weekly.

Verified locally: 1162 tests pass, `cargo clippy --workspace --all-features --all-targets -- -D warnings` is clean, `cargo audit` exits 0.