### PR TITLE
fix(parser): report linked images, image titles, and blockquote structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Images inside links are reported again.** `[![badge](b.png)](https://ci.example)` emitted the link and dropped the image entirely, so a README badge row reported zero images. The image is now emitted alongside its enclosing link, and the two keep their own destinations rather than sharing one.
+
+- **An image title is no longer folded into its source.** `![a](x.png "Title")` parsed to `src: "x.png \"Title\""` with `title: None`. The preprocessor that rewrites genuinely spaced destinations into angle-bracket form was wrapping the title along with the destination. It now splits the title off first, so a spaced destination still gets its brackets and keeps its title.
+
+- **A list item keeps its own text and its images.** Text before an image in the same item was discarded, because an image parked its title in the buffer the paragraph was accumulating into. In a tight list it was worse: with no paragraph events to catch it, the image was hoisted out to a top-level block, so the same content reported differently depending only on whether a blank line sat between the items.
+
+- **Blockquote lines stay separable.** Body lines were concatenated with no separator, so `> [!NOTE] Heads up` followed by two lines became `[!NOTE] Heads upSome text.More text.`. Anything reading a GFM alert or an Obsidian callout takes the first line as the marker and the rest as the body, so the whole body was being swallowed into the title. Breaks inside a quote now reach the quote rather than the surrounding paragraph, which also removes the stray whitespace-only paragraph that was emitted beside every blockquote.
+
+- **A fenced block inside a blockquote stays inside it.** It was emitted as a top-level sibling *ahead of* the blockquote still being buffered, so code in a callout rendered above the callout header.
+
+  All five were reported from treemd ([#79](https://github.com/Epistates/treemd/issues/79), [#80](https://github.com/Epistates/treemd/issues/80)) and none could be worked around downstream, since the information was already gone by the time a consumer received the blocks.
+
 ### Added
 
 - **Compiled-in plugin boundary** ([#34](https://github.com/Epistates/turbovault/issues/34)): Added the default-off `plugin-api` feature and the publishable `turbovault-plugin-api` crate. Plugins receive a curated CAS-only `VaultApi`, an object-safe tool provider contract, redacted request context, strict MCP namespaces, and a bounded hook bus with explicit lag/resync and close semantics.

--- a/crates/turbovault-parser/src/blocks.rs
+++ b/crates/turbovault-parser/src/blocks.rs
@@ -42,16 +42,57 @@ fn preprocess_wikilinks(markdown: &str) -> String {
 static LINK_WITH_SPACES_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\[([^\]]+)\]\(([^)<>]+\s[^)<>]*)\)").unwrap());
 
+/// Split a link target into its destination and an optional CommonMark title.
+///
+/// A title is a quoted run at the end, separated from the destination by
+/// whitespace: `x.png "Title"` is a destination plus a title, not a
+/// destination containing a space. The returned title keeps its quotes, so a
+/// caller can re-emit it verbatim.
+///
+/// Only `"` and `'` are recognised. CommonMark also allows a `(…)` title, but
+/// [`LINK_WITH_SPACES_RE`] cannot capture one because its target class
+/// excludes `)`.
+fn split_link_title(target: &str) -> (&str, Option<&str>) {
+    let trimmed = target.trim_end();
+    let quote = match trimmed.chars().last() {
+        Some(c @ ('"' | '\'')) => c,
+        _ => return (target, None),
+    };
+    let body = &trimmed[..trimmed.len() - quote.len_utf8()];
+    let Some(open) = body.rfind(quote) else {
+        return (target, None);
+    };
+    // Without the separating whitespace this is one destination that happens
+    // to contain quotes, not a destination and a title.
+    if !body[..open].ends_with(char::is_whitespace) {
+        return (target, None);
+    }
+    let url = body[..open].trim_end();
+    if url.is_empty() {
+        return (target, None);
+    }
+    (url, Some(&trimmed[open..]))
+}
+
 /// Preprocess links with spaces to angle bracket syntax.
+///
+/// The title is split off first. Wrapping `x.png "Title"` whole would make the
+/// title part of the destination, which is how `![a](x.png "Title")` used to
+/// parse to `src: "x.png \"Title\""` with no title at all.
 fn preprocess_links_with_spaces(markdown: &str) -> String {
     LINK_WITH_SPACES_RE
         .replace_all(markdown, |caps: &regex::Captures| {
             let text = &caps[1];
-            let url = &caps[2];
-            if url.contains(' ') {
-                format!("[{}](<{}>)", text, url)
-            } else {
-                caps[0].to_string()
+            let (url, title) = split_link_title(&caps[2]);
+            // Only a destination that genuinely contains a space needs the
+            // angle brackets. Once the title is off, most do not, and leaving
+            // them alone lets pulldown-cmark parse them natively.
+            if !url.contains(' ') {
+                return caps[0].to_string();
+            }
+            match title {
+                Some(title) => format!("[{text}](<{url}> {title})"),
+                None => format!("[{text}](<{url}>)"),
             }
         })
         .to_string()
@@ -151,6 +192,10 @@ struct BlockParserState {
     code_buffer: String,
     code_language: Option<String>,
     code_start_line: usize,
+    /// The current image's title, held here rather than borrowing
+    /// `paragraph_buffer`. Parking it there overwrote whatever the paragraph
+    /// had accumulated, so `- item ![a](a.png)` lost its "item " prefix.
+    image_title: String,
     blockquote_buffer: String,
     table_headers: Vec<String>,
     table_alignments: Vec<TableAlignment>,
@@ -195,6 +240,7 @@ impl BlockParserState {
             code_buffer: String::new(),
             code_language: None,
             code_start_line: 0,
+            image_title: String::new(),
             blockquote_buffer: String::new(),
             table_headers: Vec::new(),
             table_alignments: Vec::new(),
@@ -270,9 +316,13 @@ impl BlockParserState {
 
     fn flush_blockquote(&mut self, blocks: &mut Vec<ContentBlock>) {
         if self.in_blockquote && !self.blockquote_buffer.is_empty() {
-            let nested_blocks = parse_blocks(&self.blockquote_buffer);
+            // Paragraph ends inside the quote append a blank-line separator,
+            // which leaves a trailing one on the last paragraph. It carries no
+            // meaning and would show up in every consumer's `content`.
+            let content = self.blockquote_buffer.trim_end().to_string();
+            let nested_blocks = parse_blocks(&content);
             blocks.push(ContentBlock::Blockquote {
-                content: self.blockquote_buffer.clone(),
+                content,
                 blocks: nested_blocks,
             });
             self.blockquote_buffer.clear();
@@ -340,7 +390,18 @@ fn process_event(event: Event, state: &mut BlockParserState, blocks: &mut Vec<Co
             state.in_paragraph = true;
         }
         Event::End(TagEnd::Paragraph) => {
-            if state.item_depth >= 1 && state.in_paragraph && !state.paragraph_buffer.is_empty() {
+            if state.in_blockquote {
+                // The quote's text already went to `blockquote_buffer`, so
+                // there is nothing to emit here. Record the paragraph break so
+                // the re-parse still sees two paragraphs rather than one.
+                state.in_paragraph = false;
+                if !state.blockquote_buffer.is_empty() {
+                    state.blockquote_buffer.push_str("\n\n");
+                }
+            } else if state.item_depth >= 1
+                && state.in_paragraph
+                && !state.paragraph_buffer.is_empty()
+            {
                 state.item_blocks.push(ContentBlock::Paragraph {
                     content: state.paragraph_buffer.clone(),
                     inline: state.inline_buffer.clone(),
@@ -367,7 +428,25 @@ fn process_event(event: Event, state: &mut BlockParserState, blocks: &mut Vec<Co
             };
         }
         Event::End(TagEnd::CodeBlock) => {
-            if state.item_depth >= 1 && state.in_code && !state.code_buffer.is_empty() {
+            if state.in_blockquote && state.in_code {
+                // Emitting the code block here would push it onto the
+                // top-level `blocks`, where it lands *ahead of* the blockquote
+                // that is still buffering, so a fenced block inside a callout
+                // rendered above the callout header. Re-fence it into the
+                // buffer instead and let the nested parse rebuild it in place.
+                let fence = match &state.code_language {
+                    Some(lang) => format!("```{lang}\n"),
+                    None => "```\n".to_string(),
+                };
+                state.blockquote_buffer.push_str(&fence);
+                state
+                    .blockquote_buffer
+                    .push_str(state.code_buffer.trim_end());
+                state.blockquote_buffer.push_str("\n```\n");
+                state.code_buffer.clear();
+                state.code_language = None;
+                state.in_code = false;
+            } else if state.item_depth >= 1 && state.in_code && !state.code_buffer.is_empty() {
                 state.item_blocks.push(ContentBlock::Code {
                     language: state.code_language.clone(),
                     content: state.code_buffer.trim_end().to_string(),
@@ -599,52 +678,74 @@ fn process_event(event: Event, state: &mut BlockParserState, blocks: &mut Vec<Co
             state.in_image = true;
             state.link_url = dest_url.to_string();
             state.link_text.clear();
-            state.paragraph_buffer = title.to_string();
+            // NOT `paragraph_buffer`: text already collected for the enclosing
+            // paragraph has to survive an image appearing partway through it.
+            state.image_title = title.to_string();
         }
         Event::End(TagEnd::Image) => {
             state.in_image = false;
 
-            if !state.image_in_link {
-                // Capture title before we modify paragraph_buffer
-                let title = if state.paragraph_buffer.is_empty() {
-                    None
-                } else {
-                    Some(state.paragraph_buffer.clone())
-                };
+            let title = if state.image_title.is_empty() {
+                None
+            } else {
+                Some(std::mem::take(&mut state.image_title))
+            };
 
-                // Capture line_offset for inline images in list items
-                let line_offset = if state.in_list && state.item_depth >= 1 {
-                    Some(state.nested_line_offset)
-                } else {
-                    None
-                };
+            // Capture line_offset for inline images in list items
+            let line_offset = if state.in_list && state.item_depth >= 1 {
+                Some(state.nested_line_offset)
+            } else {
+                None
+            };
 
-                if state.in_paragraph {
-                    // Reset paragraph_buffer for image representation
-                    state.paragraph_buffer.clear();
-                    state.inline_buffer.push(InlineElement::Image {
-                        alt: state.link_text.clone(),
-                        src: state.link_url.clone(),
-                        title,
-                        line_offset,
-                    });
-                    // Add image placeholder to paragraph content
-                    state
-                        .paragraph_buffer
-                        .push_str(&format!("![{}]({})", state.link_text, state.link_url));
-                } else {
-                    state.flush_paragraph(blocks);
-                    blocks.push(ContentBlock::Image {
-                        alt: state.link_text.clone(),
-                        src: state.link_url.clone(),
-                        title,
-                    });
-                    state.paragraph_buffer.clear();
-                }
-
-                state.link_text.clear();
-                state.link_url.clear();
+            if state.image_in_link {
+                // A linked image (`[![alt](img)](href)`) used to emit nothing
+                // at all, so a README badge row reported zero images. The
+                // enclosing link is still emitted when it ends; the two are
+                // siblings because `InlineElement::Link` carries no children.
+                // `link_url` currently holds the image destination and
+                // `saved_link_url` the link's own, which `TagEnd::Link` uses.
+                state.inline_buffer.push(InlineElement::Image {
+                    alt: state.link_text.clone(),
+                    src: state.link_url.clone(),
+                    title,
+                    line_offset,
+                });
+                // Deliberately keep `link_text` and `link_url`: the enclosing
+                // link still needs the text, and clearing the url would strand
+                // `TagEnd::Link`'s restore.
+                return;
             }
+
+            // A tight list item produces no Paragraph events, so this used to
+            // fall through to the block arm and push the image onto the
+            // top-level blocks, hoisted clean out of the list, while
+            // `flush_paragraph` discarded the item's own text. An image in an
+            // item belongs to the item whether or not the list is loose.
+            if state.in_paragraph || state.item_depth >= 1 {
+                state.inline_buffer.push(InlineElement::Image {
+                    alt: state.link_text.clone(),
+                    src: state.link_url.clone(),
+                    title,
+                    line_offset,
+                });
+                // Append the image's source spelling to whatever the paragraph
+                // has so far, rather than replacing it.
+                state
+                    .paragraph_buffer
+                    .push_str(&format!("![{}]({})", state.link_text, state.link_url));
+            } else {
+                state.flush_paragraph(blocks);
+                blocks.push(ContentBlock::Image {
+                    alt: state.link_text.clone(),
+                    src: state.link_url.clone(),
+                    title,
+                });
+                state.paragraph_buffer.clear();
+            }
+
+            state.link_text.clear();
+            state.link_url.clear();
         }
         Event::Text(text) => {
             if state.in_code {
@@ -690,6 +791,15 @@ fn process_event(event: Event, state: &mut BlockParserState, blocks: &mut Vec<Co
                 }
                 state.add_inline_text(&text);
             }
+        }
+        // A break inside a blockquote separates two source lines, and the
+        // blockquote is reconstructed from raw text, so the break has to reach
+        // that buffer. Sending it to `paragraph_buffer` instead is what joined
+        // `> a` and `> b` into "ab" and left a stray whitespace-only paragraph
+        // beside the blockquote. This arm must precede the `in_paragraph` ones,
+        // since pulldown-cmark opens a paragraph inside the quote too.
+        Event::SoftBreak | Event::HardBreak if state.in_blockquote => {
+            state.blockquote_buffer.push('\n');
         }
         Event::SoftBreak if state.in_paragraph => {
             state.paragraph_buffer.push(' ');

--- a/crates/turbovault-parser/tests/test_images_and_blockquotes.rs
+++ b/crates/turbovault-parser/tests/test_images_and_blockquotes.rs
@@ -1,0 +1,267 @@
+//! Regression cover for two reports from treemd against turbovault-parser 1.6.0.
+//!
+//! - <https://github.com/Epistates/treemd/issues/79> (images)
+//! - <https://github.com/Epistates/treemd/issues/80> (blockquotes)
+//!
+//! Every case here failed before the fix, and none of them could be worked
+//! around downstream: the information was already gone by the time a consumer
+//! received the blocks.
+
+use turbovault_parser::{ContentBlock, InlineElement, parse_blocks};
+
+/// Every image reachable from a block, whether it is a block of its own or an
+/// inline element, including inside list items and blockquotes.
+fn collect_images(blocks: &[ContentBlock]) -> Vec<(String, String, Option<String>)> {
+    fn walk_inline(inline: &[InlineElement], out: &mut Vec<(String, String, Option<String>)>) {
+        for element in inline {
+            if let InlineElement::Image {
+                alt, src, title, ..
+            } = element
+            {
+                out.push((alt.clone(), src.clone(), title.clone()));
+            }
+        }
+    }
+
+    fn walk(blocks: &[ContentBlock], out: &mut Vec<(String, String, Option<String>)>) {
+        for block in blocks {
+            match block {
+                ContentBlock::Image { alt, src, title } => {
+                    out.push((alt.clone(), src.clone(), title.clone()));
+                }
+                ContentBlock::Paragraph { inline, .. } => walk_inline(inline, out),
+                ContentBlock::Heading { inline, .. } => walk_inline(inline, out),
+                ContentBlock::Blockquote { blocks, .. } => walk(blocks, out),
+                ContentBlock::List { items, .. } => {
+                    for item in items {
+                        walk_inline(&item.inline, out);
+                        walk(&item.blocks, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    walk(blocks, &mut out);
+    out
+}
+
+fn first_blockquote(blocks: &[ContentBlock]) -> (&str, &[ContentBlock]) {
+    blocks
+        .iter()
+        .find_map(|b| match b {
+            ContentBlock::Blockquote { content, blocks } => Some((content.as_str(), &blocks[..])),
+            _ => None,
+        })
+        .expect("expected a blockquote")
+}
+
+// ---------------------------------------------------------------------------
+// Images
+// ---------------------------------------------------------------------------
+
+/// A badge row is the single most common shape of this: an image wrapped in a
+/// link. The image used to be dropped outright, so a README reported none.
+#[test]
+fn image_wrapped_in_a_link_is_still_an_image() {
+    let blocks = parse_blocks("[![badge](b.png)](https://ci.example)\n");
+    let images = collect_images(&blocks);
+
+    assert_eq!(
+        images,
+        vec![("badge".to_string(), "b.png".to_string(), None)],
+        "a linked image must still be reported as an image"
+    );
+}
+
+/// The enclosing link keeps pointing at the link's own destination, not the
+/// image's. These two are easy to cross-wire, since both pass through
+/// `link_url`.
+#[test]
+fn a_linked_image_keeps_both_destinations_distinct() {
+    let blocks = parse_blocks("[![badge](b.png)](https://ci.example)\n");
+    let ContentBlock::Paragraph { inline, .. } = &blocks[0] else {
+        panic!("expected a paragraph, got {:?}", blocks[0]);
+    };
+
+    let link = inline
+        .iter()
+        .find_map(|e| match e {
+            InlineElement::Link { url, .. } => Some(url.as_str()),
+            _ => None,
+        })
+        .expect("expected the enclosing link");
+    let image = inline
+        .iter()
+        .find_map(|e| match e {
+            InlineElement::Image { src, .. } => Some(src.as_str()),
+            _ => None,
+        })
+        .expect("expected the wrapped image");
+
+    assert_eq!(link, "https://ci.example");
+    assert_eq!(image, "b.png");
+}
+
+/// A title is not part of the destination. The spaced-link preprocessor used
+/// to wrap `x.png "Title"` whole in angle brackets, which made the title part
+/// of the URL and left `title: None`.
+#[test]
+fn an_image_title_is_not_folded_into_the_source() {
+    let images = collect_images(&parse_blocks("![a](x.png \"Title\")\n"));
+
+    assert_eq!(
+        images,
+        vec![(
+            "a".to_string(),
+            "x.png".to_string(),
+            Some("Title".to_string())
+        )]
+    );
+}
+
+/// The preprocessor still has a job to do: a destination that genuinely
+/// contains a space needs the angle brackets, and a title alongside it must
+/// survive that rewrite.
+#[test]
+fn a_spaced_destination_still_works_and_keeps_its_title() {
+    let images = collect_images(&parse_blocks("![a](my file.png \"Title\")\n"));
+
+    assert_eq!(
+        images,
+        vec![(
+            "a".to_string(),
+            "my file.png".to_string(),
+            Some("Title".to_string())
+        )]
+    );
+}
+
+/// Tight and loose lists differ only by a blank line, so they must not differ
+/// in what they report. The tight form used to hoist the image out to a
+/// top-level block and discard the item's own text with it.
+#[test]
+fn a_list_item_image_reports_the_same_tight_or_loose() {
+    let tight = parse_blocks("- item ![a](a.png)\n- second item\n");
+    let loose = parse_blocks("- item ![a](a.png)\n\n- second item\n");
+
+    assert_eq!(
+        collect_images(&tight),
+        vec![("a".to_string(), "a.png".to_string(), None)],
+        "tight list item image"
+    );
+    assert_eq!(
+        collect_images(&tight),
+        collect_images(&loose),
+        "a blank line between items must not change what is reported"
+    );
+
+    for (label, blocks) in [("tight", &tight), ("loose", &loose)] {
+        assert!(
+            matches!(blocks.first(), Some(ContentBlock::List { .. })),
+            "{label}: the image must stay inside the list, got {:?}",
+            blocks.first()
+        );
+    }
+}
+
+/// Text before an image in the same item is part of that item. The image's
+/// title used to be parked in the paragraph buffer, overwriting it.
+#[test]
+fn text_before_an_image_survives_the_image() {
+    let blocks = parse_blocks("- item ![a](a.png)\n");
+    let ContentBlock::List { items, .. } = &blocks[0] else {
+        panic!("expected a list, got {:?}", blocks[0]);
+    };
+
+    assert!(
+        items[0].content.starts_with("item "),
+        "expected the item text to survive, got {:?}",
+        items[0].content
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Blockquotes
+// ---------------------------------------------------------------------------
+
+/// The highest-impact case: every multi-line blockquote. Body lines were
+/// concatenated with no separator, so a GFM alert or Obsidian callout, which
+/// takes the first line as its marker and the rest as the body, swallowed the
+/// entire body into the title.
+#[test]
+fn blockquote_body_lines_stay_separable() {
+    let (content, _) = {
+        let blocks = parse_blocks("> [!NOTE] Heads up\n> Some text.\n> More text.\n");
+        let (c, b) = first_blockquote(&blocks);
+        (c.to_string(), b.to_vec())
+    };
+
+    assert_eq!(content, "[!NOTE] Heads up\nSome text.\nMore text.");
+
+    let mut lines = content.lines();
+    assert_eq!(lines.next(), Some("[!NOTE] Heads up"));
+    assert_eq!(lines.next(), Some("Some text."));
+    assert_eq!(lines.next(), Some("More text."));
+    assert_eq!(lines.next(), None);
+}
+
+/// The stray whitespace-only paragraph that used to be emitted alongside a
+/// blockquote, because soft breaks inside the quote landed in the paragraph
+/// buffer.
+#[test]
+fn a_blockquote_emits_no_stray_paragraph() {
+    let blocks = parse_blocks("> [!NOTE] Heads up\n> Some text.\n> More text.\n");
+
+    assert_eq!(
+        blocks.len(),
+        1,
+        "expected only the blockquote, got {blocks:?}"
+    );
+}
+
+/// A fenced block inside a quote was emitted as a top-level sibling *ahead of*
+/// the blockquote, so it rendered above the callout header instead of within
+/// the callout.
+#[test]
+fn a_fenced_block_inside_a_blockquote_stays_inside_it() {
+    let blocks = parse_blocks("> [!NOTE] Hi\n> Text.\n>\n> ```rust\n> fn main() {}\n> ```\n");
+
+    assert_eq!(
+        blocks.len(),
+        1,
+        "the code block must not escape the quote, got {blocks:?}"
+    );
+
+    let (_, nested) = first_blockquote(&blocks);
+    let code = nested
+        .iter()
+        .find_map(|b| match b {
+            ContentBlock::Code {
+                language, content, ..
+            } => Some((language.clone(), content.clone())),
+            _ => None,
+        })
+        .expect("expected the fenced block nested in the quote");
+
+    assert_eq!(code.0, Some("rust".to_string()));
+    assert_eq!(code.1, "fn main() {}");
+
+    // Order matters: the prose introduces the code, so it has to come first.
+    assert!(
+        matches!(nested.first(), Some(ContentBlock::Paragraph { .. })),
+        "expected prose before the code block, got {nested:?}"
+    );
+}
+
+/// A quote with no code and one line is the ordinary case, and must not have
+/// picked up a trailing separator from the paragraph-break handling.
+#[test]
+fn a_single_line_blockquote_has_no_trailing_whitespace() {
+    let blocks = parse_blocks("> Just one line.\n");
+    let (content, _) = first_blockquote(&blocks);
+
+    assert_eq!(content, "Just one line.");
+}


### PR DESCRIPTION
Five defects reported from treemd ([#79](https://github.com/Epistates/treemd/issues/79), [#80](https://github.com/Epistates/treemd/issues/80)), all in `blocks.rs`. None could be worked around downstream, because the information was already gone by the time a consumer received the blocks.

**Images inside links were dropped.** `TagEnd::Image` emitted nothing at all when `image_in_link` was set, so `[![badge](b.png)](url)` produced a link and no image, and a README badge row reported zero images. The image is now emitted as a sibling of its link, since `InlineElement::Link` carries no children. The two destinations stay distinct.

**Image titles were folded into the source.** `preprocess_links_with_spaces` rewrites a destination containing a space into angle-bracket form, and it treated `x.png "Title"` as one long destination, yielding `src: "x.png \"Title\""` with `title: None`. It now splits a trailing quoted title off first, so a genuinely spaced destination still gets its brackets and keeps its title beside them.

**A list item lost its own text.** `Tag::Image` assigned the image title over `paragraph_buffer`, discarding whatever the paragraph had accumulated, so `- item ![a](a.png)` lost `item `. The title now has its own field. In a tight list it was worse: no paragraph events fire, so the image fell through to the block arm and was pushed onto the top-level blocks, hoisted clean out of the list. Tight and loose lists differ by one blank line and now report the same thing.

**Blockquote lines were concatenated.** A quote is rebuilt from raw text, but breaks inside one went to `paragraph_buffer` instead of `blockquote_buffer`, so three source lines became one run and a stray whitespace-only paragraph appeared beside every blockquote. Not cosmetic: a GFM alert or Obsidian callout takes the first line as its marker and the rest as the body, so the entire body was swallowed into the title.

**A fenced block inside a blockquote escaped it.** `TagEnd::CodeBlock` pushed to the top-level blocks while the quote was still buffering, landing the code ahead of the blockquote, so code in a callout rendered above the callout header. It is re-fenced into the buffer and the nested parse rebuilds it in place.

## Verification

Ten regression tests in `tests/test_images_and_blockquotes.rs`. Nine fail against the unfixed parser (checked by stashing the fix and re-running), the tenth is a control that holds either way. Full workspace suite passes at 1212, clippy and fmt clean.

Two findings worth recording that the reports did not mention: the tight-list case was losing the item's own text, not just misplacing the image, and every blockquote was emitting a spurious whitespace-only paragraph beside it.

Once this is released, treemd needs a version bump and its known-gap notes in `docs/QUERY_LANGUAGE.md` removed.