### PR TITLE
docs: credit the people this release came from

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,11 @@ htmlcov/
 !README.md
 !docs/**/*.md
 !CHANGELOG.md
+!CONTRIBUTORS.md
 !RELEASE*.md
 !PUBLISH*.md
+# Crate-level READMEs are packaged by Cargo (readme = "README.md"), so an
+# ignored one ships as a broken reference on crates.io.
+!crates/*/README.md
 !/LICENSE*
 !LICENSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Most of this release came from outside the maintainers. The plugin architecture was argued into
+shape by [@ForrestThump](https://github.com/ForrestThump) across #33, #42 and #43 before a line of
+it was written; the write substrate and everything that now guarantees a write either lands or
+refuses is [@dlobue](https://github.com/dlobue)'s; partial reads are
+[@Helfrid](https://github.com/Helfrid)'s. See [CONTRIBUTORS.md](CONTRIBUTORS.md).
+
 ### Fixed
 
 - **Tools no longer contradict each other after an external edit**: Search, the link graph, similarity, vault stats, and the plugin change feed are all derived state, and until now only writes TurboVault itself performed ever updated them. Anyone else touching the vault (Obsidian, an editor, `git pull`, a sync client, a second TurboVault) left them wrong indefinitely, while `read_note` and `list_notes` went to disk and stayed correct. An agent could read a note, see a phrase, search for that phrase, and be told it does not exist. The Git backend was no safer: its ref watcher only ever saw external *commits*, and an Obsidian save does not commit.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,44 @@
+# Contributors
+
+TurboVault is built by people who did not have to. Thank you.
+
+## Core
+
+**[@dlobue](https://github.com/dlobue)** — the Git write substrate and the single mutation
+chokepoint that everything now writes through, atomic `CreateOnly` on both backends, honest
+reporting for partially-applied batches, one activation path for publishing a vault manager, and
+write-backend selection at registration. Also the clobber-safety matrix, which is the reason we can
+say what the write surface guarantees rather than hoping.
+
+**[@ForrestThump](https://github.com/ForrestThump)** — most of the shape of the plugin
+architecture, argued out across [#33](https://github.com/Epistates/turbovault/issues/33),
+[#42](https://github.com/Epistates/turbovault/issues/42) and
+[#43](https://github.com/Epistates/turbovault/issues/43) before any of it was written. Write
+provenance at the chokepoint, Obsidian Tasks metadata parsing, cache-first `query_metadata` (10.6x),
+tool filtering by tag, and the Windows test fixes that made CI mean something on more than one
+platform. Also a long run of work on [turbomcp](https://github.com/Epistates/turbomcp).
+
+## Contributors
+
+- **[@Helfrid](https://github.com/Helfrid)** — partial reads for `read_note`, line slices and
+  heading sections, including the call to withhold the content hash from a partial read so it can
+  never satisfy a whole-file overwrite.
+- **[@AntttMan](https://github.com/AntttMan)**
+- **[@esumerfd](https://github.com/esumerfd)**
+- **[@hexatriene](https://github.com/hexatriene)**
+- **[@slikts](https://github.com/slikts)**
+- **[@ttfoley](https://github.com/ttfoley)**
+- **[@wingrunr21](https://github.com/wingrunr21)**
+
+## Reporters
+
+Bug reports that came with a repro and saved us the guessing:
+
+- **[@tiborkiss](https://github.com/tiborkiss)** — non-conformant `$defs` placement in tool schemas
+  ([#51](https://github.com/Epistates/turbovault/issues/51)), traced upstream to `turbomcp-macros`
+  with a minimal curl repro against llama.cpp.
+
+---
+
+If your work is here and you would rather be listed differently, or not at all, open an issue and we
+will fix it. If it is missing, that is our mistake, so please tell us.


### PR DESCRIPTION
Adds `CONTRIBUTORS.md` and names contributors in the unreleased changelog section, which until now credited issue numbers and nothing else.

The gitignore needed a fix to allow it. A blanket `*.md` with an allowlist means a new doc is invisible by default, which is exactly how `CONTRIBUTORS.md` would have silently failed to commit. Crate READMEs go on the allowlist too. They were force-added individually at some point, and Cargo packages them via `readme = "README.md"`, so an ignored one ships as a broken link on crates.io.

If anyone listed would rather be described differently, or not listed, that is easy to change.