### PR TITLE
fix(vault): refuse a git-backed registration when the path is not a repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Registering a git-backed vault checks for a repository first.** `add_vault` with
+  `write_backend: "git"` against a directory that is not a git repository used to register
+  successfully and then fail on every write, far enough from the registration call that the two were
+  hard to connect. It now fails at registration and says to run `git init` or use `direct`. This is
+  the mirror of the existing warning for the opposite mistake, registering a real repository as a
+  `direct` vault.
+
 - **Tools no longer contradict each other after an external edit**: Search, the link graph, similarity, vault stats, and the plugin change feed are all derived state, and until now only writes TurboVault itself performed ever updated them. Anyone else touching the vault (Obsidian, an editor, `git pull`, a sync client, a second TurboVault) left them wrong indefinitely, while `read_note` and `list_notes` went to disk and stayed correct. An agent could read a note, see a phrase, search for that phrase, and be told it does not exist. The Git backend was no safer: its ref watcher only ever saw external *commits*, and an Obsidian save does not commit.
 
   `VaultManager::ensure_fresh` is now a single freshness gate that every derived read passes through. It compares a `(size, mtime)` scan against what the note cache recorded when it parsed each note, and applies whatever moved through the machinery that already existed for Git commits, so search, similarity, and the plugin feed are updated from one place. The comparison cannot miss a change, because it is comparing state rather than listening for events, which is also why this is not a filesystem watcher: inotify queues overflow and its watch budget is finite, FSEvents degrades to directory-granularity rescan hints under load, and network and cloud-synced vaults deliver nothing at all for a peer's changes. A watcher yields *mostly* fresh, and for an agent that is worse than plainly stale, because nothing marks the answers it should not have trusted.

--- a/crates/turbovault-tools/src/vault_lifecycle.rs
+++ b/crates/turbovault-tools/src/vault_lifecycle.rs
@@ -209,6 +209,22 @@ impl VaultLifecycleTools {
             )));
         }
 
+        // The mirror of `direct_over_git_repo_warning`: asking for the git
+        // backend over a directory that is not a repository. Registration would
+        // succeed and then every write would fail, far enough from this call
+        // that the two are hard to connect. Checked here rather than in
+        // `build_config` because `create_vault` legitimately runs that before
+        // the directory exists.
+        if write_backend == WriteBackend::Git
+            && let Err(error) = VaultRepo::open(&expanded_path)
+        {
+            return Err(Error::config_error(format!(
+                "Vault '{name}' requested write_backend=git, but {} is not a git repository: {error}. \
+                 Run `git init` there, or register it with write_backend=direct.",
+                expanded_path.display()
+            )));
+        }
+
         // Create vault config
         let config = Self::build_config(name, &expanded_path, write_backend, backend_opts)?;
 

--- a/crates/turbovault-tools/tests/test_vault_lifecycle.rs
+++ b/crates/turbovault-tools/tests/test_vault_lifecycle.rs
@@ -216,3 +216,51 @@ async fn lifecycle_rejects_invalid_names_templates_paths_and_duplicates() {
     assert!(tools.set_active_vault("unknown").await.is_err());
     assert!(tools.remove_vault("unknown").await.is_err());
 }
+
+/// Registering a plain directory as a git-backed vault used to succeed and then
+/// fail on the first write, far enough from the registration call that the two
+/// were hard to connect. It has to fail here instead, and say what to do.
+#[tokio::test]
+async fn registering_a_non_repository_as_git_backed_fails_at_registration() {
+    let root = TempDir::new().expect("vault root");
+    let tools = lifecycle_tools();
+
+    let error = tools
+        .add_vault_from_path("notes", root.path(), WriteBackend::Git, None)
+        .await
+        .expect_err("git backend over a non-repository must be refused");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("not a git repository"),
+        "error should name the cause, got: {message}"
+    );
+    assert!(
+        message.contains("git init"),
+        "error should say how to fix it, got: {message}"
+    );
+
+    // Nothing was registered, so the name stays free for a corrected retry.
+    assert!(
+        tools
+            .add_vault_from_path("notes", root.path(), WriteBackend::Direct, None)
+            .await
+            .is_ok(),
+        "a refused registration must not consume the vault name"
+    );
+}
+
+/// The same directory, once it really is a repository, registers fine. Without
+/// this the test above would pass for the wrong reason if the git backend were
+/// broken outright.
+#[tokio::test]
+async fn registering_a_real_repository_as_git_backed_succeeds() {
+    let root = TempDir::new().expect("vault root");
+    git2::Repository::init(root.path()).expect("git fixture");
+    let tools = lifecycle_tools();
+
+    tools
+        .add_vault_from_path("notes", root.path(), WriteBackend::Git, None)
+        .await
+        .expect("a real repository must register with the git backend");
+}


### PR DESCRIPTION
Follow-up I promised on #50.

`add_vault` with `write_backend: "git"` against a directory that is not a git repository registered fine and then failed on every write, far enough from the registration call that the two were hard to connect. It now fails at registration and says to run `git init` or use `direct`.

The check sits in `add_vault_from_path` rather than `build_config`, because `create_vault` calls `build_config` before the directory exists (deliberately, so a rejected backend selection cannot leave a half-created vault behind), and a check there would make creating a new git-backed vault impossible. It uses `VaultRepo::open` rather than `is_git_repo` so a `.git` that exists but is unusable gets caught too.

This mirrors @dlobue's `direct_over_git_repo_warning` from #50, which covers the opposite mistake.

Two tests. The refusal names both the cause and the fix, and leaves the vault name free for a corrected retry. A real repository still registers, which is there so the first test cannot pass for the wrong reason. Checked that the first fails without the change.

1285 tests passing, clippy and fmt clean.