### PR TITLE
chore(release): prepare 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-28
+
+**If you use TurboVault as an MCP server, nothing you do changes.** No tool was removed or renamed,
+no argument changed meaning, and every new parameter is optional. Existing YAML config keeps working,
+`watch_for_changes` included. The major version is for the Rust crates, which have source-breaking
+changes; see Migration below.
+
 Most of this release came from outside the maintainers. The plugin architecture was argued into
 shape by [@ForrestThump](https://github.com/ForrestThump) across #33, #42 and #43 before a line of
 it was written; the write substrate and everything that now guarantees a write either lands or
@@ -78,14 +85,42 @@ refuses is [@dlobue](https://github.com/dlobue)'s; partial reads are
 - **Protected directories are enforced at the access boundary**: `excluded_paths` (`.obsidian`, `.git`, `node_modules`, `.DS_Store` by default) and the non-configurable `.turbovault/` state directory were previously applied only when scanning for notes, so `read_note`/`write_note` could reach them by path on both backends. Writing `.obsidian/plugins/*/main.js` or `.git/hooks/*` is code execution by another name, and `.turbovault/` holds the audit trail. Both backends now refuse; the plugin config capability is the only sanctioned exception and is per-plugin and path-scoped.
 - **`max_file_size` is enforced on reads and writes**, not only while scanning directories, so an explicit read can no longer pull an arbitrarily large file into memory.
 - **`WritePrecondition::CreateOnly` is atomic on both backends.** It used to be a check-then-write, which let two concurrent create-only writers both observe the path as free and both proceed, producing the blind overwrite the precondition exists to prevent. The single write chokepoint ([#44](https://github.com/Epistates/turbovault/pull/44)) now checks `ExpectAbsent` and applies under one lock on the direct backend, and through the commit's compare-and-swap on Git.
-
-### Security
-
 - **Cleared four advisories in the dependency lock**: `h2` 0.4.14 to 0.4.18 (RUSTSEC-2026-0258, unbounded empty DATA frames) and `rkyv` 0.8.16 to 0.8.17 (RUSTSEC-2026-0233, -0234 and -0235, use-after-free and out-of-bounds reads on crafted archives). `rust_decimal` moves to 1.42.1 alongside them.
 
   One advisory is left, and is now recorded in `.cargo/audit.toml` with the reason: `rkyv` 0.7.46 arrives through `rust_decimal` and GlueSQL, wants a major bump neither has made, and is only reachable under the default-off `sql` feature.
 
 - **CI audits on a schedule, not only on a diff**: advisories get published against code that has not changed, so a job wired to push and pull request alone kept reporting green on a `main` that had gone unaudited for weeks. All four of these landed in that window. CI now also runs weekly.
+
+### Migration
+
+Only affects code depending on the library crates. MCP clients and YAML config are unaffected.
+
+- **`VaultConfig::watch_for_changes` is now `reconcile_external_changes`.** Config files are covered
+  by a serde alias, so only Rust code touching the field needs updating. It also does something now:
+  before, nothing read it at all.
+
+- **`ApplyOutcome` no longer implements `Clone`.** It carries an `Error` (which wraps `io::Error`)
+  so a partially-applied plan can report what stopped it. Clone the fields you need instead. It also
+  gained `error`, and `atomic`/`failed_at` now carry real values rather than being hardcoded.
+
+- **`VaultLifecycleTools::create_vault` and `add_vault_from_path` take two more arguments**,
+  `write_backend: WriteBackend` and `backend_opts: Option<VaultGitConfig>`. Pass
+  `(WriteBackend::Direct, None)` to keep the old behaviour.
+
+- **`WriteBackend` parses through `FromStr`** rather than an inherent method, so use
+  `value.parse::<WriteBackend>()`.
+
+- **The vault change-listener reports `(path, present, origin)`** instead of `(path, present)`, and
+  returns a future the manager awaits rather than being spawned. A listener must never call back
+  into the manager's freshness gate, since it runs inside one.
+
+- **`ContentBlock::Blockquote::content` keeps its line breaks.** It used to concatenate body lines
+  with no separator. Anything that parsed the joined string, for example splitting a callout marker
+  from its body, wants revisiting; that code was almost certainly working around this bug.
+
+- **`turbovault-plugin-api` is published separately at `0.1.0`**, not at the workspace version. The
+  plugin contract has no external implementors yet and needs room to move without forcing a major on
+  everything else.
 
 ## [1.6.0] - 2026-07-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5227,7 +5227,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-audit"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "log",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-batch"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "schemars",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-core"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "log",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-export"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "serde",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-git"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "criterion",
  "git2",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-graph"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-parser"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "log",
  "pulldown-cmark",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-plugin-api"
-version = "1.6.0"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-sql"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "gluesql",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-tools"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5393,7 +5393,7 @@ dependencies = [
 
 [[package]]
 name = "turbovault-vault"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.6.0"
+version = "2.0.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Epistates, Inc <nick@epistates.com>"]
@@ -109,18 +109,21 @@ git2 = "0.21"             # in-memory index, blob/tree/commit plumbing, ref CAS 
 # sonic-rs = "0.3"         # Fastest JSON parser, deferred optimization
 
 # Workspace crates
-turbovault-core = { version = "1.6.0", path = "crates/turbovault-core" }
-turbovault-parser = { version = "1.6.0", path = "crates/turbovault-parser" }
-turbovault-graph = { version = "1.6.0", path = "crates/turbovault-graph" }
-turbovault-vault = { version = "1.6.0", path = "crates/turbovault-vault" }
-turbovault-batch = { version = "1.6.0", path = "crates/turbovault-batch" }
-turbovault-export = { version = "1.6.0", path = "crates/turbovault-export" }
-turbovault-audit = { version = "1.6.0", path = "crates/turbovault-audit" }
-turbovault-git = { version = "1.6.0", path = "crates/turbovault-git" }
-turbovault-sql = { version = "1.6.0", path = "crates/turbovault-sql" }
-turbovault-tools = { version = "1.6.0", path = "crates/turbovault-tools" }
-turbovault-plugin-api = { version = "1.6.0", path = "crates/turbovault-plugin-api" }
-turbovault = { version = "1.6.0", path = "crates/turbovault" }
+turbovault-core = { version = "2.0.0", path = "crates/turbovault-core" }
+turbovault-parser = { version = "2.0.0", path = "crates/turbovault-parser" }
+turbovault-graph = { version = "2.0.0", path = "crates/turbovault-graph" }
+turbovault-vault = { version = "2.0.0", path = "crates/turbovault-vault" }
+turbovault-batch = { version = "2.0.0", path = "crates/turbovault-batch" }
+turbovault-export = { version = "2.0.0", path = "crates/turbovault-export" }
+turbovault-audit = { version = "2.0.0", path = "crates/turbovault-audit" }
+turbovault-git = { version = "2.0.0", path = "crates/turbovault-git" }
+turbovault-sql = { version = "2.0.0", path = "crates/turbovault-sql" }
+turbovault-tools = { version = "2.0.0", path = "crates/turbovault-tools" }
+# Versioned independently of the workspace: the plugin contract has no external
+# implementors yet and needs room to change without dragging every other crate
+# to a new major. Promote it to the workspace version once it is stable.
+turbovault-plugin-api = { version = "0.1.0", path = "crates/turbovault-plugin-api" }
+turbovault = { version = "2.0.0", path = "crates/turbovault" }
 
 [profile.release]
 opt-level = 3

--- a/crates/turbovault-audit/Cargo.toml
+++ b/crates/turbovault-audit/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 publish = true
 description = "Operation audit trail, snapshot storage, and rollback for TurboVault"
+readme = "README.md"
 documentation = "https://docs.rs/turbovault-audit"
 
 [dependencies]

--- a/crates/turbovault-audit/README.md
+++ b/crates/turbovault-audit/README.md
@@ -1,0 +1,38 @@
+# turbovault-audit
+
+[![Crates.io](https://img.shields.io/crates/v/turbovault-audit.svg)](https://crates.io/crates/turbovault-audit)
+[![Docs.rs](https://docs.rs/turbovault-audit/badge.svg)](https://docs.rs/turbovault-audit)
+[![License](https://img.shields.io/crates/l/turbovault-audit.svg)](https://github.com/epistates/turbovault/blob/main/LICENSE)
+
+Operation audit trail, snapshot storage, and rollback for TurboVault.
+
+Records what changed a vault, keeps enough of the prior content to undo it, and
+performs the undo. State lives under the vault's `.turbovault/` directory, which
+the note APIs refuse to read or write, so an audit trail cannot be edited
+through the same surface that produced it.
+
+## What it provides
+
+- **`AuditLog`** appends an `AuditEntry` per changed path: the operation type,
+  the path, a timestamp, and an open `metadata` field the writer can use to say
+  who it was. Query it with `AuditFilter`, or summarise with `AuditStats`.
+- **`SnapshotStore`** keeps the pre-change bytes for a path, content-addressed,
+  so a rollback has something to restore.
+- **`RollbackEngine`** turns an entry back into a write. `RollbackPreview`
+  answers what a rollback would do without doing it, which matters because a
+  rollback is itself a vault mutation and gets audited like one.
+
+## Provenance is advisory
+
+`AuditEntry::metadata` carries whatever the writer put in a `ChangePlan`. It is
+useful for attributing a change and for loop prevention in an agent that watches
+the vault it writes to. It is **not** an authentication boundary: nothing
+verifies the claim, and a change made outside the process carries no metadata at
+all. Do not make a trust decision on it.
+
+## Where entries come from
+
+Callers do not usually construct entries. Every mutation in TurboVault flows
+through one write chokepoint, and the direct substrate records the audit entry
+there, so a new write path inherits the trail without opting in. On the Git
+backend the commit history is the durable record and this trail complements it.

--- a/crates/turbovault-git/Cargo.toml
+++ b/crates/turbovault-git/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 publish = true
 description = "Git-native write substrate for TurboVault: every mutation is a commit (blobs -> isolated index -> tree -> commit -> ref CAS -> materialize)"
+readme = "README.md"
 documentation = "https://docs.rs/turbovault-git"
 
 [dependencies]

--- a/crates/turbovault-git/README.md
+++ b/crates/turbovault-git/README.md
@@ -1,0 +1,43 @@
+# turbovault-git
+
+[![Crates.io](https://img.shields.io/crates/v/turbovault-git.svg)](https://crates.io/crates/turbovault-git)
+[![Docs.rs](https://docs.rs/turbovault-git/badge.svg)](https://docs.rs/turbovault-git)
+[![License](https://img.shields.io/crates/l/turbovault-git.svg)](https://github.com/epistates/turbovault/blob/main/LICENSE)
+
+Git-native write substrate for TurboVault: every mutation is a commit.
+
+A vault backed by this crate gets the guarantees git already has. A write either
+lands whole or does not land, concurrent writers cannot silently clobber each
+other, and the history of who changed what is the repository itself rather than
+a log beside it.
+
+## How a write happens
+
+Blobs are written, assembled into an isolated index, turned into a tree, then a
+commit, and the branch ref is moved by compare-and-swap. Only after the ref
+moves is the working tree materialized to match.
+
+The CAS on the ref is the part that matters. Two writers racing the same vault
+both build their commits, and the loser's ref update fails rather than
+overwriting. The caller re-reads and retries against what actually landed, so
+the loser's change is never silently dropped.
+
+## What it provides
+
+- **`VaultRepo`** opens a vault as a repository and is the entry point for
+  commits. `CommitHook` observes commits as they are made.
+- **`CommitLocks`** serialises in-process writers to one repository, so the CAS
+  handles cross-process races and the lock registry handles the cheap local
+  case.
+- **`FanoutWorktree`** runs a multi-note operation on an isolated branch and
+  merges it back (`MergeStrategy`, `MergeBackResult`). `OrphanFanout` finds
+  worktrees a crashed session left behind.
+- **`ChangesetResult`**, **`TreeChange`** and **`PathChange`** describe what a
+  commit did, which is what the caller needs to update its indexes.
+
+## Requirements and scope
+
+The vault path must already be a git repository. This crate never runs the `git`
+binary; it uses `git2`/libgit2 directly, so there is no shell to inject into.
+Remotes are out of scope: it commits locally, and pushing or pulling stays the
+operator's business.

--- a/crates/turbovault-plugin-api/Cargo.toml
+++ b/crates/turbovault-plugin-api/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "turbovault-plugin-api"
-version.workspace = true
+# Not `version.workspace`: the plugin contract is versioned on its own so it can
+# change shape without forcing a major on crates that do not depend on it. It
+# joins the workspace version once there is an external plugin to break.
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/turbovault/src/tools/providers.rs
+++ b/crates/turbovault/src/tools/providers.rs
@@ -1435,6 +1435,17 @@ mod tests {
             server.server_info().description.is_none(),
             "default server must not inject plugin guidance"
         );
+        // The version on the wire is derived from the crate, not from the
+        // `version = "..."` literal each provider passes to `#[turbomcp::server]`.
+        // Those literals are overridden by this impl and never reach a client,
+        // so they drift at every release without anyone noticing. This pins the
+        // one that matters, and fails if someone "fixes" the drift by
+        // hardcoding it here instead.
+        assert_eq!(
+            server.server_info().version,
+            env!("CARGO_PKG_VERSION"),
+            "served version must track the crate version"
+        );
         #[cfg(feature = "plugin-api")]
         for tool in server.list_tools() {
             validate_mcp_tool_name(&tool.name).expect("core tool name must conform to MCP SEP-986");

--- a/crates/turbovault/src/tools/providers/analysis.rs
+++ b/crates/turbovault/src/tools/providers/analysis.rs
@@ -22,7 +22,7 @@ impl Deref for AnalysisProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl AnalysisProvider {
     // ─── DIFF TOOLS ──────────────────────────────────────────────────
 

--- a/crates/turbovault/src/tools/providers/audit.rs
+++ b/crates/turbovault/src/tools/providers/audit.rs
@@ -21,7 +21,7 @@ impl Deref for AuditProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl AuditProvider {
     // ─── AUDIT TOOLS ─────────────────────────────────────────────────
 

--- a/crates/turbovault/src/tools/providers/batch.rs
+++ b/crates/turbovault/src/tools/providers/batch.rs
@@ -21,7 +21,7 @@ impl Deref for BatchProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl BatchProvider {
     // ==================== Batch Operations ====================
 

--- a/crates/turbovault/src/tools/providers/content.rs
+++ b/crates/turbovault/src/tools/providers/content.rs
@@ -21,7 +21,7 @@ impl Deref for ContentProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl ContentProvider {
     // ==================== Resources (OFM Knowledge Injection) ====================
 

--- a/crates/turbovault/src/tools/providers/context.rs
+++ b/crates/turbovault/src/tools/providers/context.rs
@@ -21,7 +21,7 @@ impl Deref for ContextProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl ContextProvider {
     // ==================== Vault Context (LLM Discovery) ====================
 

--- a/crates/turbovault/src/tools/providers/discovery.rs
+++ b/crates/turbovault/src/tools/providers/discovery.rs
@@ -21,7 +21,7 @@ impl Deref for DiscoveryProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl DiscoveryProvider {
     // ==================== Search (LLM Discovery) ====================
 

--- a/crates/turbovault/src/tools/providers/export.rs
+++ b/crates/turbovault/src/tools/providers/export.rs
@@ -21,7 +21,7 @@ impl Deref for ExportProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl ExportProvider {
     // ==================== Export Operations ====================
 

--- a/crates/turbovault/src/tools/providers/fanout.rs
+++ b/crates/turbovault/src/tools/providers/fanout.rs
@@ -54,7 +54,7 @@ impl Deref for FanoutProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl FanoutProvider {
     #[tool(
         description = "Open an isolated Git worktree for parallel agent writes. Fanout provides isolation, while batch_execute provides all-or-nothing multi-file atomicity.",

--- a/crates/turbovault/src/tools/providers/files.rs
+++ b/crates/turbovault/src/tools/providers/files.rs
@@ -34,7 +34,7 @@ struct PartialReadPayload<'a> {
     slice: SliceResult,
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl FileProvider {
     // ==================== File Operations ====================
 

--- a/crates/turbovault/src/tools/providers/graph.rs
+++ b/crates/turbovault/src/tools/providers/graph.rs
@@ -21,7 +21,7 @@ impl Deref for GraphProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl GraphProvider {
     // ==================== Search & Links ====================
 

--- a/crates/turbovault/src/tools/providers/metadata.rs
+++ b/crates/turbovault/src/tools/providers/metadata.rs
@@ -21,7 +21,7 @@ impl Deref for MetadataProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl MetadataProvider {
     // ==================== Metadata Operations ====================
 

--- a/crates/turbovault/src/tools/providers/relationship.rs
+++ b/crates/turbovault/src/tools/providers/relationship.rs
@@ -21,7 +21,7 @@ impl Deref for RelationshipProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl RelationshipProvider {
     // ==================== Relationship Operations ====================
 

--- a/crates/turbovault/src/tools/providers/templates.rs
+++ b/crates/turbovault/src/tools/providers/templates.rs
@@ -21,7 +21,7 @@ impl Deref for TemplateProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl TemplateProvider {
     // ==================== Templates (LLM Note Creation) ====================
 

--- a/crates/turbovault/src/tools/providers/vault.rs
+++ b/crates/turbovault/src/tools/providers/vault.rs
@@ -50,7 +50,7 @@ impl Deref for VaultProvider {
     }
 }
 
-#[turbomcp::server(name = "obsidian-vault", version = "1.6.0")]
+#[turbomcp::server(name = "obsidian-vault", version = "2.0.0")]
 impl VaultProvider {
     // ==================== Vault Lifecycle (Multi-Vault Management) ====================
 


### PR DESCRIPTION
Major rather than minor because the library crates have source-breaking changes and they are published. `turbovault` and `turbovault-core` are on crates.io at 1.6.0, so someone can already be depending on them.

**The MCP surface is untouched.** No tool removed or renamed, no argument changed meaning, every new parameter optional, and existing YAML config keeps working (`watch_for_changes` included, via a serde alias). The release notes lead with that so nobody reads the major bump as a migration they have to do.

## The breaks

Three confirmed, each with its fix under Migration in the changelog:

- `VaultConfig::watch_for_changes` is now `reconcile_external_changes`. Config files are covered by the alias; Rust code touching the field is not.
- `ApplyOutcome` lost `Clone`, since it now carries an `Error` so a partially-applied plan can report what stopped it.
- `VaultLifecycleTools::create_vault` and `add_vault_from_path` each take two more arguments.

The change-listener signature and `ContentBlock::Blockquote::content` semantics moved too, both documented.

## turbovault-plugin-api at 0.1.0

Versioned independently of the workspace. It is new, unpublished, and has no external implementors, so tying it to the workspace version would either freeze the contract or drag every other crate to 3.0.0 the first time it moves. It joins the workspace version once there is an external plugin to break.

## Incidental findings

The 14 `version = "1.6.0"` literals the providers pass to `#[turbomcp::server]` are updated, but they never reach a client: `ObsidianMcpServer` overrides `server_info` and derives the version from `CARGO_PKG_VERSION`. A test now pins that, and fails if someone "fixes" the apparent drift by hardcoding it in the override instead.

`turbovault-audit` and `turbovault-git` had no README despite being published, so their crates.io pages were bare while every sibling had one. Added. The `!crates/*/README.md` gitignore rule from #57 is what kept them from being silently ignored.

The Unreleased section had picked up two `### Security` headings from a merge. Merged.

## Verification

1285 tests passing, clippy clean on `--all-features`, fmt clean, `cargo audit` exits 0, and `cargo package -p turbovault-core` succeeds.