### PR TITLE
test(plugin-api): bound the event waits so a missing event fails, not hangs

### DIFF
--- a/crates/turbovault/tests/test_plugin_boundary.rs
+++ b/crates/turbovault/tests/test_plugin_boundary.rs
@@ -17,12 +17,27 @@ use turbovault_plugin_api::{
     HookEvent, HookRecvError, HookSubscription, Plugin, PluginCapabilities, PluginContext,
     PluginDescriptor, PluginError, PluginProvider, PluginRequestContext, PluginResult,
     PluginStorage, Prompt, PromptResult, Resource, ResourceResult, ResourceTemplate,
-    ShutdownSignal, Tool, ToolResult, VaultApi, WriteNoteRequest, WritePrecondition,
-    WriteProvenance,
+    ShutdownSignal, Tool, ToolResult, VaultApi, VaultEventEnvelope, WriteNoteRequest,
+    WritePrecondition, WriteProvenance,
 };
 
 /// Where the probe plugin persists its position in the event feed.
 const CURSOR_KEY: &str = "feed/cursor.json";
+
+/// Await the next event, failing rather than blocking if it never arrives.
+///
+/// A bare `recv().await` on a bus that publishes nothing waits forever, so a
+/// regression that stops core writes reaching subscribers presents as a CI
+/// timeout with no indication of which assertion was waiting. These publishes
+/// are synchronous with the write, so five seconds is orders of magnitude more
+/// than they need and still reads as a failure rather than a hang.
+async fn next_event(events: &mut HookSubscription, what: &str) -> VaultEventEnvelope {
+    match tokio::time::timeout(std::time::Duration::from_secs(5), events.recv()).await {
+        Ok(Ok(envelope)) => envelope,
+        Ok(Err(e)) => panic!("expected {what}, but the feed errored: {e:?}"),
+        Err(_) => panic!("timed out waiting for {what}: nothing was published"),
+    }
+}
 
 /// A plugin that exercises the curated API and can be told to misbehave.
 struct ProbePlugin {
@@ -437,7 +452,7 @@ async fn core_mcp_writes_reach_plugin_subscribers() {
         .await
         .expect("core write");
 
-    let created = events.recv().await.expect("core write event");
+    let created = next_event(&mut events, "the core write event").await;
     assert_eq!(created.vault, "probe-vault");
     assert_eq!(
         created.event,
@@ -461,7 +476,7 @@ async fn core_mcp_writes_reach_plugin_subscribers() {
         .await
         .expect("core overwrite");
     assert_eq!(
-        events.recv().await.expect("core modify event").event,
+        next_event(&mut events, "the core modify event").await.event,
         HookEvent::FileModified {
             path: "agent.md".to_string()
         }
@@ -481,7 +496,7 @@ async fn core_mcp_writes_reach_plugin_subscribers() {
         .await
         .expect("core delete");
     assert_eq!(
-        events.recv().await.expect("core delete event").event,
+        next_event(&mut events, "the core delete event").await.event,
         HookEvent::FileDeleted {
             path: "agent.md".to_string()
         }
@@ -506,7 +521,7 @@ async fn plugin_writes_are_attributed_by_the_host_not_the_caller() {
         .await
         .expect("plugin write");
 
-    let event = events.recv().await.expect("plugin write event");
+    let event = next_event(&mut events, "the plugin write event").await;
     assert_eq!(
         event.plugin_id.as_deref(),
         Some("probe"),


### PR DESCRIPTION
Four assertions in the plugin boundary suite awaited the hook bus with a bare `recv().await`. If a regression stops core writes reaching subscribers the event never arrives, so the test blocks forever: the whole crate's test run wedges, CI hits its job timeout, and nothing says which assertion was waiting or why.

Found this while probing whether #46 merges cleanly with main. It does, apart from one trivial conflict, but the merged tree hangs, and the only way to learn it was `core_mcp_writes_reach_plugin_subscribers` was bisecting test targets by hand with an external timeout. Ten minutes of silence for what should be one failed assertion.

`next_event` wraps `recv` in a five-second timeout and panics with the name of the event it wanted. These publishes are synchronous with the write, so five seconds is orders of magnitude more than they need and still reads as a failure rather than a hang.

Verified by temporarily disabling event publication in `after_write`:

```
thread 'core_mcp_writes_reach_plugin_subscribers' panicked at tests/test_plugin_boundary.rs:38:19:
timed out waiting for the core write event: nothing was published
```

The fifth `recv` is left alone. It asserts the bus reports `Closed` after shutdown, so it terminates by construction, and that termination is the property under test.

18 tests pass in 0.78s, clippy and fmt clean.