### PR TITLE
docs: fix the intra-doc links that fail the release verify job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,12 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-features --all-targets --locked
 
+      # Must match the release workflow's verify job, `-D warnings` included.
+      # Without it a broken intra-doc link is a warning here and an error
+      # there, so the first anyone hears of it is a tag failing to release.
       - name: Build documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
         run: cargo doc --workspace --no-deps --locked
 
   coverage:

--- a/crates/turbovault-core/src/change_plan.rs
+++ b/crates/turbovault-core/src/change_plan.rs
@@ -74,7 +74,7 @@ pub struct ChangePlan {
     /// break that loop.
     ///
     /// Deliberately `serde_json::Value` rather than a typed provenance struct:
-    /// it lands verbatim in [`turbovault_audit::AuditEntry::metadata`], which
+    /// it lands verbatim in `turbovault_audit::AuditEntry::metadata`, which
     /// is already this type, so nothing here needs to know or agree on a
     /// schema. Callers put whatever they read back — provenance, correlation
     /// ids, trace context. A typed accessor can layer on top later without
@@ -221,7 +221,7 @@ impl ChangePlan {
     /// `Upsert`/`Remove`, both `from` and `to` for `Rename` (a rename removes
     /// bytes at `from` and adds them at `to`). The single source of truth for
     /// "which paths does this plan mutate" — used by the git substrate's
-    /// gitignore gate + materialize call ([`turbovault-git`]'s
+    /// gitignore gate + materialize call (`turbovault-git`'s
     /// `commit_changeset`) and by the tool layer's intra-batch path-collision
     /// check.
     pub fn touched_paths(&self) -> Vec<String> {

--- a/crates/turbovault-git/src/cas.rs
+++ b/crates/turbovault-git/src/cas.rs
@@ -26,7 +26,7 @@ impl VaultRepo {
     ///
     /// `expected_old == None` means the ref must **not** yet exist (the
     /// initial-commit case). On any mismatch returns a `ConcurrencyError` (via
-    /// [`Error::concurrency`]) with **nothing applied** — the ref is untouched.
+    /// `Error::concurrency`) with **nothing applied** — the ref is untouched.
     #[instrument(
         skip(self),
         fields(refname = %refname, expected = ?expected_old, new = %new),

--- a/crates/turbovault-git/src/changeset.rs
+++ b/crates/turbovault-git/src/changeset.rs
@@ -95,9 +95,9 @@ impl VaultRepo {
 
     /// Apply `plan` as a single commit (see the module docs for the pipeline).
     ///
-    /// Aborts with a `ConcurrencyError` (via [`Error::concurrency`]) if any
+    /// Aborts with a `ConcurrencyError` (via `Error::concurrency`) if any
     /// precondition is stale (nothing committed, working tree untouched) and
-    /// with [`Error::other`] for an empty plan or duplicate change paths.
+    /// with `Error::other` for an empty plan or duplicate change paths.
     #[instrument(
         skip(self, plan),
         fields(

--- a/crates/turbovault-git/src/error.rs
+++ b/crates/turbovault-git/src/error.rs
@@ -29,7 +29,7 @@ pub enum Error {
     /// from parsing/validating a core `ChangePlan`/`Precondition`, without
     /// this crate re-declaring core's error variants. Also where this crate's
     /// own "changed underneath us" / io / free-form errors land — see
-    /// [`Error::concurrency`] / [`Error::other`] / `From<std::io::Error>`.
+    /// `Error::concurrency` / `Error::other` / `From<std::io::Error>`.
     #[error(transparent)]
     Core(#[from] turbovault_core::Error),
 }

--- a/crates/turbovault-git/src/occ.rs
+++ b/crates/turbovault-git/src/occ.rs
@@ -40,7 +40,7 @@ impl VaultRepo {
     /// Validate every `(path, Precondition)` against `base_tree` (the tree the
     /// changeset is building on; `None` = an empty/unborn base where nothing
     /// exists). Returns `Ok(())` only if **all** match; the first mismatch
-    /// aborts with a `ConcurrencyError` (via [`Error::concurrency`]; the whole
+    /// aborts with a `ConcurrencyError` (via `Error::concurrency`; the whole
     /// changeset fails, nothing applied).
     #[instrument(
         skip(self, preconditions),

--- a/crates/turbovault-tools/src/batch_tools.rs
+++ b/crates/turbovault-tools/src/batch_tools.rs
@@ -238,7 +238,7 @@ impl BatchTools {
     /// Atomic move + inbound-wikilink rewrite through the manager (both
     /// substrates). Flushes the reindex queue first so the backlink resolution
     /// reads a coherent link graph (replaces the MCP layer's pre-move flush),
-    /// builds the one-plan rename+rewrite via [`Self::fold_move_with_links`],
+    /// builds the one-plan rename+rewrite via `Self::fold_move_with_links`,
     /// and applies it via [`VaultManager::apply_changes`]. Returns the
     /// vault-relative source paths whose wikilinks were rewritten. `message`
     /// is the git commit subject (ignored on direct).

--- a/crates/turbovault-tools/src/file_tools.rs
+++ b/crates/turbovault-tools/src/file_tools.rs
@@ -53,7 +53,7 @@ pub struct NoteInfo {
 ///
 /// This mirrors the flat, all-optional shape the MCP tool layer receives, so
 /// every field is independently settable and some combinations are nonsense.
-/// [`SliceSpec::selector`] converts it into a [`Selector`], which can only
+/// `SliceSpec::selector` converts it into a `Selector`, which can only
 /// represent a valid request.
 ///
 /// A default (all-`None`) spec selects nothing, and [`slice_content`] reports

--- a/crates/turbovault-vault/src/manager.rs
+++ b/crates/turbovault-vault/src/manager.rs
@@ -791,8 +791,8 @@ impl VaultManager {
     /// one. The comparison is a scan of `(size, mtime)` against what the note
     /// cache recorded when it parsed each note, debounced so a burst of calls
     /// pays for one pass. What it costs is bounded by
-    /// [`RECONCILE_DUTY_DIVISOR`]; how stale an answer can be is bounded by
-    /// [`ReconcileState::interval`].
+    /// `RECONCILE_DUTY_DIVISOR`; how stale an answer can be is bounded by
+    /// `ReconcileState::interval`.
     ///
     /// The two halves run in this order on purpose. Draining first settles any
     /// commit this process has already been told about and records the
@@ -1164,7 +1164,7 @@ impl VaultManager {
     /// themselves (`Precondition::for_replace` for the historical "no hash =
     /// blind overwrite-or-create" default) and supply the plan's `message`.
     /// This method builds the one-change [`ChangePlan`]
-    /// and delegates to [`Self::substrate`]; the fs-write + precondition +
+    /// and delegates to `self.substrate`; the fs-write + precondition +
     /// audit work itself lives in `DirectSubstrate::apply`. This method only
     /// does path resolution and the post-apply link-graph/cache sync (R7).
     #[instrument(skip(self, content), fields(file = ?path, size = content.len()), name = "vault_write_file")]

--- a/crates/turbovault/src/tools/providers.rs
+++ b/crates/turbovault/src/tools/providers.rs
@@ -760,7 +760,7 @@ impl ObsidianMcpServer {
     /// signal handler as well as after the transport's `serve()` returns.
     ///
     /// Closes the plugin hook bus so subscribers observe
-    /// [`turbovault_plugin_api::HookRecvError::Closed`] instead of waiting
+    /// `turbovault_plugin_api::HookRecvError::Closed` instead of waiting
     /// forever, then abandons fanout worktrees registered by this process.
     pub async fn shutdown(&self) {
         #[cfg(feature = "plugin-api")]


### PR DESCRIPTION
Tagging `v2.0.0` would have failed before building a single binary.

`cargo doc --workspace --no-deps --locked` with `RUSTDOCFLAGS="-D warnings"` fails on main today, and that is exactly what the release workflow's verify job runs. Found it while verifying main was release-ready.

CI already built documentation, just without `-D warnings`, so a broken intra-doc link passed here as a warning and failed there as an error. Nobody would learn about it until a tag refused to release, which is why thirteen accumulated since v1.6.0.

## The links

Two shapes, six crates:

- **Public docs linking to private items:** `Error::concurrency` and `Error::other` (both `pub(crate)` constructors), `RECONCILE_DUTY_DIVISOR`, `ReconcileState::interval`, `Self::substrate`, `Self::fold_move_with_links`, `SliceSpec::selector`, `Selector`.
- **Links across a dependency edge that does not exist:** `turbovault-core` pointing at `turbovault_audit` and `turbovault-git`, and `turbovault` pointing at `turbovault_plugin_api`, which sits behind an off-by-default feature.

Each becomes a plain code span. The prose still names the thing, it just stops claiming to be a resolvable link. No public API moved and nothing was made public to satisfy a link.

## The gap that let it happen

The second commit sets `RUSTDOCFLAGS: -D warnings` on CI's existing doc step so the two commands match. The next broken link fails on the PR that introduces it.

## Verification

Both doc configurations clean: the release-gate command, and `--all-features`, which is how docs.rs builds these crates (`[package.metadata.docs.rs] all-features = true`). A failure there would have published the crates with no documentation at all.

1285 tests passing, clippy and fmt clean.