### PR TITLE
fix(mcp): hoist $defs to the schema root so strict clients accept our tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ refuses is [@dlobue](https://github.com/dlobue)'s; partial reads are
 
 ### Fixed
 
+- **Tool schemas are valid JSON Schema again** ([#51](https://github.com/Epistates/turbovault/issues/51)): every `$defs` now sits at the root of a tool's `inputSchema`, where its `#/$defs/...` pointers can resolve. They were emitted one level down, inside the property that referenced them, so a strict consumer could not resolve any of them. llama.cpp's `llama-server` rejects the whole request with HTTP 400 when one such tool is present, taking the entire catalog offline for that host, and clients that skip validation quietly lose grammar-constrained argument generation and start sending malformed arguments. `advanced_search` and `batch_execute` were affected, as would be any tool taking a struct or enum parameter.
+
+  The cause is upstream in `turbomcp-macros`, which builds the schema one parameter at a time and nests each parameter's whole root document under `properties`. Still present in 3.2.0, so TurboVault hoists them itself for now. Reported by [@tiborkiss](https://github.com/tiborkiss) with a minimal repro.
+
 - **Registering a git-backed vault checks for a repository first.** `add_vault` with
   `write_backend: "git"` against a directory that is not a git repository used to register
   successfully and then fail on every write, far enough from the registration call that the two were

--- a/crates/turbovault/src/tools/providers.rs
+++ b/crates/turbovault/src/tools/providers.rs
@@ -22,6 +22,8 @@ mod vault;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use serde_json::Value;
+
 use anyhow::{Result, anyhow};
 use turbomcp::ServerCapabilities;
 use turbomcp::prelude::*;
@@ -92,6 +94,86 @@ impl VaultEventSink for HookBusSink {
         let _ = self
             .hooks
             .publish(vault, event, content_hash, plugin_id, event_attribution);
+    }
+}
+
+/// Lift every `$defs` in a tool's input schema to the schema root, and strip
+/// the root-schema artifacts that come with it.
+///
+/// `turbomcp-macros` builds an input schema one parameter at a time, calling
+/// `schemars::schema_for!` per parameter and inserting the resulting *root*
+/// schema whole as the property value. A root schema carries `$schema`,
+/// `title`, and any `$defs` its type needs, and the `$ref`s schemars generates
+/// are root-relative because from its own point of view it *is* the root.
+/// Nesting that document under `properties.<name>` moves the definitions
+/// without rewriting the pointers, so `#/$defs/Foo` resolves against a
+/// document root that has no `$defs` at all.
+///
+/// Consumers that resolve `#/$defs/...` correctly then reject the tool.
+/// llama.cpp's `llama-server` fails the whole request with HTTP 400 as soon as
+/// one such tool is present, taking the entire catalog offline for that host
+/// (Epistates/turbovault#51). Hosts that do not validate lose grammar-
+/// constrained argument generation and start producing malformed arguments.
+///
+/// This is a workaround for the upstream defect, still present in
+/// turbomcp-macros 3.2.0, and should be deleted once a release generates the
+/// schema from a single args struct.
+fn hoist_schema_defs(tool: &mut Tool) {
+    /// Recursively take `$defs` out of a subschema, merging into `collected`.
+    /// Also drops `$schema` and `title`, which are meaningful on a root
+    /// document and noise on a property (a subschema may not redeclare the
+    /// dialect, and the title is a generated Rust type name).
+    fn strip(value: &mut serde_json::Value, collected: &mut serde_json::Map<String, Value>) {
+        match value {
+            Value::Object(map) => {
+                if let Some(Value::Object(defs)) = map.remove("$defs") {
+                    for (name, schema) in defs {
+                        // schemars names a definition after its type, so the
+                        // same name is the same type and merging is safe.
+                        // Two different shapes under one name would mean a
+                        // silently wrong schema, so refuse rather than guess.
+                        if let Some(existing) = collected.get(&name) {
+                            debug_assert_eq!(
+                                existing, &schema,
+                                "two different definitions named {name:?} in one tool schema"
+                            );
+                        } else {
+                            collected.insert(name, schema);
+                        }
+                    }
+                }
+                map.remove("$schema");
+                map.remove("title");
+                for nested in map.values_mut() {
+                    strip(nested, collected);
+                }
+            }
+            Value::Array(items) => {
+                for item in items {
+                    strip(item, collected);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let Some(properties) = tool.input_schema.properties.as_mut() else {
+        return;
+    };
+    let mut collected = serde_json::Map::new();
+    strip(properties, &mut collected);
+    if collected.is_empty() {
+        return;
+    }
+    // Merge rather than replace: a root `$defs` could already exist, and the
+    // definitions lifted out of the properties belong beside it.
+    match tool.input_schema.extra_keywords.get_mut("$defs") {
+        Some(Value::Object(root)) => root.extend(collected),
+        _ => {
+            tool.input_schema
+                .extra_keywords
+                .insert("$defs".to_string(), Value::Object(collected));
+        }
     }
 }
 
@@ -681,6 +763,14 @@ impl ObsidianMcpServer {
 
             (hooks, shutdown, mounted_plugins)
         };
+
+        // Applied once over the assembled catalog rather than at each push, so
+        // core and plugin tools get the same treatment and a future mount site
+        // cannot forget it.
+        let mut tools = tools;
+        for tool in &mut tools {
+            hoist_schema_defs(tool);
+        }
 
         Ok(Self {
             core,
@@ -1392,12 +1482,122 @@ mod tests {
         );
     }
 
+    /// Rebuild `value` with every object's keys in sorted order.
+    ///
+    /// `ToolInputSchema::extra_keywords` is a `HashMap` serialized with
+    /// `#[serde(flatten)]`, so its keys come out in the map's iteration order,
+    /// which std randomizes per process. With one extra keyword that was
+    /// invisible; a schema carrying both `$schema` and a hoisted `$defs` makes
+    /// the byte comparison below fail on roughly two runs in three. Sorting
+    /// gives the fixture one spelling regardless of how the map iterated.
+    fn canonical_json(value: &Value) -> Value {
+        match value {
+            Value::Object(map) => {
+                let mut sorted: Vec<_> = map.iter().collect();
+                sorted.sort_by_key(|(key, _)| *key);
+                Value::Object(
+                    sorted
+                        .into_iter()
+                        .map(|(k, v)| (k.clone(), canonical_json(v)))
+                        .collect(),
+                )
+            }
+            Value::Array(items) => Value::Array(items.iter().map(canonical_json).collect()),
+            other => other.clone(),
+        }
+    }
+
+    /// Every `#/$defs/...` pointer a tool emits has to resolve against that
+    /// tool's own schema root, and no subschema may carry `$defs` or declare a
+    /// dialect.
+    ///
+    /// `turbomcp-macros` builds the schema per parameter and nests each
+    /// parameter's whole root document under `properties`, which strands the
+    /// definitions one level below the pointers that reference them
+    /// (Epistates/turbovault#51). A strict consumer then rejects the tool:
+    /// llama.cpp's `llama-server` fails the entire request with HTTP 400,
+    /// taking every other tool down with it.
+    ///
+    /// Asserted as a property rather than against the fixture, so it holds for
+    /// a tool nobody has added yet and for any parameter shape schemars
+    /// decides to generate a definition for.
+    #[test]
+    fn every_tool_schema_resolves_its_own_defs() {
+        let server = ObsidianMcpServer::new().expect("provider composition");
+
+        fn pointers(value: &Value, into: &mut Vec<String>) {
+            match value {
+                Value::Object(map) => {
+                    for (key, nested) in map {
+                        if key == "$ref"
+                            && let Some(target) = nested.as_str()
+                            && let Some(name) = target.strip_prefix("#/$defs/")
+                        {
+                            into.push(name.to_string());
+                        }
+                        pointers(nested, into);
+                    }
+                }
+                Value::Array(items) => items.iter().for_each(|item| pointers(item, into)),
+                _ => {}
+            }
+        }
+
+        fn nested_root_keywords(value: &Value, found: &mut Vec<&'static str>) {
+            if let Value::Object(map) = value {
+                if map.contains_key("$defs") {
+                    found.push("$defs");
+                }
+                if map.contains_key("$schema") {
+                    found.push("$schema");
+                }
+                map.values().for_each(|v| nested_root_keywords(v, found));
+            } else if let Value::Array(items) = value {
+                items.iter().for_each(|v| nested_root_keywords(v, found));
+            }
+        }
+
+        for tool in server.list_tools() {
+            let name = &tool.name;
+            let defined: Vec<String> = tool
+                .input_schema
+                .extra_keywords
+                .get("$defs")
+                .and_then(Value::as_object)
+                .map(|defs| defs.keys().cloned().collect())
+                .unwrap_or_default();
+
+            let mut referenced = Vec::new();
+            if let Some(properties) = tool.input_schema.properties.as_ref() {
+                pointers(properties, &mut referenced);
+            }
+            for target in &referenced {
+                assert!(
+                    defined.contains(target),
+                    "{name}: $ref #/$defs/{target} does not resolve; root defines {defined:?}"
+                );
+            }
+
+            // The properties are subschemas, so neither keyword belongs there.
+            let mut stray = Vec::new();
+            if let Some(properties) = tool.input_schema.properties.as_ref() {
+                nested_root_keywords(properties, &mut stray);
+            }
+            assert!(
+                stray.is_empty(),
+                "{name}: root-only keywords {stray:?} found inside properties"
+            );
+        }
+    }
+
     #[test]
     fn tools_list_is_byte_for_byte_equivalent_to_the_pre_split_catalog() {
         let server = ObsidianMcpServer::new().expect("provider composition");
         let expected = include_str!("providers/tool_catalog.json").trim_end();
-        let actual =
-            serde_json::to_string_pretty(&server.list_tools()).expect("serialize tool catalog");
+        let actual = serde_json::to_string_pretty(&canonical_json(
+            &serde_json::to_value(server.list_tools()).expect("tool catalog to json"),
+        ))
+        .expect("serialize tool catalog");
 
         assert_eq!(server.list_tools().len(), 74, "public tool count changed");
         // The fixture is a deliberate tripwire on the public tool surface, so a

--- a/crates/turbovault/src/tools/providers/tool_catalog.json
+++ b/crates/turbovault/src/tools/providers/tool_catalog.json
@@ -1,320 +1,272 @@
 [
   {
-    "name": "get_vault_context",
-    "description": "Get complete vault context (vaults, stats, capabilities, markdown dialect) in a single discovery call",
-    "inputSchema": {
-      "type": "object",
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
-    },
-    "annotations": {
-      "readOnlyHint": true
-    },
     "_meta": {
       "tags": [
         "read"
       ]
-    }
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Get complete vault context (vaults, stats, capabilities, markdown dialect) in a single discovery call",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "name": "get_vault_context"
   },
   {
-    "name": "read_note",
+    "_meta": {
+      "tags": [
+        "read"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Read markdown content of a note from active vault, either whole or a selected part",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
         "head_lines": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
-          "type": [
-            "integer",
-            "null"
-          ],
           "format": "uint",
-          "minimum": 0
-        },
-        "tail_lines": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 0
-        },
-        "heading_level": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint8",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint8",
           "minimum": 0,
-          "maximum": 255
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "heading_equals": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
           "type": [
             "string",
             "null"
           ]
         },
-        "last_sections": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
+        "heading_level": {
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
           "type": [
             "integer",
             "null"
-          ],
+          ]
+        },
+        "last_sections": {
           "format": "uint",
-          "minimum": 0
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "path": {
+          "type": "string"
+        },
+        "tail_lines": {
+          "format": "uint",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [
         "path"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "_meta": {
-      "tags": [
-        "read"
-      ]
-    }
+    "name": "read_note"
   },
   {
-    "name": "write_note",
+    "_meta": {
+      "tags": [
+        "write"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true
+    },
     "description": "Write a note with overwrite/append/prepend mode and optimistic concurrency. Existing overwrite targets require expected_hash unless force=true. Git-backed vaults commit the mutation atomically.",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
-        "content": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
-        "mode": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "commit_message": {
           "type": [
             "string",
             "null"
           ]
         },
+        "content": {
+          "type": "string"
+        },
         "expected_hash": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
           "type": [
             "string",
             "null"
           ]
         },
         "force": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_boolean",
           "type": [
             "boolean",
             "null"
           ]
         },
-        "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "mode": {
           "type": [
             "string",
             "null"
           ]
+        },
+        "path": {
+          "type": "string"
         }
       },
       "required": [
         "path",
         "content"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "destructiveHint": true
-    },
+    "name": "write_note"
+  },
+  {
     "_meta": {
       "tags": [
         "write"
       ]
-    }
-  },
-  {
-    "name": "edit_note",
+    },
+    "annotations": {
+      "destructiveHint": true
+    },
     "description": "Apply targeted edits using SEARCH/REPLACE blocks (safer than full overwrite)",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
-        "edits": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
-        "expected_hash": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "commit_message": {
           "type": [
             "string",
             "null"
           ]
         },
         "dry_run": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_boolean",
           "type": [
             "boolean",
             "null"
           ]
         },
-        "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "edits": {
+          "type": "string"
+        },
+        "expected_hash": {
           "type": [
             "string",
             "null"
           ]
+        },
+        "path": {
+          "type": "string"
         }
       },
       "required": [
         "path",
         "edits"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
+    },
+    "name": "edit_note"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "write",
+        "delete"
+      ]
     },
     "annotations": {
       "destructiveHint": true
     },
-    "_meta": {
-      "tags": [
-        "write"
-      ]
-    }
-  },
-  {
-    "name": "delete_note",
     "description": "Delete a note with confirmation, concurrency protection, and backlink safety. By default refuses when inbound links exist; use on_backlinks='rewrite-stale-callout' for an atomic delete+rewrite, or force=true to leave broken links.",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
-        "confirm_path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
-        "expected_hash": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "commit_message": {
           "type": [
             "string",
             "null"
           ]
         },
-        "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "confirm_path": {
+          "type": "string"
+        },
+        "expected_hash": {
           "type": [
             "string",
             "null"
           ]
         },
         "force": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_boolean",
           "type": [
             "boolean",
             "null"
           ]
         },
         "on_backlinks": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
           "type": [
             "string",
             "null"
           ]
+        },
+        "path": {
+          "type": "string"
         }
       },
       "required": [
         "path",
         "confirm_path"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
+    },
+    "name": "delete_note"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "write"
+      ]
     },
     "annotations": {
       "destructiveHint": true
     },
-    "_meta": {
-      "tags": [
-        "write",
-        "delete"
-      ]
-    }
-  },
-  {
-    "name": "move_note",
     "description": "Move or rename a note. Git-backed vaults update inbound wikilinks atomically by default; set update_backlinks=false for a rename-only operation.",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
+        "commit_message": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expected_hash": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "from": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
         "to": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
-        "expected_hash": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "update_backlinks": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_boolean",
           "type": [
             "boolean",
             "null"
@@ -325,400 +277,375 @@
         "from",
         "to"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "destructiveHint": true
-    },
-    "_meta": {
-      "tags": [
-        "write"
-      ]
-    }
+    "name": "move_note"
   },
   {
-    "name": "get_backlinks",
+    "_meta": {
+      "tags": [
+        "read",
+        "graph"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Find all notes that link TO this note (incoming links)",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "path"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "get_backlinks"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "graph"
       ]
-    }
-  },
-  {
-    "name": "get_forward_links",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Find all notes that this note links TO (outgoing links)",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "path"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "get_forward_links"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "graph"
       ]
-    }
-  },
-  {
-    "name": "get_related_notes",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Find notes connected within N hops in the link graph (default 2 hops)",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
         "max_hops": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
+          "format": "uint",
+          "minimum": 0,
           "type": [
             "integer",
             "null"
-          ],
-          "format": "uint",
-          "minimum": 0
+          ]
+        },
+        "path": {
+          "type": "string"
         }
       },
       "required": [
         "path"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "get_related_notes"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "graph"
       ]
-    }
-  },
-  {
-    "name": "get_hub_notes",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Find the top N most connected notes in the vault (default 10). Returns notes ranked by total link count (incoming + outgoing). Hub notes are central to knowledge graph structure and often represent key concepts or index pages.",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "top_n": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
+          "format": "uint",
+          "minimum": 0,
           "type": [
             "integer",
             "null"
-          ],
-          "format": "uint",
-          "minimum": 0
+          ]
         }
       },
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "get_hub_notes"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "graph"
       ]
-    }
-  },
-  {
-    "name": "get_dead_end_notes",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Find notes with incoming links but NO outgoing links (knowledge dead-ends). Returns list of paths with backlink counts. Dead-ends may indicate incomplete notes, missing connections, or final destination topics.",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "get_dead_end_notes"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "graph"
       ]
-    }
-  },
-  {
-    "name": "get_isolated_clusters",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Find disconnected groups of notes (subgraphs with no connections to main graph). Returns clusters as arrays of paths. Isolated clusters may represent separate projects, orphaned content, or incomplete knowledge areas.",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
+    },
+    "name": "get_isolated_clusters"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "read",
+        "health"
+      ]
     },
     "annotations": {
       "readOnlyHint": true
     },
-    "_meta": {
-      "tags": [
-        "read",
-        "graph"
-      ]
-    }
-  },
-  {
-    "name": "quick_health_check",
     "description": "Perform fast health assessment of active vault returning 0-100 score",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "quick_health_check"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "health"
       ]
-    }
-  },
-  {
-    "name": "full_health_analysis",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Comprehensive vault health report with detailed metrics including broken links, orphan analysis, link density, cluster analysis, and recommendations",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "full_health_analysis"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "health"
       ]
-    }
-  },
-  {
-    "name": "get_broken_links",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Find all links pointing to non-existent notes with source path, target path, link text, and line number for each broken link",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "_meta": {
-      "tags": [
-        "read",
-        "health"
-      ]
-    }
+    "name": "get_broken_links"
   },
   {
-    "name": "detect_cycles",
-    "description": "Detect circular reference chains in the link graph returning all cycles as arrays of paths",
-    "inputSchema": {
-      "type": "object",
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
-    },
-    "annotations": {
-      "readOnlyHint": true
-    },
     "_meta": {
       "tags": [
         "read",
         "graph"
       ]
-    }
-  },
-  {
-    "name": "explain_vault",
-    "description": "Generate holistic vault overview in a single comprehensive call",
-    "inputSchema": {
-      "type": "object",
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
     },
     "annotations": {
       "readOnlyHint": true
     },
+    "description": "Detect circular reference chains in the link graph returning all cycles as arrays of paths",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "name": "detect_cycles"
+  },
+  {
     "_meta": {
       "tags": [
         "read"
       ]
-    }
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Generate holistic vault overview in a single comprehensive call",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "name": "explain_vault"
   },
   {
-    "name": "search",
+    "_meta": {
+      "tags": [
+        "read",
+        "search"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Full-text search across all notes using Tantivy search engine with BM25 ranking",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "query": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "query"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "search"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "search"
       ]
-    }
-  },
-  {
-    "name": "advanced_search",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Enhanced search with tag, frontmatter, and path filters returning ranked results with match context",
     "inputSchema": {
-      "type": "object",
-      "properties": {
-        "query": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
-        "tags": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_Array_of_string",
-          "type": [
-            "array",
-            "null"
+      "$defs": {
+        "FrontmatterFilter": {
+          "description": "A frontmatter key-value filter for advanced search",
+          "properties": {
+            "key": {
+              "description": "Frontmatter key to match (e.g. \"type\", \"status\", \"project\")",
+              "type": "string"
+            },
+            "value": {
+              "description": "Value to match against (substring match)",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "value"
           ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "exclude_paths": {
           "items": {
             "type": "string"
-          }
-        },
-        "frontmatter_filters": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_Array_of_FrontmatterFilter",
+          },
           "type": [
             "array",
             "null"
-          ],
+          ]
+        },
+        "frontmatter_filters": {
           "items": {
             "$ref": "#/$defs/FrontmatterFilter"
           },
-          "$defs": {
-            "FrontmatterFilter": {
-              "description": "A frontmatter key-value filter for advanced search",
-              "type": "object",
-              "properties": {
-                "key": {
-                  "description": "Frontmatter key to match (e.g. \"type\", \"status\", \"project\")",
-                  "type": "string"
-                },
-                "value": {
-                  "description": "Value to match against (substring match)",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "key",
-                "value"
-              ]
-            }
-          }
-        },
-        "exclude_paths": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_Array_of_string",
           "type": [
             "array",
             "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          ]
         },
         "limit": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
+          "format": "uint",
+          "minimum": 0,
           "type": [
             "integer",
             "null"
-          ],
-          "format": "uint",
-          "minimum": 0
+          ]
+        },
+        "query": {
+          "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
       "required": [
         "query"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "advanced_search"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "search"
       ]
-    }
-  },
-  {
-    "name": "search_by_frontmatter",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Find notes where a frontmatter field matches a value. Returns up to 100 results ranked by relevance",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "key": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
         "value": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
@@ -726,168 +653,154 @@
         "key",
         "value"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "search_by_frontmatter"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "search"
       ]
-    }
-  },
-  {
-    "name": "recommend_related",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "ML-powered note recommendations based on content similarity and link proximity with similarity scores and reasoning",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "path"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "_meta": {
-      "tags": [
-        "read",
-        "search"
-      ]
-    }
+    "name": "recommend_related"
   },
   {
-    "name": "inspect_frontmatter",
-    "description": "Inspect the frontmatter schema across all vault notes — shows column names, types, nullability, and counts. Call this before writing SQL queries to discover available columns",
-    "inputSchema": {
-      "type": "object",
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
-    },
-    "annotations": {
-      "readOnlyHint": true
-    },
     "_meta": {
       "tags": [
         "read",
         "frontmatter"
       ]
-    }
-  },
-  {
-    "name": "query_frontmatter_sql",
-    "description": "Execute arbitrary SQL against a 'files' table built from all vault note frontmatter. Each note becomes a row with 'path' + all frontmatter keys as columns. Supports WHERE, JOIN, GROUP BY, ORDER BY, LIMIT, subqueries, and aggregations",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "sql": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        }
-      },
-      "required": [
-        "sql"
-      ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
     },
     "annotations": {
       "readOnlyHint": true
     },
+    "description": "Inspect the frontmatter schema across all vault notes — shows column names, types, nullability, and counts. Call this before writing SQL queries to discover available columns",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "name": "inspect_frontmatter"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "frontmatter",
         "sql"
       ]
-    }
-  },
-  {
-    "name": "list_templates",
-    "description": "List all available note templates in the active vault",
-    "inputSchema": {
-      "type": "object",
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
     },
     "annotations": {
       "readOnlyHint": true
     },
+    "description": "Execute arbitrary SQL against a 'files' table built from all vault note frontmatter. Each note becomes a row with 'path' + all frontmatter keys as columns. Supports WHERE, JOIN, GROUP BY, ORDER BY, LIMIT, subqueries, and aggregations",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "sql": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "sql"
+      ],
+      "type": "object"
+    },
+    "name": "query_frontmatter_sql"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "template"
       ]
-    }
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "List all available note templates in the active vault",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "name": "list_templates"
   },
   {
-    "name": "get_template",
+    "_meta": {
+      "tags": [
+        "read",
+        "template"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Get detailed information about a specific template including fields and preview",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "template_id": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "template_id"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "_meta": {
-      "tags": [
-        "read",
-        "template"
-      ]
-    }
+    "name": "get_template"
   },
   {
-    "name": "create_from_template",
+    "_meta": {
+      "tags": [
+        "write",
+        "template"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true
+    },
     "description": "Create a new note from a template with field substitution and frontmatter",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "template_id": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
-        "file_path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
-        "fields": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
         "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
           "type": [
             "string",
             "null"
           ]
+        },
+        "fields": {
+          "type": "string"
+        },
+        "file_path": {
+          "type": "string"
+        },
+        "template_id": {
+          "type": "string"
         }
       },
       "required": [
@@ -895,855 +808,803 @@
         "file_path",
         "fields"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "destructiveHint": true
-    },
-    "_meta": {
-      "tags": [
-        "write",
-        "template"
-      ]
-    }
+    "name": "create_from_template"
   },
   {
-    "name": "find_notes_from_template",
+    "_meta": {
+      "tags": [
+        "read",
+        "template"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Find all notes created from a specific template via frontmatter tracking",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "template_id": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "template_id"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "_meta": {
-      "tags": [
-        "read",
-        "template"
-      ]
-    }
+    "name": "find_notes_from_template"
   },
   {
-    "name": "create_vault",
+    "_meta": {
+      "tags": [
+        "write",
+        "admin"
+      ]
+    },
     "description": "Create and register a new Obsidian vault at the specified filesystem path with an optional template. Optional write_backend selects the write path: 'direct' (default) or 'git'. Optional backend_opts holds that backend's settings; 'direct' has none, 'git' accepts branch, author {name, email}, merge_strategy ('merge-commit' or 'fast-forward'), include_ignored, require_commit_message. Passing backend_opts with write_backend 'direct' is an error",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
+        "backend_opts": {
+          "additionalProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
         "name": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
         "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
         "template": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
           "type": [
             "string",
             "null"
           ]
         },
         "write_backend": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
           "type": [
             "string",
             "null"
           ]
-        },
-        "backend_opts": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_Map_of_AnyValue",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": true
         }
       },
       "required": [
         "name",
         "path"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
+    "name": "create_vault"
+  },
+  {
     "_meta": {
       "tags": [
         "write",
         "admin"
       ]
-    }
-  },
-  {
-    "name": "add_vault",
+    },
     "description": "Register an existing Obsidian vault with the MCP server and auto-initialize. Optional write_backend selects the write path: 'direct' (default) or 'git'. Optional backend_opts holds that backend's settings; 'direct' has none, 'git' accepts branch, author {name, email}, merge_strategy ('merge-commit' or 'fast-forward'), include_ignored, require_commit_message. Passing backend_opts with write_backend 'direct' is an error",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
+        "backend_opts": {
+          "additionalProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
         "name": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
         "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
         "write_backend": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
           "type": [
             "string",
             "null"
           ]
-        },
-        "backend_opts": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_Map_of_AnyValue",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": true
         }
       },
       "required": [
         "name",
         "path"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
+    "name": "add_vault"
+  },
+  {
     "_meta": {
       "tags": [
         "write",
         "admin"
       ]
-    }
-  },
-  {
-    "name": "remove_vault",
+    },
     "description": "Unregister a vault from the MCP server (does NOT delete files)",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "name": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "name"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "_meta": {
-      "tags": [
-        "write",
-        "admin"
-      ]
-    }
+    "name": "remove_vault"
   },
   {
-    "name": "list_vaults",
+    "_meta": {
+      "tags": [
+        "read",
+        "admin"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "List all vaults registered with the MCP server",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "list_vaults"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "admin"
       ]
-    }
-  },
-  {
-    "name": "get_vault_config",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Get detailed configuration for a specific vault",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "name": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "name"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "_meta": {
-      "tags": [
-        "read",
-        "admin"
-      ]
-    }
+    "name": "get_vault_config"
   },
   {
-    "name": "set_active_vault",
-    "description": "Switch the active vault for subsequent operations",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        }
-      },
-      "required": [
-        "name"
-      ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
-    },
     "_meta": {
       "tags": [
         "write",
         "admin"
       ]
-    }
+    },
+    "description": "Switch the active vault for subsequent operations",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "set_active_vault"
   },
   {
-    "name": "get_active_vault",
-    "description": "Get the name of the currently active vault",
-    "inputSchema": {
-      "type": "object",
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
-    },
-    "annotations": {
-      "readOnlyHint": true
-    },
     "_meta": {
       "tags": [
         "read",
         "admin"
       ]
-    }
-  },
-  {
-    "name": "batch_execute",
-    "description": "Execute multiple file operations. With write_backend=git, the complete batch is one atomic commit with per-path CAS preconditions: every operation applies or none do.",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "operations": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Array_of_BatchOperation",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/BatchOperation"
-          },
-          "$defs": {
-            "BatchOperation": {
-              "description": "Individual batch operation to execute",
-              "oneOf": [
-                {
-                  "description": "Create a new note with content. Defaults to strict-create: the\nsubstrate adds `expect_absent`, so the loser of a concurrent-create\nrace aborts the entire batch with `ConcurrencyError`\n(turbovault-947 / 6fo §6 reconsideration domino).\n\n`force: Some(true)` disables `expect_absent`, falling back to\nupsert semantics (caller-acknowledged blind create/overwrite —\nequivalent to `WriteNote { expected_hash: None }`).",
-                  "type": "object",
-                  "properties": {
-                    "path": {
-                      "type": "string"
-                    },
-                    "content": {
-                      "type": "string"
-                    },
-                    "force": {
-                      "description": "Disable the implicit `expect_absent` precondition. Default\nfalse; pass true to acknowledge a blind create/overwrite.",
-                      "type": [
-                        "boolean",
-                        "null"
-                      ]
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "CreateNote"
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "path",
-                    "content"
-                  ]
-                },
-                {
-                  "description": "Write/overwrite a note. `expected_hash` (git blob OID hex on git\nbackend, SHA-256 on direct) carries an `expect_blob` precondition;\nthe whole batch aborts if the target file no longer matches the\nexpected pre-image (turbovault-c0e).",
-                  "type": "object",
-                  "properties": {
-                    "path": {
-                      "type": "string"
-                    },
-                    "content": {
-                      "type": "string"
-                    },
-                    "expected_hash": {
-                      "description": "Optional optimistic-concurrency precondition checked before any operation in the batch is applied.",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "WriteNote"
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "path",
-                    "content"
-                  ]
-                },
-                {
-                  "description": "Delete a note. `expected_hash` guards the delete against a\nconcurrent modification of the target.\n\nturbovault-0g4.7: on the **git backend**, `on_backlinks` controls inbound\nwikilinks (parity with the standalone `delete_note`):\n- `\"refuse\"` (default) — abort the batch if the note has inbound\n  backlinks (prevents silently shipping broken links);\n- `\"rewrite-stale-callout\"` — atomically `~~[[strikethrough]]~~` every\n  linker in the same commit;\n- `\"force\"` — delete and leave inbound links dangling (the pre-0g4.7\n  behavior).\n\nThe direct backend ignores this field and always does a bare delete (no\natomic multi-file primitive).",
-                  "type": "object",
-                  "properties": {
-                    "path": {
-                      "type": "string"
-                    },
-                    "expected_hash": {
-                      "description": "Optional optimistic-concurrency precondition on the deleted file.",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "on_backlinks": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "DeleteNote"
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "path"
-                  ]
-                },
-                {
-                  "description": "Move/rename a note. `expected_hash` guards the SOURCE against\nconcurrent modification (the destination always carries\n`expect_absent`, refusing to clobber).\n\nturbovault-0g4.6: on the **git backend**, `update_backlinks` (default\ntrue) atomically rewrites every inbound wikilink — `[[from]]`,\n`[[from|alias]]`, `[[from#section]]`, `[[from#^block]]`, `![[from]]` and\npath-prefix forms — to the new target in the SAME commit, with per-source\n`expect_blob` preconditions. Set it false for a rename-only move (inbound\nlinks dangle — the pre-0g4.6 behavior). The direct backend ignores this\nfield and is always rename-only (it has no atomic multi-file primitive).",
-                  "type": "object",
-                  "properties": {
-                    "from": {
-                      "type": "string"
-                    },
-                    "to": {
-                      "type": "string"
-                    },
-                    "expected_hash": {
-                      "description": "Optional optimistic-concurrency precondition on the source file.",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "update_backlinks": {
-                      "type": [
-                        "boolean",
-                        "null"
-                      ]
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "MoveNote"
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "from",
-                    "to"
-                  ]
-                },
-                {
-                  "description": "Update links in a note (find and replace link target).\n`expected_hash` guards the source file from concurrent\nmodification — important when several batch ops update siblings\nof the same renamed page.",
-                  "type": "object",
-                  "properties": {
-                    "file": {
-                      "type": "string"
-                    },
-                    "old_target": {
-                      "type": "string"
-                    },
-                    "new_target": {
-                      "type": "string"
-                    },
-                    "expected_hash": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "UpdateLinks"
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "file",
-                    "old_target",
-                    "new_target"
-                  ]
-                },
-                {
-                  "description": "turbovault-0g4.1: apply SEARCH/REPLACE blocks to an existing note as\npart of the atomic batch commit (the batch equivalent of `edit_note`).\n`edits` uses the same block grammar as the tool; multiple blocks edit\nmultiple locations in the one file. `expected_hash` (git blob OID hex)\ncarries an `expect_blob` precondition — a stale pre-image aborts the\nwhole batch. **Git backend only**; the direct executor refuses it.",
-                  "type": "object",
-                  "properties": {
-                    "path": {
-                      "type": "string"
-                    },
-                    "edits": {
-                      "type": "string"
-                    },
-                    "expected_hash": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "EditNote"
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "path",
-                    "edits"
-                  ]
-                },
-                {
-                  "description": "turbovault-0g4.2: set/merge frontmatter keys on a note as part of the\natomic batch commit (the batch equivalent of `update_frontmatter`).\n`merge` defaults to true (deep-merge into existing frontmatter); false\nreplaces the frontmatter wholesale. `expected_hash` (git blob OID hex)\ncarries an `expect_blob` precondition. **Git backend only**.",
-                  "type": "object",
-                  "properties": {
-                    "path": {
-                      "type": "string"
-                    },
-                    "frontmatter": {
-                      "type": "object",
-                      "additionalProperties": true
-                    },
-                    "merge": {
-                      "type": [
-                        "boolean",
-                        "null"
-                      ]
-                    },
-                    "expected_hash": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "UpdateFrontmatter"
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "path",
-                    "frontmatter"
-                  ]
-                },
-                {
-                  "description": "turbovault-0g4.3: add or remove frontmatter tags on a note as part of\nthe atomic batch commit (the batch equivalent of `manage_tags`\nadd/remove). `operation` is `\"add\"` or `\"remove\"`; `\"list\"` is\nread-only and not a batch op (rejected). `expected_hash` carries an\n`expect_blob` precondition. **Git backend only**.",
-                  "type": "object",
-                  "properties": {
-                    "path": {
-                      "type": "string"
-                    },
-                    "operation": {
-                      "type": "string"
-                    },
-                    "tags": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "expected_hash": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "ManageTags"
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "path",
-                    "operation",
-                    "tags"
-                  ]
-                },
-                {
-                  "description": "turbovault-0g4.4: render a template and create a note as part of the\natomic batch commit (the batch equivalent of `create_from_template`).\n`force` (default false) → strict create (`expect_absent`, aborts if the\npath exists); true → blind upsert. **Git backend only**.",
-                  "type": "object",
-                  "properties": {
-                    "template_id": {
-                      "type": "string"
-                    },
-                    "path": {
-                      "type": "string"
-                    },
-                    "fields": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "string"
-                      }
-                    },
-                    "force": {
-                      "type": [
-                        "boolean",
-                        "null"
-                      ]
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "CreateFromTemplate"
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "template_id",
-                    "path",
-                    "fields"
-                  ]
-                }
-              ]
-            }
-          }
-        },
-        "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "operations"
-      ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
     },
     "annotations": {
-      "destructiveHint": true
+      "readOnlyHint": true
     },
+    "description": "Get the name of the currently active vault",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "name": "get_active_vault"
+  },
+  {
     "_meta": {
       "tags": [
         "write",
         "batch"
       ]
-    }
-  },
-  {
-    "name": "begin_fanout",
-    "description": "Open an isolated Git worktree for parallel agent writes. Fanout provides isolation, while batch_execute provides all-or-nothing multi-file atomicity.",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "merge_strategy": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
     },
     "annotations": {
       "destructiveHint": true
     },
-    "_meta": {
-      "tags": [
-        "write",
-        "git"
-      ]
-    }
-  },
-  {
-    "name": "commit_fanout",
-    "description": "Merge the active fanout back into its base vault and clean up the scratch worktree.",
+    "description": "Execute multiple file operations. With write_backend=git, the complete batch is one atomic commit with per-path CAS preconditions: every operation applies or none do.",
     "inputSchema": {
-      "type": "object",
+      "$defs": {
+        "BatchOperation": {
+          "description": "Individual batch operation to execute",
+          "oneOf": [
+            {
+              "description": "Create a new note with content. Defaults to strict-create: the\nsubstrate adds `expect_absent`, so the loser of a concurrent-create\nrace aborts the entire batch with `ConcurrencyError`\n(turbovault-947 / 6fo §6 reconsideration domino).\n\n`force: Some(true)` disables `expect_absent`, falling back to\nupsert semantics (caller-acknowledged blind create/overwrite —\nequivalent to `WriteNote { expected_hash: None }`).",
+              "properties": {
+                "content": {
+                  "type": "string"
+                },
+                "force": {
+                  "description": "Disable the implicit `expect_absent` precondition. Default\nfalse; pass true to acknowledge a blind create/overwrite.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "path": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "CreateNote",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "path",
+                "content"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Write/overwrite a note. `expected_hash` (git blob OID hex on git\nbackend, SHA-256 on direct) carries an `expect_blob` precondition;\nthe whole batch aborts if the target file no longer matches the\nexpected pre-image (turbovault-c0e).",
+              "properties": {
+                "content": {
+                  "type": "string"
+                },
+                "expected_hash": {
+                  "description": "Optional optimistic-concurrency precondition checked before any operation in the batch is applied.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "path": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "WriteNote",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "path",
+                "content"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Delete a note. `expected_hash` guards the delete against a\nconcurrent modification of the target.\n\nturbovault-0g4.7: on the **git backend**, `on_backlinks` controls inbound\nwikilinks (parity with the standalone `delete_note`):\n- `\"refuse\"` (default) — abort the batch if the note has inbound\n  backlinks (prevents silently shipping broken links);\n- `\"rewrite-stale-callout\"` — atomically `~~[[strikethrough]]~~` every\n  linker in the same commit;\n- `\"force\"` — delete and leave inbound links dangling (the pre-0g4.7\n  behavior).\n\nThe direct backend ignores this field and always does a bare delete (no\natomic multi-file primitive).",
+              "properties": {
+                "expected_hash": {
+                  "description": "Optional optimistic-concurrency precondition on the deleted file.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "on_backlinks": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "path": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "DeleteNote",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "path"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Move/rename a note. `expected_hash` guards the SOURCE against\nconcurrent modification (the destination always carries\n`expect_absent`, refusing to clobber).\n\nturbovault-0g4.6: on the **git backend**, `update_backlinks` (default\ntrue) atomically rewrites every inbound wikilink — `[[from]]`,\n`[[from|alias]]`, `[[from#section]]`, `[[from#^block]]`, `![[from]]` and\npath-prefix forms — to the new target in the SAME commit, with per-source\n`expect_blob` preconditions. Set it false for a rename-only move (inbound\nlinks dangle — the pre-0g4.6 behavior). The direct backend ignores this\nfield and is always rename-only (it has no atomic multi-file primitive).",
+              "properties": {
+                "expected_hash": {
+                  "description": "Optional optimistic-concurrency precondition on the source file.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "from": {
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "MoveNote",
+                  "type": "string"
+                },
+                "update_backlinks": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "type",
+                "from",
+                "to"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Update links in a note (find and replace link target).\n`expected_hash` guards the source file from concurrent\nmodification — important when several batch ops update siblings\nof the same renamed page.",
+              "properties": {
+                "expected_hash": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "file": {
+                  "type": "string"
+                },
+                "new_target": {
+                  "type": "string"
+                },
+                "old_target": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "UpdateLinks",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "file",
+                "old_target",
+                "new_target"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "turbovault-0g4.1: apply SEARCH/REPLACE blocks to an existing note as\npart of the atomic batch commit (the batch equivalent of `edit_note`).\n`edits` uses the same block grammar as the tool; multiple blocks edit\nmultiple locations in the one file. `expected_hash` (git blob OID hex)\ncarries an `expect_blob` precondition — a stale pre-image aborts the\nwhole batch. **Git backend only**; the direct executor refuses it.",
+              "properties": {
+                "edits": {
+                  "type": "string"
+                },
+                "expected_hash": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "path": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "EditNote",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "path",
+                "edits"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "turbovault-0g4.2: set/merge frontmatter keys on a note as part of the\natomic batch commit (the batch equivalent of `update_frontmatter`).\n`merge` defaults to true (deep-merge into existing frontmatter); false\nreplaces the frontmatter wholesale. `expected_hash` (git blob OID hex)\ncarries an `expect_blob` precondition. **Git backend only**.",
+              "properties": {
+                "expected_hash": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "frontmatter": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "merge": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "path": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "UpdateFrontmatter",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "path",
+                "frontmatter"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "turbovault-0g4.3: add or remove frontmatter tags on a note as part of\nthe atomic batch commit (the batch equivalent of `manage_tags`\nadd/remove). `operation` is `\"add\"` or `\"remove\"`; `\"list\"` is\nread-only and not a batch op (rejected). `expected_hash` carries an\n`expect_blob` precondition. **Git backend only**.",
+              "properties": {
+                "expected_hash": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "operation": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "tags": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "ManageTags",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "path",
+                "operation",
+                "tags"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "turbovault-0g4.4: render a template and create a note as part of the\natomic batch commit (the batch equivalent of `create_from_template`).\n`force` (default false) → strict create (`expect_absent`, aborts if the\npath exists); true → blind upsert. **Git backend only**.",
+              "properties": {
+                "fields": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "force": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "path": {
+                  "type": "string"
+                },
+                "template_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "CreateFromTemplate",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "template_id",
+                "path",
+                "fields"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "merge_strategy": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "commit_message": {
           "type": [
             "string",
             "null"
           ]
         },
-        "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "operations": {
+          "items": {
+            "$ref": "#/$defs/BatchOperation"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "operations"
+      ],
+      "type": "object"
+    },
+    "name": "batch_execute"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "write",
+        "git"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true
+    },
+    "description": "Open an isolated Git worktree for parallel agent writes. Fanout provides isolation, while batch_execute provides all-or-nothing multi-file atomicity.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "merge_strategy": {
           "type": [
             "string",
             "null"
           ]
         }
       },
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "destructiveHint": true
-    },
+    "name": "begin_fanout"
+  },
+  {
     "_meta": {
       "tags": [
         "write",
         "git"
       ]
-    }
+    },
+    "annotations": {
+      "destructiveHint": true
+    },
+    "description": "Merge the active fanout back into its base vault and clean up the scratch worktree.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "commit_message": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "merge_strategy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "name": "commit_fanout"
   },
   {
-    "name": "abandon_fanout",
+    "_meta": {
+      "tags": [
+        "write",
+        "git"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true
+    },
     "description": "Discard the active fanout and remove its worktree without changing the base vault.",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "destructiveHint": true
-    },
-    "_meta": {
-      "tags": [
-        "write",
-        "git"
-      ]
-    }
+    "name": "abandon_fanout"
   },
   {
-    "name": "list_orphan_fanouts",
+    "_meta": {
+      "tags": [
+        "read",
+        "git"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "List orphan fanout worktrees left by interrupted server sessions.",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "vault": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
           "type": [
             "string",
             "null"
           ]
         }
       },
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
+    },
+    "name": "list_orphan_fanouts"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "read",
+        "export"
+      ]
     },
     "annotations": {
       "readOnlyHint": true
     },
-    "_meta": {
-      "tags": [
-        "read",
-        "git"
-      ]
-    }
-  },
-  {
-    "name": "export_health_report",
     "description": "Export vault health analysis as structured data",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "format": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "format"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "export_health_report"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "export"
       ]
-    }
-  },
-  {
-    "name": "export_broken_links",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Export broken links report as structured data",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "format": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "format"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "export_broken_links"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "export"
       ]
-    }
-  },
-  {
-    "name": "export_vault_stats",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Export comprehensive vault statistics as structured data",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "format": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "format"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "export_vault_stats"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "export"
       ]
-    }
-  },
-  {
-    "name": "export_analysis_report",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Export comprehensive vault analysis combining health, stats, links, and clusters",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "format": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "format"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
+    },
+    "name": "export_analysis_report"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "read",
+        "frontmatter"
+      ]
     },
     "annotations": {
       "readOnlyHint": true
     },
-    "_meta": {
-      "tags": [
-        "read",
-        "export"
-      ]
-    }
-  },
-  {
-    "name": "query_metadata",
     "description": "Query notes by frontmatter metadata pattern (equality, comparison, existence checks)",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "pattern": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "pattern"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "query_metadata"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "frontmatter"
       ]
-    }
-  },
-  {
-    "name": "get_metadata_value",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Extract specific metadata value from a note's frontmatter (supports dot notation for nested keys)",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "file": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
         "key": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
@@ -1751,102 +1612,86 @@
         "file",
         "key"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "_meta": {
-      "tags": [
-        "read",
-        "frontmatter"
-      ]
-    }
+    "name": "get_metadata_value"
   },
   {
-    "name": "update_frontmatter",
+    "_meta": {
+      "tags": [
+        "write",
+        "frontmatter"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true
+    },
     "description": "Update YAML frontmatter of a note without modifying content body",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
+        "commit_message": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "frontmatter": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Map_of_AnyValue",
-          "type": "object",
-          "additionalProperties": true
+          "additionalProperties": true,
+          "type": "object"
         },
         "merge": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_boolean",
           "type": [
             "boolean",
             "null"
           ]
         },
-        "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
-          "type": [
-            "string",
-            "null"
-          ]
+        "path": {
+          "type": "string"
         }
       },
       "required": [
         "path",
         "frontmatter"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "destructiveHint": true
-    },
+    "name": "update_frontmatter"
+  },
+  {
     "_meta": {
       "tags": [
         "write",
         "frontmatter"
       ]
-    }
-  },
-  {
-    "name": "manage_tags",
+    },
+    "annotations": {
+      "destructiveHint": true
+    },
     "description": "Add, remove, or list tags on a note. List returns both frontmatter and inline #tags. Add/remove only modify frontmatter tags array",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
+        "commit_message": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "operation": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
+          "type": "string"
+        },
+        "path": {
           "type": "string"
         },
         "tags": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_Array_of_string",
-          "type": [
-            "array",
-            "null"
-          ],
           "items": {
             "type": "string"
-          }
-        },
-        "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+          },
           "type": [
-            "string",
+            "array",
             "null"
           ]
         }
@@ -1855,90 +1700,75 @@
         "path",
         "operation"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "destructiveHint": true
-    },
-    "_meta": {
-      "tags": [
-        "write",
-        "frontmatter"
-      ]
-    }
+    "name": "manage_tags"
   },
   {
-    "name": "get_notes_info",
+    "_meta": {
+      "tags": [
+        "read"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Get file metadata (size, modified time, has_frontmatter) for multiple notes without reading full content",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "paths": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Array_of_string",
-          "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array"
         }
       },
       "required": [
         "paths"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "_meta": {
-      "tags": [
-        "read"
-      ]
-    }
+    "name": "get_notes_info"
   },
   {
-    "name": "move_file",
+    "_meta": {
+      "tags": [
+        "write"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true
+    },
     "description": "Move or rename any file (images, PDFs, attachments) within vault with double confirmation. Binary-safe, no content processing",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "from": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
-        "to": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
+        "commit_message": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "confirm_from": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
         "confirm_to": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
         "expected_hash": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
           "type": [
             "string",
             "null"
           ]
         },
-        "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
-          "type": [
-            "string",
-            "null"
-          ]
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
         }
       },
       "required": [
@@ -1947,69 +1777,62 @@
         "confirm_from",
         "confirm_to"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "destructiveHint": true
-    },
-    "_meta": {
-      "tags": [
-        "write"
-      ]
-    }
+    "name": "move_file"
   },
   {
-    "name": "suggest_links",
-    "description": "AI-powered link suggestions for a note (returns top N candidates with reasoning)",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "file": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
-        "limit": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_int32",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "int32"
-        }
-      },
-      "required": [
-        "file"
-      ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
-    },
-    "annotations": {
-      "readOnlyHint": true
-    },
     "_meta": {
       "tags": [
         "read",
         "graph"
       ]
-    }
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "AI-powered link suggestions for a note (returns top N candidates with reasoning)",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "limit": {
+          "format": "int32",
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "file"
+      ],
+      "type": "object"
+    },
+    "name": "suggest_links"
   },
   {
-    "name": "get_link_strength",
+    "_meta": {
+      "tags": [
+        "read",
+        "graph"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Calculate connection strength between two notes (0.0-1.0 score based on multiple factors)",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "source": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
         "target": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
@@ -2017,102 +1840,97 @@
         "source",
         "target"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "get_link_strength"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "graph"
       ]
-    }
-  },
-  {
-    "name": "get_centrality_ranking",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Rank all notes by graph centrality metrics (betweenness, closeness, eigenvector)",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
+    },
+    "name": "get_centrality_ranking"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "read"
+      ]
     },
     "annotations": {
       "readOnlyHint": true
     },
-    "_meta": {
-      "tags": [
-        "read",
-        "graph"
-      ]
-    }
-  },
-  {
-    "name": "get_ofm_syntax_guide",
     "description": "Get Obsidian Flavored Markdown syntax guide for the OFM syntax TurboVault parses, classifies, or preserves",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "get_ofm_syntax_guide"
+  },
+  {
     "_meta": {
       "tags": [
         "read"
       ]
-    }
-  },
-  {
-    "name": "get_ofm_quick_ref",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Get condensed OFM cheat sheet with common patterns and best practices",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "get_ofm_quick_ref"
+  },
+  {
     "_meta": {
       "tags": [
         "read"
       ]
-    }
-  },
-  {
-    "name": "get_ofm_examples",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Get comprehensive example note demonstrating ALL OFM features with real-world patterns",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "get_ofm_examples"
+  },
+  {
     "_meta": {
       "tags": [
         "read"
       ]
-    }
-  },
-  {
-    "name": "diff_notes",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Compare two notes side-by-side showing unified diff, line-level and word-level changes, and similarity score",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "left": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
         "right": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
@@ -2120,32 +1938,29 @@
         "left",
         "right"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
+    },
+    "name": "diff_notes"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "read",
+        "audit"
+      ]
     },
     "annotations": {
       "readOnlyHint": true
     },
-    "_meta": {
-      "tags": [
-        "read"
-      ]
-    }
-  },
-  {
-    "name": "diff_note_version",
     "description": "Compare current note with a previous version from the audit trail",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
+        "operation_id": {
           "type": "string"
         },
-        "operation_id": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
+        "path": {
           "type": "string"
         }
       },
@@ -2153,486 +1968,432 @@
         "path",
         "operation_id"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
+    },
+    "name": "diff_note_version"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "read",
+        "health"
+      ]
     },
     "annotations": {
       "readOnlyHint": true
     },
-    "_meta": {
-      "tags": [
-        "read",
-        "audit"
-      ]
-    }
-  },
-  {
-    "name": "evaluate_note_quality",
     "description": "Evaluate note quality across readability, structure, completeness, and staleness dimensions (0-100 score per dimension plus composite)",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "path"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "evaluate_note_quality"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "health"
       ]
-    }
-  },
-  {
-    "name": "vault_quality_report",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Generate vault-wide quality report with score distribution, dimension averages, lowest/highest quality notes, and recommendations",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "bottom_n": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
+          "format": "uint",
+          "minimum": 0,
           "type": [
             "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 0
-        }
-      },
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
-    },
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "_meta": {
-      "tags": [
-        "read",
-        "health"
-      ]
-    }
-  },
-  {
-    "name": "analyze_note_grounding",
-    "description": "Extract grounding primitives for a note — the raw material an external LLM judge needs to score hallucination/contradiction/redundancy: candidate factual claims from the prose, declared citations (# Citations), structural signals (Schema/Examples sections), and an 'uncited' flag (makes claims but cites nothing). TurboVault does NOT score grounding itself; it surfaces the data deterministically",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        }
-      },
-      "required": [
-        "path"
-      ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
-    },
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "_meta": {
-      "tags": [
-        "read",
-        "quality",
-        "okf"
-      ]
-    }
-  },
-  {
-    "name": "find_ungrounded_notes",
-    "description": "Scan the vault for hallucination-risk notes: notes that make factual claims in prose but declare no citations (# Citations). Returns them sorted by claim count (most claims first) — the notes most worth grounding review or an LLM-judge pass",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "limit": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 0
-        }
-      },
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
-    },
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "_meta": {
-      "tags": [
-        "read",
-        "quality",
-        "okf"
-      ]
-    }
-  },
-  {
-    "name": "okf_validate",
-    "description": "Validate the vault as an Open Knowledge Format (OKF) bundle: checks every note for OKF v0.1 conformance (parseable frontmatter with a non-empty `type`) and surfaces each concept's OKF metadata (type, title, description, resource, timestamp, citation count) plus the bundle's type vocabulary. Reports non-conformant files for use as a CI gate",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "subtree": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
-          "type": [
-            "string",
             "null"
           ]
         }
       },
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
+    },
+    "name": "vault_quality_report"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "read",
+        "quality",
+        "okf"
+      ]
     },
     "annotations": {
       "readOnlyHint": true
     },
+    "description": "Extract grounding primitives for a note — the raw material an external LLM judge needs to score hallucination/contradiction/redundancy: candidate factual claims from the prose, declared citations (# Citations), structural signals (Schema/Examples sections), and an 'uncited' flag (makes claims but cites nothing). TurboVault does NOT score grounding itself; it surfaces the data deterministically",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "name": "analyze_note_grounding"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "read",
+        "quality",
+        "okf"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Scan the vault for hallucination-risk notes: notes that make factual claims in prose but declare no citations (# Citations). Returns them sorted by claim count (most claims first) — the notes most worth grounding review or an LLM-judge pass",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "limit": {
+          "format": "uint",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "name": "find_ungrounded_notes"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "okf",
         "frontmatter"
       ]
-    }
-  },
-  {
-    "name": "generate_index",
-    "description": "Generate or refresh OKF index.md files for progressive disclosure: each indexed directory gets an index.md listing its concept notes (with their frontmatter descriptions) and subdirectories, so agents and humans can navigate the bundle one level at a time instead of loading everything. Idempotent — unchanged indexes are not rewritten",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Validate the vault as an Open Knowledge Format (OKF) bundle: checks every note for OKF v0.1 conformance (parseable frontmatter with a non-empty `type`) and surfaces each concept's OKF metadata (type, title, description, resource, timestamp, citation count) plus the bundle's type vocabulary. Reports non-conformant files for use as a CI gate",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "directory": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "recursive": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_boolean",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "dry_run": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_boolean",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "subtree": {
           "type": [
             "string",
             "null"
           ]
         }
       },
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
+    "name": "okf_validate"
+  },
+  {
     "_meta": {
       "tags": [
         "write",
         "okf"
       ]
-    }
-  },
-  {
-    "name": "append_log_entry",
-    "description": "Append an entry to an OKF log.md update history (spec §7). Files the entry under a `## YYYY-MM-DD` date section, newest-first — a new date becomes the top section, an existing date gains another bullet. Creates log.md (with a title) if absent",
+    },
+    "description": "Generate or refresh OKF index.md files for progressive disclosure: each indexed directory gets an index.md listing its concept notes (with their frontmatter descriptions) and subdirectories, so agents and humans can navigate the bundle one level at a time instead of loading everything. Idempotent — unchanged indexes are not rewritten",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "text": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
-        "directory": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "commit_message": {
           "type": [
             "string",
             "null"
           ]
         },
-        "kind": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "directory": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "dry_run": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "recursive": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "name": "generate_index"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "write",
+        "okf"
+      ]
+    },
+    "description": "Append an entry to an OKF log.md update history (spec §7). Files the entry under a `## YYYY-MM-DD` date section, newest-first — a new date becomes the top section, an existing date gains another bullet. Creates log.md (with a title) if absent",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "commit_message": {
           "type": [
             "string",
             "null"
           ]
         },
         "date": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
           "type": [
             "string",
             "null"
           ]
         },
-        "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "directory": {
           "type": [
             "string",
             "null"
           ]
+        },
+        "kind": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "text": {
+          "type": "string"
         }
       },
       "required": [
         "text"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "_meta": {
-      "tags": [
-        "write",
-        "okf"
-      ]
-    }
+    "name": "append_log_entry"
   },
   {
-    "name": "visualize",
-    "description": "Render the vault's concept graph as a single self-contained HTML file: a force-directed graph of every note, a detail panel with the rendered markdown body and 'cited by' backlinks, plus type filter and search. The bundle is embedded as JSON; the graph/markdown libraries load from a CDN. Shareable as a static artifact — open in any browser, no backend. Covers both OKF cross-links and Obsidian wikilinks",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "output": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "name": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "commit_message": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
-    },
     "_meta": {
       "tags": [
         "write",
         "export",
         "okf"
       ]
-    }
-  },
-  {
-    "name": "find_stale_notes",
-    "description": "Find notes that have not been updated recently, sorted by staleness (most stale first)",
+    },
+    "description": "Render the vault's concept graph as a single self-contained HTML file: a force-directed graph of every note, a detail panel with the rendered markdown body and 'cited by' backlinks, plus type filter and search. The bundle is embedded as JSON; the graph/markdown libraries load from a CDN. Shareable as a static artifact — open in any browser, no backend. Covers both OKF cross-links and Obsidian wikilinks",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "threshold_days": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint64",
+        "commit_message": {
           "type": [
-            "integer",
+            "string",
             "null"
-          ],
-          "format": "uint64",
-          "minimum": 0
+          ]
         },
-        "limit": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
+        "name": {
           "type": [
-            "integer",
+            "string",
             "null"
-          ],
-          "format": "uint",
-          "minimum": 0
+          ]
+        },
+        "output": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "visualize"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "health"
       ]
-    }
-  },
-  {
-    "name": "semantic_search",
-    "description": "Find notes semantically similar to a query using TF-IDF cosine similarity (finds conceptual matches beyond exact keyword overlap)",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Find notes that have not been updated recently, sorted by staleness (most stale first)",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "query": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
         "limit": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
+          "format": "uint",
+          "minimum": 0,
           "type": [
             "integer",
             "null"
-          ],
+          ]
+        },
+        "threshold_days": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "name": "find_stale_notes"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "read",
+        "search",
+        "semantic"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Find notes semantically similar to a query using TF-IDF cosine similarity (finds conceptual matches beyond exact keyword overlap)",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "limit": {
           "format": "uint",
-          "minimum": 0
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "query": {
+          "type": "string"
         }
       },
       "required": [
         "query"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "semantic_search"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "search",
         "semantic"
       ]
-    }
-  },
-  {
-    "name": "find_similar_notes",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Find notes most similar in content to a specific note using TF-IDF cosine similarity",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        },
         "limit": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
+          "format": "uint",
+          "minimum": 0,
           "type": [
             "integer",
             "null"
-          ],
-          "format": "uint",
-          "minimum": 0
+          ]
+        },
+        "path": {
+          "type": "string"
         }
       },
       "required": [
         "path"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "find_similar_notes"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "search",
         "semantic"
       ]
-    }
-  },
-  {
-    "name": "find_duplicates",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Find near-duplicate notes across vault using SimHash fingerprinting and TF-IDF cosine similarity verification",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "threshold": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_double",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        },
         "limit": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
+          "format": "uint",
+          "minimum": 0,
           "type": [
             "integer",
             "null"
-          ],
-          "format": "uint",
-          "minimum": 0
+          ]
+        },
+        "threshold": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
         }
       },
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
+    },
+    "name": "find_duplicates"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "read",
+        "semantic"
+      ]
     },
     "annotations": {
       "readOnlyHint": true
     },
-    "_meta": {
-      "tags": [
-        "read",
-        "search",
-        "semantic"
-      ]
-    }
-  },
-  {
-    "name": "compare_notes",
     "description": "Compare two specific notes showing similarity score, shared terms, diff summary, and actionable recommendation",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "left": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         },
         "right": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
@@ -2640,137 +2401,118 @@
         "left",
         "right"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
+    },
+    "name": "compare_notes"
+  },
+  {
+    "_meta": {
+      "tags": [
+        "read",
+        "audit"
+      ]
     },
     "annotations": {
       "readOnlyHint": true
     },
-    "_meta": {
-      "tags": [
-        "read",
-        "semantic"
-      ]
-    }
-  },
-  {
-    "name": "audit_log",
     "description": "View operation history for the active vault with optional filters by path, operation type (CREATE/UPDATE/DELETE/MOVE), and result limit",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "path": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
+        "limit": {
+          "format": "uint",
+          "minimum": 0,
           "type": [
-            "string",
+            "integer",
             "null"
           ]
         },
         "operation": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_string",
           "type": [
             "string",
             "null"
           ]
         },
-        "limit": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "Nullable_uint",
+        "path": {
           "type": [
-            "integer",
+            "string",
             "null"
-          ],
-          "format": "uint",
-          "minimum": 0
+          ]
         }
       },
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
+    "name": "audit_log"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "audit"
       ]
-    }
-  },
-  {
-    "name": "rollback_preview",
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
     "description": "Preview what a rollback would change without applying it (dry run). Shows unified diff between current content and rollback target",
     "inputSchema": {
-      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "operation_id": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
           "type": "string"
         }
       },
       "required": [
         "operation_id"
       ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
+      "type": "object"
     },
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "_meta": {
-      "tags": [
-        "read",
-        "audit"
-      ]
-    }
+    "name": "rollback_preview"
   },
   {
-    "name": "rollback_note",
-    "description": "Restore a note to its state before a specific operation (identified by operation_id from audit_log)",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "operation_id": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "title": "string",
-          "type": "string"
-        }
-      },
-      "required": [
-        "operation_id"
-      ],
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
-    },
-    "annotations": {
-      "destructiveHint": true
-    },
     "_meta": {
       "tags": [
         "write",
         "audit"
       ]
-    }
-  },
-  {
-    "name": "audit_stats",
-    "description": "Get audit trail statistics including operation counts by type, total snapshot storage used, and time range of recorded operations",
-    "inputSchema": {
-      "type": "object",
-      "additionalProperties": false,
-      "$schema": "https://json-schema.org/draft/2020-12/schema"
     },
     "annotations": {
-      "readOnlyHint": true
+      "destructiveHint": true
     },
+    "description": "Restore a note to its state before a specific operation (identified by operation_id from audit_log)",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "operation_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "operation_id"
+      ],
+      "type": "object"
+    },
+    "name": "rollback_note"
+  },
+  {
     "_meta": {
       "tags": [
         "read",
         "audit"
       ]
-    }
+    },
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Get audit trail statistics including operation counts by type, total snapshot storage used, and time range of recorded operations",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "name": "audit_stats"
   }
 ]


### PR DESCRIPTION
Resolves the reporter's problem in #51 without waiting on upstream.

`turbomcp-macros` builds a tool's input schema one parameter at a time, calling `schemars::schema_for!` per parameter and inserting the resulting *root* schema whole as the property value. A root schema carries `$schema`, `title`, and any `$defs` its type needs, and its `$ref`s are root-relative because from its own point of view it is the root. Nesting that document under `properties.<name>` moves the definitions without rewriting the pointers, so `#/$defs/Foo` resolves against a root that has no `$defs`.

Consumers that resolve those pointers correctly reject the tool. llama.cpp's `llama-server` fails the **entire request** with HTTP 400 as soon as one is present, so a single affected tool takes the whole catalog offline for that host. Clients that skip validation lose grammar-constrained argument generation and start emitting malformed arguments.

## Why now rather than waiting

I said on #51 that I would hoist these on our side if the upstream patch took a while. It has. turbomcp 3.2.0 shipped with the same per-parameter construction, so upgrading does not help. This is a workaround and should be deleted when a release builds the schema from a single args struct.

`hoist_schema_defs` walks each tool's properties, lifts every `$defs` to the root, and drops the `$schema` and `title` that only belong on a root document. Applied once over the assembled catalog so core and plugin tools get the same treatment and a new mount site cannot forget it.

## Tests

A property assertion that every `#/$defs` pointer resolves against its own schema root and no subschema carries `$defs` or `$schema`. It holds for tools nobody has written yet, which the fixture cannot do. Verified it fails with the hoist disabled:

```
read_note: root-only keywords ["$schema", ...] found inside properties
```

The catalog fixture is now compared canonically. `extra_keywords` is a `HashMap` serialized with `serde(flatten)`, so its key order is whatever the map iterated. With one keyword that never showed; with `$schema` and a hoisted `$defs` the byte comparison failed about two runs in three. Sorting keys before comparing gives it one spelling, confirmed stable over five consecutive runs. That flakiness was introduced by this change, not pre-existing.

1286 tests passing, clippy, fmt and docs clean.