### PR TITLE
chore: ignore the .claude agent state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@ htmlcov/
 .env.*
 !.env.example
 
+# Agent tooling state. Local to whoever is running it: settings, session
+# scratch, and project state that means nothing in anyone else's checkout.
+# `CLAUDE.md` itself stays tracked-by-hand at the repo root, since that is
+# shared project instruction rather than local state.
+.claude/
+
 # Private strategy docs (keep untracked)
 .strategy/
 **/PRIVATE_*.md


### PR DESCRIPTION
It holds local settings, session scratch and project state that means nothing in anyone else's checkout, and it was untracked but *not* ignored. So it showed up as a dirty working tree and sat one `git add -A` away from committing someone's personal settings.

`CLAUDE.md` at the repo root is deliberately left alone. That is shared project instruction rather than local state, and it lives outside this directory.

No effect on what gets packaged: `.claude/` is at the repo root and every crate is under `crates/`.