### PR TITLE
chore(deps): move off yanked chacha20, unify turbomcp on 3.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,9 +604,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -4877,9 +4877,9 @@ dependencies = [
 
 [[package]]
 name = "turbomcp-client"
-version = "3.1.5"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5b8f3be285b6968d55abbcce3efa9048603199a7b6bc01eb16542710bc197"
+checksum = "8bfddbf30db5fd5a330d146c915cb4b8e8cc0892bfe78e3b9133bd35e50259c9"
 dependencies = [
  "chrono",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,11 @@ turbomcp-core = "3.3.0"
 turbomcp-protocol = "3.3.0"
 turbomcp-server = { version = "3.3.0", default-features = false }
 turbomcp-types = "3.3.0"
+# Used by the wire-level e2e test. Declared here with the rest so a turbomcp
+# bump cannot leave the client behind, which is how it ended up driving a
+# 3.3.0 server from a 3.1.5 client.
+turbomcp-client = "3.3.0"
+turbomcp-transport = "3.3.0"
 
 # SQL query engine (optional, for frontmatter SQL queries)
 gluesql = { version = "0.19", default-features = false, features = ["gluesql_memory_storage"] }

--- a/crates/turbovault/Cargo.toml
+++ b/crates/turbovault/Cargo.toml
@@ -103,8 +103,8 @@ serial_test = "4"
 # the JSON-RPC layer the in-process 6fo.18 suite skips and asserting derived
 # graph/search state via MCP tool responses (the real flush-on-query path,
 # no `flush_*_test` backdoor).
-turbomcp-client = "3.1.5"
-turbomcp-transport = "3.1.5"
+turbomcp-client = { workspace = true }
+turbomcp-transport = { workspace = true }
 # Also a plugin-api-gated runtime dependency; tests need it unconditionally.
 turbomcp-protocol = { workspace = true }
 


### PR DESCRIPTION
Two lockfile problems surfaced by the 2.0.0 publish. Neither is a security issue, so nothing here warrants a release on its own.

## chacha20 is yanked

`chacha20` 0.10.0 is yanked, as is 0.10.1, so cargo warned on every package step during publish. It arrives through `rand` 0.10.2 under turbomcp's transport and protocol crates.

`cargo audit` reports it only as **yanked, with no RUSTSEC advisory against it**, so this is hygiene rather than a patch worth cutting a release for. Moved to 0.10.2.

## turbomcp-client was left behind at 3.1.5

Everything else went to 3.3.0 in #64, so the wire-level e2e test was driving a 3.3.0 server with a 3.1.5 client. That is the skew that hides a protocol regression: the test still passes because both ends independently work, and nothing checks they agree on the same version of the wire.

It drifted because `turbomcp-client` and `turbomcp-transport` were pinned directly in `crates/turbovault/Cargo.toml` instead of `[workspace.dependencies]`, so the sweep that took the rest to 3.3.0 never saw them. Both now live with the others, and all fifteen turbomcp crates in the lock resolve to one version.

## Verification

1286 tests passing. Clippy, fmt, docs, `cargo audit` and `cargo metadata --locked` all clean. No crate version changes.