### PR TITLE
ci: publish with cargo publish --workspace, and log the post-2.0.0 changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,47 +67,13 @@ jobs:
             exit 0
           fi
           set -euo pipefail
-          # A crates.io version can never be replaced, so a run that dies
-          # partway leaves the release half published. Skipping what is already
-          # up makes a re-run resume from the failure instead of dying on the
-          # first crate it already published.
-          publish() {
-            local crate=$1
-            local version status
-            version=$(cargo metadata --format-version 1 --no-deps \
-              | jq -r --arg c "$crate" '.packages[] | select(.name == $c) | .version')
-            if [ -z "${version}" ]; then
-              echo "::error::${crate} is not in the workspace metadata"
-              exit 1
-            fi
-            status=$(curl -sS -o /dev/null -w '%{http_code}' \
-              -A "turbovault-release-workflow" \
-              "https://crates.io/api/v1/crates/${crate}/${version}")
-            if [ "${status}" = "200" ]; then
-              echo "${crate} ${version} is already published, skipping"
-              return 0
-            fi
-            echo "Publishing ${crate} ${version}"
-            cargo publish --package "${crate}" --locked
-            # The index has to serve this version before the next crate that
-            # depends on it can resolve.
-            sleep 30
-          }
-          # Dependency order: every crate publishes after everything it needs.
-          # `turbovault-plugin-api` is versioned independently (0.1.0) but still
-          # has to precede the binary that mounts plugins.
-          publish turbovault-core
-          publish turbovault-git
-          publish turbovault-audit
-          publish turbovault-parser
-          publish turbovault-graph
-          publish turbovault-export
-          publish turbovault-vault
-          publish turbovault-batch
-          publish turbovault-sql
-          publish turbovault-tools
-          publish turbovault-plugin-api
-          publish turbovault
+          # Cargo resolves the publish order from the dependency graph itself,
+          # waits for the index between crates, and warns rather than fails on
+          # anything already on crates.io, so a run that died partway resumes.
+          # This replaced a hand-maintained crate list with its own ordering,
+          # sleeps and already-published probe, all of which cargo now does and
+          # any of which could drift from the real graph when a crate is added.
+          cargo publish --workspace --locked
 
   # ── Build Prebuilt Binaries ───────────────────────────────────────────
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Nothing here changes behaviour, and no crate version moved, so there is nothing to upgrade to yet.
+
+### Changed
+
+- **Off the yanked `chacha20`.** 0.10.0 and 0.10.1 are both yanked, so cargo warned on every package
+  step while publishing 2.0.0. It arrives through `rand` under turbomcp's transport and protocol
+  crates. `cargo audit` reports it as yanked with no advisory against it, so this is hygiene rather
+  than a security fix. Now on 0.10.2, and no yanked package remains in the lock.
+
+- **Every turbomcp crate resolves to one version.** `turbomcp-client` was still on 3.1.5 while the
+  rest moved to 3.3.0, so the wire-level end-to-end test drove a 3.3.0 server with a 3.1.5 client.
+  That is the shape of skew that hides a protocol regression, because both ends work on their own
+  and nothing asserts they agree on the same wire. It drifted because `turbomcp-client` and
+  `turbomcp-transport` were pinned inside `crates/turbovault/Cargo.toml` instead of
+  `[workspace.dependencies]`; both now sit with the others, so a future bump cannot leave one
+  behind.
+
+- **Releases publish with `cargo publish --workspace`.** The workflow kept a hand-written crate list
+  with its own dependency ordering, 30-second sleeps and an already-published probe. Cargo derives
+  the order from the graph, waits on the index itself, and warns rather than fails on a crate that
+  is already up, so a partial run still resumes. The hand-written version could only drift from the
+  real graph as crates are added.
+
+- **`.claude/` is ignored.** It holds local agent settings and session state, and was untracked but
+  not ignored, so it showed as a dirty tree and sat one `git add -A` away from committing someone's
+  personal configuration.
+
 ## [2.0.0] - 2026-09-09
 
 **If you use TurboVault as an MCP server, nothing you do changes.** No tool was removed or renamed,


### PR DESCRIPTION
The publish job kept a hand-written list of all twelve crates with its own dependency ordering, 30-second sleeps between uploads, and a curl probe against the crates.io API to skip anything already published.

Cargo does all three. `cargo publish --workspace` derives the order from the dependency graph, waits on the index itself, and warns rather than fails on a crate already up, so a run that died partway still resumes.

Confirmed against the live 2.0.0 release with a dry run: twelve `already exists on crates.io index` warnings and exit 0. Forty-five lines become one.

The hand-written version had no upside and one failure mode, which is drifting from the real graph the next time a crate is added.

## Changelog

Also fills in `[Unreleased]`, which had nothing under it since the tag: the `chacha20` and `turbomcp-client` work from #67, this change, and the `.claude` ignore from #66. It says up front that none of it changes behaviour and no crate version moved, so nobody reads the section looking for an upgrade.