### PR TITLE
fix(parser): keep image and link destinations inside a blockquote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing here changes behaviour, and no crate version moved, so there is nothing to upgrade to yet.
+### Fixed
+
+- **Images and links inside a blockquote keep their destinations** ([#68](https://github.com/Epistates/turbovault/issues/68)): a quote is rebuilt from its raw text and re-parsed, and that pass only ever saw an image's alt or a link's label, so `> ![a](a.png)` came back as the bare text `a`. Every destination inside a quote was lost, while inline code round-tripped fine because it was already re-emitted with its delimiters. Images and links now are too, titles and spaced destinations included.
+
+  1.6.0 flattened these the same way. It also hoisted a copy of the image out of the quote as a top-level sibling, so anything scanning top-level blocks still found a source, which is why 2.0.0 looked like a regression: it correctly stopped hoisting, and that removed the thing masking the loss.
 
 ### Changed
 

--- a/crates/turbovault-parser/src/blocks.rs
+++ b/crates/turbovault-parser/src/blocks.rs
@@ -42,6 +42,28 @@ fn preprocess_wikilinks(markdown: &str) -> String {
 static LINK_WITH_SPACES_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\[([^\]]+)\]\(([^)<>]+\s[^)<>]*)\)").unwrap());
 
+/// Render an image back to its markdown spelling.
+///
+/// Used when rebuilding a blockquote's raw text, which is re-parsed rather than
+/// carried through as structure, so anything not written here is lost.
+///
+/// A destination containing a space is wrapped in angle brackets, since bare
+/// `![a](my file.png)` is not a link at all to a strict parser and would come
+/// back as literal text. A title is re-quoted beside it.
+fn format_image(alt: &str, src: &str, title: Option<&str>) -> String {
+    let dest = if src.contains(char::is_whitespace) {
+        format!("<{src}>")
+    } else {
+        src.to_string()
+    };
+    match title {
+        // A title containing a double quote would terminate the title early,
+        // so fall back to the destination alone rather than emit a broken one.
+        Some(title) if !title.contains('"') => format!("![{alt}]({dest} \"{title}\")"),
+        _ => format!("![{alt}]({dest})"),
+    }
+}
+
 /// Split a link target into its destination and an optional CommonMark title.
 ///
 /// A title is a quoted run at the end, separated from the destination by
@@ -634,6 +656,31 @@ fn process_event(event: Event, state: &mut BlockParserState, blocks: &mut Vec<Co
         Event::End(TagEnd::Link) => {
             state.in_link = false;
 
+            // Same as images: inside a quote only the buffer reaches the
+            // re-parse, so the destination has to be written back out. A link
+            // wrapping an image re-emits the image as its label, which is the
+            // one case where `link_text` is not the whole story.
+            if state.in_blockquote {
+                let label = if state.image_in_link {
+                    format_image(&state.link_text, &state.link_url, None)
+                } else {
+                    state.link_text.clone()
+                };
+                let url = if state.image_in_link {
+                    state.saved_link_url.clone()
+                } else {
+                    state.link_url.clone()
+                };
+                state
+                    .blockquote_buffer
+                    .push_str(&format!("[{label}]({url})"));
+                state.link_text.clear();
+                state.link_url.clear();
+                state.saved_link_url.clear();
+                state.image_in_link = false;
+                return;
+            }
+
             // Capture line_offset for nested list items
             let line_offset = if state.in_list && state.item_depth >= 1 {
                 Some(state.nested_line_offset)
@@ -698,6 +745,21 @@ fn process_event(event: Event, state: &mut BlockParserState, blocks: &mut Vec<Co
                 None
             };
 
+            // Inside a quote the buffer is the only thing that survives to the
+            // re-parse, so re-emit the whole element rather than the alt alone.
+            // A linked image writes nothing here; `TagEnd::Link` emits the
+            // wrapper with this image nested inside it.
+            if state.in_blockquote && !state.image_in_link {
+                state.blockquote_buffer.push_str(&format_image(
+                    &state.link_text,
+                    &state.link_url,
+                    title.as_deref(),
+                ));
+                state.link_text.clear();
+                state.link_url.clear();
+                return;
+            }
+
             if state.image_in_link {
                 // A linked image (`[![alt](img)](href)`) used to emit nothing
                 // at all, so a README badge row reported zero images. The
@@ -750,6 +812,13 @@ fn process_event(event: Event, state: &mut BlockParserState, blocks: &mut Vec<Co
         Event::Text(text) => {
             if state.in_code {
                 state.code_buffer.push_str(&text);
+            } else if state.in_blockquote && (state.in_image || state.in_link) {
+                // An image's alt or a link's label, which is only half of the
+                // element. Held here so the end tag can re-emit the whole
+                // `![alt](src)` / `[text](url)` into the buffer. Appending it
+                // straight to `blockquote_buffer` is what dropped every
+                // destination inside a quote: the re-parse saw bare text.
+                state.link_text.push_str(&text);
             } else if state.in_blockquote {
                 state.blockquote_buffer.push_str(&text);
             } else if state.in_heading {

--- a/crates/turbovault-parser/tests/test_images_and_blockquotes.rs
+++ b/crates/turbovault-parser/tests/test_images_and_blockquotes.rs
@@ -265,3 +265,129 @@ fn a_single_line_blockquote_has_no_trailing_whitespace() {
 
     assert_eq!(content, "Just one line.");
 }
+
+// ---------------------------------------------------------------------------
+// Inline elements inside a blockquote (Epistates/turbovault#68)
+// ---------------------------------------------------------------------------
+
+/// A blockquote is rebuilt from raw text and re-parsed, and that pass used to
+/// see only the alt or label, so every destination inside a quote was lost.
+///
+/// 1.6.0 flattened these the same way, but also hoisted a copy of the image out
+/// of the quote as a top-level sibling, so a consumer scanning top-level blocks
+/// still found a source. 2.0.0 correctly stopped hoisting, which is what made
+/// the loss visible.
+#[test]
+fn a_blockquote_image_keeps_its_source() {
+    let images = collect_images(&parse_blocks("> ![a](a.png)\n"));
+
+    assert_eq!(
+        images,
+        vec![("a".to_string(), "a.png".to_string(), None)],
+        "an image in a quote must keep its source"
+    );
+}
+
+#[test]
+fn a_blockquote_link_keeps_its_destination() {
+    let blocks = parse_blocks("> [link](https://example.com)\n");
+    let (_, nested) = first_blockquote(&blocks);
+
+    let ContentBlock::Paragraph { inline, .. } = &nested[0] else {
+        panic!("expected a paragraph in the quote, got {:?}", nested[0]);
+    };
+    let link = inline
+        .iter()
+        .find_map(|e| match e {
+            InlineElement::Link { text, url, .. } => Some((text.clone(), url.clone())),
+            _ => None,
+        })
+        .expect("expected a link, not flattened text");
+
+    assert_eq!(
+        link,
+        ("link".to_string(), "https://example.com".to_string())
+    );
+}
+
+/// The title has to survive the round trip through raw text too.
+#[test]
+fn a_blockquote_image_keeps_its_title() {
+    let images = collect_images(&parse_blocks("> ![a](a.png \"Title\")\n"));
+
+    assert_eq!(
+        images,
+        vec![(
+            "a".to_string(),
+            "a.png".to_string(),
+            Some("Title".to_string())
+        )]
+    );
+}
+
+/// A destination with a space is not a link at all to a strict parser, so
+/// rebuilding it bare would come back as literal text.
+#[test]
+fn a_blockquote_image_survives_a_spaced_destination() {
+    let images = collect_images(&parse_blocks("> ![a](my file.png)\n"));
+
+    assert_eq!(
+        images,
+        vec![("a".to_string(), "my file.png".to_string(), None)]
+    );
+}
+
+/// The badge row case, inside a quote: the image and its wrapping link each
+/// keep their own destination.
+#[test]
+fn a_blockquote_linked_image_keeps_both_destinations() {
+    let blocks = parse_blocks("> [![badge](b.png)](https://ci.example)\n");
+    let (_, nested) = first_blockquote(&blocks);
+
+    let ContentBlock::Paragraph { inline, .. } = &nested[0] else {
+        panic!("expected a paragraph, got {:?}", nested[0]);
+    };
+    let image = inline.iter().find_map(|e| match e {
+        InlineElement::Image { src, .. } => Some(src.as_str()),
+        _ => None,
+    });
+    let link = inline.iter().find_map(|e| match e {
+        InlineElement::Link { url, .. } => Some(url.as_str()),
+        _ => None,
+    });
+
+    assert_eq!(image, Some("b.png"));
+    assert_eq!(link, Some("https://ci.example"));
+}
+
+/// Prose, inline code, a link and an image in one quoted line. Inline code
+/// already round-tripped; this pins that the new handling did not disturb it.
+#[test]
+fn a_blockquote_keeps_mixed_inline_elements_together() {
+    let blocks = parse_blocks("> text with `code` and [a](u) and ![i](s)\n");
+    let (content, nested) = first_blockquote(&blocks);
+
+    assert_eq!(content, "text with `code` and [a](u) and ![i](s)");
+
+    let ContentBlock::Paragraph { inline, .. } = &nested[0] else {
+        panic!("expected a paragraph, got {:?}", nested[0]);
+    };
+    assert!(
+        inline
+            .iter()
+            .any(|e| matches!(e, InlineElement::Code { value } if value == "code")),
+        "inline code must still round-trip, got {inline:?}"
+    );
+    assert!(
+        inline
+            .iter()
+            .any(|e| matches!(e, InlineElement::Link { url, .. } if url == "u")),
+        "link must survive, got {inline:?}"
+    );
+    assert!(
+        inline
+            .iter()
+            .any(|e| matches!(e, InlineElement::Image { src, .. } if src == "s")),
+        "image must survive, got {inline:?}"
+    );
+}


### PR DESCRIPTION
A blockquote is rebuilt from raw text and re-parsed rather than carried through as structure, so anything not written into that buffer is gone. Text events inside a quote appended straight to it, which for an image or a link meant only the alt or the label landed:

```rust
parse_blocks("> ![a](a.png)")        // -> Text { value: "a" }
parse_blocks("> [link](https://ex)")  // -> Text { value: "link" }
```

Inline code already had the answer. It re-emits itself with its backticks so the buffer stays re-parseable, and has since it was written. Images and links now do the same: their text is held in `link_text` while the element is open, and the end tag writes the whole `![alt](src)` or `[text](url)` back out.

Three details in the round trip:

- A title is re-quoted, and skipped if it contains a double quote, which would terminate it early and produce a broken element rather than a plain one.
- A destination containing a space is wrapped in angle brackets, because bare `![a](my file.png)` is not a link at all to a strict parser and would come back as literal text.
- A link wrapping an image re-emits the image as its label, so a quoted badge row keeps both destinations.

## Not a 2.0.0 regression

1.6.0 flattened these identically. It also hoisted a copy of the image out of the quote as a top-level sibling, so a consumer scanning top-level blocks still found a source. 2.0.0 correctly stopped hoisting, and that removed the thing that had been masking it.

## Verification

Six regression tests, all six failing against the unfixed parser, the ten existing ones unaffected. 1292 passing overall, clippy, fmt and docs clean.

Resolves #68.